### PR TITLE
failed test incorrect case Imagick

### DIFF
--- a/tests/PHPStan/Rules/Methods/data/incorrect-method-case.php
+++ b/tests/PHPStan/Rules/Methods/data/incorrect-method-case.php
@@ -5,6 +5,12 @@ namespace IncorrectMethodCase;
 class Foo
 {
 
+	public function createImagick()
+	{
+		$imagick = new \Imagick();
+		$imagick->readImageBlob('');
+	}
+
 	public function fooBar()
 	{
 		$this->foobar();


### PR DESCRIPTION
add failed test for error: Call to method Imagick::readimageblob() with incorrect case: readImageBlob. 

travis: 
```
printf "\n" | pecl install imagick
downloading imagick-3.4.3RC1.tgz ...
```
