### PR TITLE
Add partial support for methods defined by @method annotations

### DIFF
--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -5,7 +5,6 @@ parameters:
 		- %rootDir%/tests/PHPStan/Analyser/traits/*
 		- %rootDir%/tests/notAutoloaded/*
 	ignoreErrors:
-		- '#PHPUnit_Framework_MockObject_MockObject::method\(\)#'
 		- '#PHPUnit_Framework_MockObject_MockObject given#'
 services:
 	-

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -86,6 +86,9 @@ services:
 		implement: PHPStan\Reflection\FunctionReflectionFactory
 
 	-
+		class: PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension
+
+	-
 		class: PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension
 
 	-

--- a/src/Broker/BrokerFactory.php
+++ b/src/Broker/BrokerFactory.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Broker;
 
+use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\FunctionReflectionFactory;
 use PHPStan\Reflection\Php\PhpClassReflectionExtension;
@@ -33,12 +34,13 @@ class BrokerFactory
 		};
 
 		$phpClassReflectionExtension = $this->container->getByType(PhpClassReflectionExtension::class);
+		$annotationsMethodsClassReflectionExtension = $this->container->getByType(AnnotationsMethodsClassReflectionExtension::class);
 		$annotationsPropertiesClassReflectionExtension = $this->container->getByType(AnnotationsPropertiesClassReflectionExtension::class);
 		$phpDefectClassReflectionExtension = $this->container->getByType(PhpDefectClassReflectionExtension::class);
 
 		return new Broker(
 			array_merge([$phpClassReflectionExtension, $annotationsPropertiesClassReflectionExtension, $phpDefectClassReflectionExtension], $tagToService($this->container->findByTag(self::PROPERTIES_CLASS_REFLECTION_EXTENSION_TAG))),
-			array_merge([$phpClassReflectionExtension], $tagToService($this->container->findByTag(self::METHODS_CLASS_REFLECTION_EXTENSION_TAG))),
+			array_merge([$phpClassReflectionExtension, $annotationsMethodsClassReflectionExtension], $tagToService($this->container->findByTag(self::METHODS_CLASS_REFLECTION_EXTENSION_TAG))),
 			$tagToService($this->container->findByTag(self::DYNAMIC_METHOD_RETURN_TYPE_EXTENSION_TAG)),
 			$tagToService($this->container->findByTag(self::DYNAMIC_STATIC_METHOD_RETURN_TYPE_EXTENSION_TAG)),
 			$this->container->getByType(FunctionReflectionFactory::class),

--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Annotations;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Type;
+
+class AnnotationMethodReflection implements MethodReflection
+{
+
+	/** @var string */
+	private $name;
+
+	/** @var \PHPStan\Reflection\ClassReflection */
+	private $declaringClass;
+
+	/** @var  Type */
+	private $returnType;
+
+	public function __construct(string $name, ClassReflection $declaringClass, Type $returnType)
+	{
+		$this->name = $name;
+		$this->declaringClass = $declaringClass;
+		$this->returnType = $returnType;
+	}
+
+	public function getDeclaringClass(): ClassReflection
+	{
+		return $this->declaringClass;
+	}
+
+	public function getPrototype(): MethodReflection
+	{
+		return $this;
+	}
+
+	public function isStatic(): bool
+	{
+		return false;
+	}
+
+	public function getParameters(): array
+	{
+		return [];
+	}
+
+	public function isVariadic(): bool
+	{
+		return true;
+	}
+
+	public function isPrivate(): bool
+	{
+		return false;
+	}
+
+	public function isPublic(): bool
+	{
+		return true;
+	}
+
+	public function getName(): string
+	{
+		return $this->name;
+	}
+
+	public function getReturnType(): Type
+	{
+		return $this->returnType;
+	}
+
+}

