### PR TITLE
CallableType: accept invokable object

### DIFF
--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -78,6 +78,10 @@ class CallableType implements Type
 			return true;
 		}
 
+		if ($type->getClass() !== null && method_exists($type->getClass(), '__invoke')) {
+			return true;
+		}
+
 		if ($type instanceof UnionType && UnionTypeHelper::acceptsAll($this, $type)) {
 			return true;
 		}

--- a/tests/PHPStan/Rules/Methods/data/invoke-magic-method.php
+++ b/tests/PHPStan/Rules/Methods/data/invoke-magic-method.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Test;
+
+class ClassForCallable
+{
+
+	/** @var callable[] */
+	public $onFoo;
+
+}
+
+class ClassWithInvoke
+{
+
+	public function __invoke()
+	{
+	}
+
+}
+
+function () {
+	$foo = new ClassForCallable();
+	$foo->onFoo[] = new ClassWithInvoke();
+};


### PR DESCRIPTION
If I understand it correctly, then this should allow assigning object implementing ```__invoke``` method to ```callable``` type.

My use case was:
```
/** @var callable[] */
public $onModify;
```

```
interface IImageModifier
{
	public function __invoke(Image $image);
}
```