### PR TITLE
Loosen dependency version constraints.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
 		"nette/robot-loader": "~2.4",
 		"nette/utils": "~2.4",
 		"nikic/php-parser": "^2.1 || ^3.0.2",
-		"symfony/console": "~2.8 || ~3.0",
-		"symfony/finder": "~2.8 || ~3.0"
+		"symfony/console": "~2.7 || ~3.0",
+		"symfony/finder": "~2.7 || ~3.0"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "~0.13.0",


### PR DESCRIPTION
This change allows using phpstan with Laravel's LTS version 5.1

As far as I can tell you're not using anything that is not available in symfony/{console,finder} 2.7