### PR TITLE
Move tracy to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
 		"nette/utils": "~2.4",
 		"nikic/php-parser": "~3.0.2",
 		"symfony/console": "~2.8 || ~3.0",
-		"symfony/finder": "~2.8 || ~3.0",
-		"tracy/tracy": "~2.4"
+		"symfony/finder": "~2.8 || ~3.0"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "~0.12.0",
 		"satooshi/php-coveralls": "^1.0",
 		"phing/phing": "^2.13.0",
 		"phpunit/phpunit": "^5.6",
-		"slevomat/coding-standard": "dev-php7#d4a1a9cd4e"
+		"slevomat/coding-standard": "dev-php7#d4a1a9cd4e",
+		"tracy/tracy": "~2.4"
 	},
 	"autoload": {
 		"psr-4": {"PHPStan\\": "src/"}


### PR DESCRIPTION
In fact tracy worries me about `dump` method.
It comes first compared to this [dump](https://github.com/symfony/var-dumper/blob/master/Resources/functions/dump.php).

Is it possible to move `tracy` in `require-dev`?