### PR TITLE
UselessCast: add failed test for switch statement

### DIFF
--- a/tests/PHPStan/Rules/Comparison/data/strict-comparison.php
+++ b/tests/PHPStan/Rules/Comparison/data/strict-comparison.php
@@ -24,3 +24,13 @@ $boolean === true;
 $boolean === false;
 true === false;
 false === true;
+
+$return = false;
+switch ('foo') {
+    case 'foo':
+        $return = true;
+        break;
+}
+if ($return === true) {
+    return '';
+}


### PR DESCRIPTION
`Expected only 6 errors, but result contains 7`
`Strict comparison using === between false and true will always evaluate to false`