### PR TITLE
Fix reflection for array_udiff_*

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -78,6 +78,24 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Rules\AbstractRuleTest
 		$this->analyse([__DIR__ . '/data/call-to-array-map-unique.php'], []);
 	}
 
+	public function testCallToArrayUdiff()
+	{
+		$this->analyse([__DIR__ . '/data/call-to-array-udiff.php'], [
+			[
+				'Function array_udiff invoked with 2 parameters, at least 3 required.',
+				6,
+			],
+			[
+				'Function array_udiff_assoc invoked with 2 parameters, at least 3 required.',
+				7,
+			],
+			[
+				'Function array_udiff_uassoc invoked with 2 parameters, at least 4 required.',
+				8,
+			],
+		]);
+	}
+
 	public function testCallToWeirdFunctions()
 	{
 		$this->analyse([__DIR__ . '/data/call-to-weird-functions.php'], [

--- a/tests/PHPStan/Rules/Functions/data/call-to-array-udiff.php
+++ b/tests/PHPStan/Rules/Functions/data/call-to-array-udiff.php
@@ -1,0 +1,12 @@
+<?php
+
+array_udiff([], [], new \stdClass());
+array_udiff([], [], [], 'foo');
+array_udiff_assoc([], [], [], 'foo');
+array_udiff_uassoc([], [], [], 'foo', 'foo');
+array_udiff([], 'foo');
+array_udiff_assoc([], 'foo');
+array_udiff_uassoc([], 'foo');
+array_udiff([], [], []);
+array_udiff_assoc([], [], []);
+array_udiff_uassoc([], [], [], []);


### PR DESCRIPTION
Fixes #169.

I wanted to fix this purely by inserting the additional parameter, but since the native reflection object doesn't mark the three functions as variadic, I had to handle this in `isVariadic`. I'm not happy about the lookup being done for every native function, but couldn't come up with a better idea.