### PR TITLE
Registry factory WIP

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -90,78 +90,96 @@ services:
 
 	-
 		class: PHPStan\Rules\Classes\AccessPropertiesRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Classes\AccessStaticPropertiesRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Classes\ClassConstantRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Classes\ExistingClassInInstanceOfRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Classes\ExistingClassesInPropertiesRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Classes\InstantiationRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Classes\RequireParentConstructCallRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Exceptions\CatchedExceptionExistenceRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Functions\CallToFunctionParametersRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Functions\CallToNonExistentFunctionRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Functions\ExistingClassesInClosureTypehintsRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Functions\ExistingClassesInTypehintsRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Functions\PrintfParametersRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Methods\CallMethodsRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Methods\CallStaticMethodsRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Methods\ExistingClassesInTypehintsRule
+		tags:
+			- phpstan.rules.rule
 
 	-
-		class: PHPStan\Rules\Registry
-		setup:
-			- register(@PHPStan\Rules\Classes\AccessPropertiesRule)
-			- register(@PHPStan\Rules\Classes\AccessStaticPropertiesRule)
-			- register(@PHPStan\Rules\Classes\ClassConstantRule)
-			- register(@PHPStan\Rules\Classes\ExistingClassInInstanceOfRule)
-			- register(@PHPStan\Rules\Classes\ExistingClassesInPropertiesRule)
-			- register(@PHPStan\Rules\Classes\InstantiationRule)
-			- register(@PHPStan\Rules\Classes\RequireParentConstructCallRule)
-			- register(@PHPStan\Rules\Exceptions\CatchedExceptionExistenceRule)
-			- register(@PHPStan\Rules\Functions\CallToNonExistentFunctionRule)
-			- register(@PHPStan\Rules\Functions\CallToFunctionParametersRule)
-			- register(@PHPStan\Rules\Functions\ExistingClassesInClosureTypehintsRule)
-			- register(@PHPStan\Rules\Functions\ExistingClassesInTypehintsRule)
-			- register(@PHPStan\Rules\Functions\PrintfParametersRule)
-			- register(@PHPStan\Rules\Methods\CallMethodsRule)
-			- register(@PHPStan\Rules\Methods\CallStaticMethodsRule)
-			- register(@PHPStan\Rules\Methods\ExistingClassesInTypehintsRule)
-			- register(@PHPStan\Rules\Variables\DefinedVariableRule)
+		class: PHPStan\Rules\RegistryFactory
 
 	-
 		class: PHPStan\Rules\Variables\DefinedVariableRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Variables\DefinedVariableInAnonymousFunctionUseRule
+		tags:
+			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Type\FileTypeMapper
@@ -179,3 +197,7 @@ services:
 	directParser:
 		class: PHPStan\Parser\DirectParser
 		autowired: no
+
+	registry:
+		class: PHPStan\Rules\Registry
+		factory: @PHPStan\Rules\RegistryFactory::create

--- a/src/Rules/Registry.php
+++ b/src/Rules/Registry.php
@@ -10,7 +10,17 @@ class Registry
 	 */
 	private $rules;
 
-	public function register(Rule $rule)
+	/**
+	 * @param \PHPStan\Rules\Rule[] $rules
+	 */
+	public function __construct(array $rules)
+	{
+		foreach ($rules as $rule) {
+			$this->register($rule);
+		}
+	}
+
+	private function register(Rule $rule)
 	{
 		if (!isset($this->rules[$rule->getNodeType()])) {
 			$this->rules[$rule->getNodeType()] = [];

--- a/src/Rules/Registry.php
+++ b/src/Rules/Registry.php
@@ -6,7 +6,7 @@ class Registry
 {
 
 	/**
-	 * @var \PHPStan\Rules\Rule[]
+	 * @var \PHPStan\Rules\Rule[][]
 	 */
 	private $rules;
 

--- a/src/Rules/RegistryFactory.php
+++ b/src/Rules/RegistryFactory.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules;
+
+class RegistryFactory
+{
+
+	const RULE_TAG = 'phpstan.rules.rule';
+
+	/** @var \Nette\DI\Container */
+	private $container;
+
+	public function __construct(\Nette\DI\Container $container)
+	{
+		$this->container = $container;
+	}
+
+	public function create(): Registry
+	{
+		$tagToService = function (array $tags) {
+			return array_map(function (string $serviceName) {
+				return $this->container->getService($serviceName);
+			}, array_keys($tags));
+		};
+
+		return new Registry(
+			$tagToService($this->container->findByTag(self::RULE_TAG))
+		);
+	}
+
+}

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -124,8 +124,9 @@ class AnalyserTest extends \PHPStan\TestCase
 		string $bootstrapFile = null
 	): \PHPStan\Analyser\Analyser
 	{
-		$registry = new Registry();
-		$registry->register(new AlwaysFailRule());
+		$registry = new Registry([
+			new AlwaysFailRule(),
+		]);
 
 		$traverser = new \PhpParser\NodeTraverser();
 		$traverser->addVisitor(new \PhpParser\NodeVisitor\NameResolver());

--- a/tests/PHPStan/Rules/AbstractRuleTest.php
+++ b/tests/PHPStan/Rules/AbstractRuleTest.php
@@ -18,8 +18,9 @@ abstract class AbstractRuleTest extends \PHPStan\TestCase
 	private function getAnalyser(): Analyser
 	{
 		if ($this->analyser === null) {
-			$registry = new Registry();
-			$registry->register($this->getRule());
+			$registry = new Registry([
+				$this->getRule(),
+			]);
 
 			$broker = $this->createBroker();
 			$printer = new \PhpParser\PrettyPrinter\Standard();

--- a/tests/PHPStan/Rules/RegistryTest.php
+++ b/tests/PHPStan/Rules/RegistryTest.php
@@ -9,8 +9,9 @@ class RegistryTest extends \PHPStan\TestCase
 	{
 		$rule = new DummyRule();
 
-		$registry = new Registry();
-		$registry->register($rule);
+		$registry = new Registry([
+			$rule,
+		]);
 
 		$rules = $registry->getRules('PHPParser_Node_Expr_FuncCall');
 		$this->assertSame(1, count($rules));


### PR DESCRIPTION
Věci k vyřešení:

- jaký název tagu?
- neudělat z `$tagToService` samostatnou static helper třídu? `NetteContainerHelpers`? Případně udělat vlastní bridge na nette container (v budoucnu jen switchneš na symfony)?
- opravdu zrušit public metodu `register` v registru? Za mě ano, ale je to bc break
- dříve nebyl zaregistrován `DefinedVariableInAnonymousFunctionUseRule`. Nevím, jestli to byla chyba nebo záměr