### PR TITLE
Negated shortcut path should add type to original type making union

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1324,7 +1324,7 @@ class NodeScopeResolverTest extends \PHPStan\TestCase
 	{
 		return [
 			[
-				'PhpParser\Node\Expr\ArrayDimFetch',
+				'PhpParser\Node\Expr\ArrayDimFetch|PhpParser\Node\Stmt\Function_',
 				'$foo',
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -326,4 +326,10 @@ class CallMethodsRuleTest extends \PHPStan\Rules\AbstractRuleTest
 		$this->analyse([__DIR__ . '/data/protected-method-call-from-parent.php'], []);
 	}
 
+	public function testInstanceofUnionMethods()
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/call-instanceof-methods.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/call-instanceof-methods.php
+++ b/tests/PHPStan/Rules/Methods/data/call-instanceof-methods.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace CallInstanceofMethodsTests;
+
+interface Foo
+{
+	public function do();
+}
+abstract class Baz
+{
+	public abstract function doBaz();
+}
+abstract class BazChild extends Baz implements Foo
+{
+}
+abstract class Test
+{
+	public function testMethod(Baz $baz)
+	{
+		if (!$baz instanceof Foo) {
+			return;
+		}
+
+		$baz->do();
+		$baz->doBaz();
+	}
+}
+


### PR DESCRIPTION
I think that code in provided test file `call-instanceof-methods.php` 
should not produce error on line `25` 
when call to method `doBaz` of class `Baz` is made.

Another example of similar code with error:


```php
interface HasTitle 
{
	public function title(): string;
}

class Article 
{
	public function body(): string { return 'example'; }
}

class ArticleWithTitle extends Article implements HasTitle 
{
	public function title(): string { return 'example'; }
}

class ArticleRender 
{
	public function render(Article $article): string
	{
		if (!$article instanceof HasTitle) {
			return $article->body();
		}
		
		return "<h1>".$article->title()."</h1>" . $article->body();
	}
}

```

This PR demonstrates change of this behaviour by making type of 
`$article` an union `Article|HasTitle`.

I know that code like above is not example of good practice 
and generally situations like that should be avoided in modeling stage,
but I found one example with my codebase that is affected and produce 
error.

What do you think about this change?
