### PR TITLE
Failing test which causes infinite recursion and segmentation faults

### DIFF
--- a/tests/PHPStan/Analyser/traits/FooTrait.php
+++ b/tests/PHPStan/Analyser/traits/FooTrait.php
@@ -2,6 +2,15 @@
 
 namespace AnalyseTraits;
 
+class SomeClass
+{
+
+	use FooTrait;
+
+}
+
+
+
 trait FooTrait
 {
 
@@ -9,6 +18,8 @@ trait FooTrait
 	{
 		$this->doFoo();
 	}
+
+
 
 	public function conflictingMethodWithDifferentArgumentNames(string $string)
 	{


### PR DESCRIPTION
If you run `bin/phpstan analyse tests/PHPStan/Analyser/trait` you get `Segmentation fault` without xDebug and `Maximum function nesting level of '600' reached, aborting!` with xDebug allowed.

Problem is if you have one PHP file with defined trait and class which uses this trait.