### PR TITLE
fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ you can provide your own bootstrap file:
 
 ```yaml
 parameters:
-	bootstrap: - %rootDir%/../../../phpstan-bootstrap.php
+	bootstrap: %rootDir%/../../../phpstan-bootstrap.php
 ```
 
 ### Custom rules


### PR DESCRIPTION
The line "bootstrap: - %rootDir%/../../../phpstan-bootstrap.php" leads to the following exception:
TypeError: Argument 8 passed to PHPStan\Analyser\Analyser::__construct() must be of the type string or null, array given