### PR TITLE
Add support for the "scalar" pseudo type

### DIFF
--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -37,7 +37,7 @@ class FileTypeMapper
 
 	public function getTypeMap(string $fileName): array
 	{
-		$cacheKey = sprintf('%s-%d-v23-%d', $fileName, filemtime($fileName), $this->enableUnionTypes ? 1 : 0);
+		$cacheKey = sprintf('%s-%d-v24-%d', $fileName, filemtime($fileName), $this->enableUnionTypes ? 1 : 0);
 		if (isset($this->memoryCache[$cacheKey])) {
 			return $this->memoryCache[$cacheKey];
 		}

--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -63,6 +63,8 @@ class TypehintHelper
 				return new StringType($isNullable);
 			case 'float':
 				return new FloatType($isNullable);
+			case 'scalar':
+				return new CommonUnionType([new IntegerType(false), new FloatType(false), new StringType(false), new TrueOrFalseBooleanType(false)], $isNullable);
 			case 'array':
 				return new ArrayType(new MixedType(), $isNullable);
 			case 'iterable':

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -123,6 +123,10 @@ class ReturnTypeRuleTest extends \PHPStan\Rules\AbstractRuleTest
 				'Method ReturnTypes\Foo::returnsPhpDocParent() should return ReturnTypes\FooParent but returns null.',
 				173,
 			],
+			[
+				'Method ReturnTypes\Foo::returnScalar() should return int|float|string|bool but returns stdClass.',
+				185,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/data/returnTypes.php
+++ b/tests/PHPStan/Rules/Methods/data/returnTypes.php
@@ -172,6 +172,18 @@ class Foo extends FooParent implements FooInterface
 		return 1;
 		return null;
 	}
+
+	/**
+	 * @return scalar
+	 */
+	public function returnScalar()
+	{
+		return 1;
+		return 10.1;
+		return 'a';
+		return false;
+		return new \stdClass();
+	}
 }
 
 class FooChild extends Foo


### PR DESCRIPTION
PHPStan looks great and it already allowed me to find a potential bug. Thanks!

However I've found a false positive while scanning the [API Platform](https://api-platform.com) code base:

```
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Hal/Serializer/CollectionNormalizer.php                                                                                                                   
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  55     Return typehint of method ApiPlatform\Core\Hal\Serializer\CollectionNormalizer::normalize() has invalid type Symfony\Component\Serializer\Normalizer\scalar.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------- 

```

`scalar` is a valid PHPDoc type (see https://github.com/phpDocumentor/phpDocumentor2/issues/694#issuecomment-11158057), and is used in the wild (the report is related to the use of `scalar` in the PHPDoc of Symfony interfaces implemented by API Platform).

This PR add support for `scalar`.