--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Annotations;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Type\FileTypeMapper;
+use PHPStan\Type\MixedType;
+
+class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflectionExtension
+{
+
+	/** @var FileTypeMapper */
+	private $fileTypeMapper;
+
+	/** @var MethodReflection[][] */
+	private $methods = [];
+
+	public function __construct(FileTypeMapper $fileTypeMapper)
+	{
+		$this->fileTypeMapper = $fileTypeMapper;
+	}
+
+	public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+	{
+		if (!isset($this->methods[$classReflection->getName()])) {
+			$this->methods[$classReflection->getName()] = $this->createMethods($classReflection);
+		}
+
+		return isset($this->methods[$classReflection->getName()][$methodName]);
+	}
+
+	public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+	{
+		return $this->methods[$classReflection->getName()][$methodName];
+	}
+
+	/**
+	 * @param ClassReflection $classReflection
+	 * @return MethodReflection[]
+	 */
+	private function createMethods(ClassReflection $classReflection): array
+	{
+		$methods = [];
+		foreach ($classReflection->getParents() as $parentClass) {
+			$methods += $this->createMethods($parentClass);
+		}
+
+		$fileName = $classReflection->getNativeReflection()->getFileName();
+		if ($fileName === false) {
+			return $methods;
+		}
+
+		$docComment = $classReflection->getNativeReflection()->getDocComment();
+		if ($docComment === false) {
+			return $methods;
+		}
+
+		$typeMap = $this->fileTypeMapper->getTypeMap($fileName);
+
+		preg_match_all('#@method\s+(?:(.*)\s+)?([a-zA-Z0-9_]+)\(.*\)#', $docComment, $matches, PREG_SET_ORDER);
+		foreach ($matches as $match) {
+			$typeStringCandidate = $match[1];
+			if (preg_match('#' . FileTypeMapper::TYPE_PATTERN . '#', $typeStringCandidate, $typeStringMatches)) {
+				$typeString = $typeStringMatches[1];
+				if (!isset($typeMap[$typeString])) {
+					continue;
+				}
+				$returnType = $typeMap[$typeString];
+			} else {
+				$returnType = new MixedType();
+			}
+			$methodName = $match[2];
+			$methods[$methodName] = new AnnotationMethodReflection($methodName, $classReflection, $returnType);
+		}
+		return $methods;
+	}
+
+}

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -37,7 +37,7 @@ class FileTypeMapper
 
 	public function getTypeMap(string $fileName): array
 	{
-		$cacheKey = sprintf('%s-%d-v22-%d', $fileName, filemtime($fileName), $this->enableUnionTypes ? 1 : 0);
+		$cacheKey = sprintf('%s-%d-v23-%d', $fileName, filemtime($fileName), $this->enableUnionTypes ? 1 : 0);
 		if (isset($this->memoryCache[$cacheKey])) {
 			return $this->memoryCache[$cacheKey];
 		}
@@ -63,6 +63,7 @@ class FileTypeMapper
 			'#@var\s+\$[a-zA-Z0-9_]+\s+' . self::TYPE_PATTERN . '#',
 			'#@return\s+' . self::TYPE_PATTERN . '#',
 			'#@property(?:-read)?\s+' . self::TYPE_PATTERN . '\s+\$[a-zA-Z0-9_]+#',
+			'#@method\s+' . self::TYPE_PATTERN . '\s+[a-zA-Z0-9_]+\(.*\)#',
 		];
 
 		/** @var \PhpParser\Node\Stmt\ClassLike|null $lastClass */

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Annotations;
+
+use PHPStan\Broker\Broker;
+
+class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
+{
+
+	public function dataMethods(): array
+	{
+		return [
+			[
+				\AnnotationsMethods\Foo::class,
+				[
+					'getInteger' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'int',
+					],
+					'doSomething' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'void',
+					],
+					'getFooOrBar' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+					],
+					'methodWithNoReturnType' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'mixed',
+					],
+				],
+			],
+			[
+				\AnnotationsMethods\Bar::class,
+				[
+					'getInteger' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'int',
+					],
+					'doSomething' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'void',
+					],
+					'getFooOrBar' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+					],
+					'methodWithNoReturnType' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'mixed',
+					],
+				],
+			],
+			[
+				\AnnotationsMethods\Baz::class,
+				[
+					'getInteger' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'int',
+					],
+					'doSomething' => [
+						'class' => \AnnotationsMethods\Baz::class,
+						'returnType' => 'void',
+					],
+					'getFooOrBar' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+					],
+					'getIpsum' => [
+						'class' => \AnnotationsMethods\Baz::class,
+						'returnType' => 'OtherNamespace\Ipsum',
+					],
+					'methodWithNoReturnType' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'mixed',
+					],
+				],
+			],
+			[
+				\AnnotationsMethods\BazBaz::class,
+				[
+					'getInteger' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'int',
+					],
+					'doSomething' => [
+						'class' => \AnnotationsMethods\Baz::class,
+						'returnType' => 'void',
+					],
+					'getFooOrBar' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+					],
+					'getIpsum' => [
+						'class' => \AnnotationsMethods\Baz::class,
+						'returnType' => 'OtherNamespace\Ipsum',
+					],
+					'methodWithNoReturnType' => [
+						'class' => \AnnotationsMethods\Foo::class,
+						'returnType' => 'mixed',
+					],
+					'getTest' => [
+						'class' => \AnnotationsMethods\BazBaz::class,
+						'returnType' => 'OtherNamespace\Test',
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataMethods
+	 * @param string $className
+	 * @param mixed[] $methods
+	 */
+	public function testMethods(string $className, array $methods)
+	{
+		/** @var Broker $broker */
+		$broker = $this->getContainer()->getByType(Broker::class);
+		$class = $broker->getClass($className);
+		foreach ($methods as $methodName => $expectedMethodData) {
+			$this->assertTrue($class->hasMethod($methodName), sprintf('Method %s not found in class %s.', $methodName, $className));
+
+			$method = $class->getMethod($methodName);
+			$this->assertSame(
+				$expectedMethodData['class'],
+				$method->getDeclaringClass()->getName(),
+				sprintf('Declaring class of method $%s does not match.', $methodName)
+			);
+			$this->assertEquals(
+				$expectedMethodData['returnType'],
+				$method->getReturnType()->describe(),
+				sprintf('Return type of method %s::%s does not match', $className, $methodName)
+			);
+		}
+	}
+
+}

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AnnotationsMethods;
+
+use OtherNamespace\Ipsum;
+use OtherNamespace\Test as OtherTest;
+
+/**
+ * @method int getInteger(int $a, int $b)
+ * @method void doSomething(int $a, $b)
+ * @method self|Bar getFooOrBar()
+ * @method methodWithNoReturnType()
+ */
+class Foo
+{
+
+}
+
+class Bar extends Foo
+{
+
+}
+
+/**
+ * @method Ipsum  getIpsum($a)
+ * @method void doSomething(int $a, $b)
+ */
+class Baz extends Bar
+{
+
+}
+
+/**
+ * @method OtherTest getTest()
+ */
+class BazBaz extends Baz
+{
+
+}


### PR DESCRIPTION
Add partial support for methods defined by @method annotations. Parse name and return type of methods. Parametes are (for now) ignored so all function defined by annotations are variadic.