### PR TITLE
Support docblock method signatures without parenthesise

### DIFF
--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -59,7 +59,7 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 
 		$typeMap = $this->fileTypeMapper->getTypeMap($fileName);
 
-		preg_match_all('#@method\s+(?:(?P<IsStatic>static)\s+)?(?:(?P<Type>[^\s]*)\s+)?(?P<MethodName>[a-zA-Z0-9_]+)\(.*\)#', $docComment, $matches, PREG_SET_ORDER);
+		preg_match_all('#@method\s+(?:(?P<IsStatic>static)\s+)?(?:(?P<Type>[^\s(]*)\s+)?(?P<MethodName>[a-zA-Z0-9_]+)(?P<Parameters>(?:\([^)]*\))?)#', $docComment, $matches, PREG_SET_ORDER);
 		foreach ($matches as $match) {
 			$isStatic = $match['IsStatic'] === 'static';
 			$typeStringCandidate = $match['Type'];

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -37,7 +37,7 @@ class FileTypeMapper
 
 	public function getTypeMap(string $fileName): array
 	{
-		$cacheKey = sprintf('%s-%d-v25-%d', $fileName, filemtime($fileName), $this->enableUnionTypes ? 1 : 0);
+		$cacheKey = sprintf('%s-%d-v26-%d', $fileName, filemtime($fileName), $this->enableUnionTypes ? 1 : 0);
 		if (isset($this->memoryCache[$cacheKey])) {
 			return $this->memoryCache[$cacheKey];
 		}
@@ -63,7 +63,7 @@ class FileTypeMapper
 			'#@var\s+\$[a-zA-Z0-9_]+\s+' . self::TYPE_PATTERN . '#',
 			'#@return\s+' . self::TYPE_PATTERN . '#',
 			'#@property(?:-read)?\s+' . self::TYPE_PATTERN . '\s+\$[a-zA-Z0-9_]+#',
-			'#@method\s+(?:static\s+)?' . self::TYPE_PATTERN . '\s*?[a-zA-Z0-9_]+\(.*\)#',
+			'#@method\s+(?:static\s+)?' . self::TYPE_PATTERN . '\s*?[a-zA-Z0-9_]+(?:\(.*\))?#',
 		];
 
 		/** @var \PhpParser\Node\Stmt\ClassLike|null $lastClass */

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -155,11 +155,6 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
 				'isStatic' => false,
 			],
-//					'methodWithNoReturnTypeWithDescriptionNoParams' => [
-//						'class' => \AnnotationsMethods\Foo::class,
-//						'returnType' => 'mixed',
-//						'isStatic' => false,
-//					],
 			'getIntegerStaticallyWithDescriptionNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'int',
@@ -175,11 +170,6 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
 				'isStatic' => true,
 			],
-//					'methodWithNoReturnTypeStaticallyWithDescriptionNoParams' => [
-//						'class' => \AnnotationsMethods\Foo::class,
-//						'returnType' => 'mixed',
-//						'isStatic' => true,
-//					],
 			'aStaticMethodThatHasAUniqueReturnTypeInThisClassNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'bool|string',

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Reflection\Annotations;
 

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace PHPStan\Reflection\Annotations;
 
@@ -9,427 +9,285 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 
 	public function dataMethods(): array
 	{
+		$fooMethods = [
+			'getInteger' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'int',
+				'isStatic' => false,
+			],
+			'doSomething' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'void',
+				'isStatic' => false,
+			],
+			'getFooOrBar' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+				'isStatic' => false,
+			],
+			'methodWithNoReturnType' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'mixed',
+				'isStatic' => false,
+			],
+			'getIntegerStatically' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'int',
+				'isStatic' => true,
+			],
+			'doSomethingStatically' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'void',
+				'isStatic' => true,
+			],
+			'getFooOrBarStatically' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+				'isStatic' => true,
+			],
+			'methodWithNoReturnTypeStatically' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'mixed',
+				'isStatic' => true,
+			],
+			'getIntegerWithDescription' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'int',
+				'isStatic' => false,
+			],
+			'doSomethingWithDescription' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'void',
+				'isStatic' => false,
+			],
+			'getFooOrBarWithDescription' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+				'isStatic' => false,
+			],
+			'methodWithNoReturnTypeWithDescription' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'mixed',
+				'isStatic' => false,
+			],
+			'getIntegerStaticallyWithDescription' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'int',
+				'isStatic' => true,
+			],
+			'doSomethingStaticallyWithDescription' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'void',
+				'isStatic' => true,
+			],
+			'getFooOrBarStaticallyWithDescription' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+				'isStatic' => true,
+			],
+			'methodWithNoReturnTypeStaticallyWithDescription' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'mixed',
+				'isStatic' => true,
+			],
+			'aStaticMethodThatHasAUniqueReturnTypeInThisClass' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'bool',
+				'isStatic' => true,
+			],
+			'aStaticMethodThatHasAUniqueReturnTypeInThisClassWithDescription' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'string',
+				'isStatic' => true,
+			],
+			'getIntegerNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'int',
+				'isStatic' => false,
+			],
+			'doSomethingNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'void',
+				'isStatic' => false,
+			],
+			'getFooOrBarNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+				'isStatic' => false,
+			],
+			'methodWithNoReturnTypeNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'mixed',
+				'isStatic' => false,
+			],
+			'getIntegerStaticallyNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'int',
+				'isStatic' => true,
+			],
+			'doSomethingStaticallyNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'void',
+				'isStatic' => true,
+			],
+			'getFooOrBarStaticallyNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+				'isStatic' => true,
+			],
+			'methodWithNoReturnTypeStaticallyNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'mixed',
+				'isStatic' => true,
+			],
+			'getIntegerWithDescriptionNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'int',
+				'isStatic' => false,
+			],
+			'doSomethingWithDescriptionNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'void',
+				'isStatic' => false,
+			],
+			'getFooOrBarWithDescriptionNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+				'isStatic' => false,
+			],
+//					'methodWithNoReturnTypeWithDescriptionNoParams' => [
+//						'class' => \AnnotationsMethods\Foo::class,
+//						'returnType' => 'mixed',
+//						'isStatic' => false,
+//					],
+			'getIntegerStaticallyWithDescriptionNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'int',
+				'isStatic' => true,
+			],
+			'doSomethingStaticallyWithDescriptionNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'void',
+				'isStatic' => true,
+			],
+			'getFooOrBarStaticallyWithDescriptionNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
+				'isStatic' => true,
+			],
+//					'methodWithNoReturnTypeStaticallyWithDescriptionNoParams' => [
+//						'class' => \AnnotationsMethods\Foo::class,
+//						'returnType' => 'mixed',
+//						'isStatic' => true,
+//					],
+			'aStaticMethodThatHasAUniqueReturnTypeInThisClassNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'bool|string',
+				'isStatic' => true,
+			],
+			'aStaticMethodThatHasAUniqueReturnTypeInThisClassWithDescriptionNoParams' => [
+				'class' => \AnnotationsMethods\Foo::class,
+				'returnType' => 'string|float',
+				'isStatic' => true,
+			],
+		];
+		$barMethods = $fooMethods;
+		$bazMethods = array_merge(
+			$fooMethods,
+			[
+				'doSomething' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+				],
+				'getIpsum' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'OtherNamespace\Ipsum',
+					'isStatic' => false,
+				],
+				'getIpsumStatically' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'OtherNamespace\Ipsum',
+					'isStatic' => true,
+				],
+				'getIpsumWithDescription' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'OtherNamespace\Ipsum',
+					'isStatic' => false,
+				],
+				'getIpsumStaticallyWithDescription' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'OtherNamespace\Ipsum',
+					'isStatic' => true,
+				],
+				'doSomethingStatically' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'void',
+					'isStatic' => true,
+				],
+				'doSomethingWithDescription' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+				],
+				'doSomethingStaticallyWithDescription' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'void',
+					'isStatic' => true,
+				],
+				'doSomethingNoParams' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+				],
+				'doSomethingStaticallyNoParams' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'void',
+					'isStatic' => true,
+				],
+				'doSomethingWithDescriptionNoParams' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+				],
+				'doSomethingStaticallyWithDescriptionNoParams' => [
+					'class' => \AnnotationsMethods\Baz::class,
+					'returnType' => 'void',
+					'isStatic' => true,
+				],
+			]
+		);
+		$bazBazMethods = array_merge(
+			$bazMethods,
+			[
+				'getTest' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'OtherNamespace\Test',
+					'isStatic' => false,
+				],
+				'getTestStatically' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'OtherNamespace\Test',
+					'isStatic' => true,
+				],
+				'getTestWithDescription' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'OtherNamespace\Test',
+					'isStatic' => false,
+				],
+				'getTestStaticallyWithDescription' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'OtherNamespace\Test',
+					'isStatic' => true,
+				],
+			]
+		);
+
 		return [
-			[
-				\AnnotationsMethods\Foo::class,
-				[
-					'getInteger' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => false,
-					],
-					'doSomething' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'void',
-						'isStatic' => false,
-					],
-					'getFooOrBar' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => false,
-					],
-					'methodWithNoReturnType' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => false,
-					],
-					'getIntegerStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => true,
-					],
-					'doSomethingStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'void',
-						'isStatic' => true,
-					],
-					'getFooOrBarStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => true,
-					],
-					'methodWithNoReturnTypeStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => true,
-					],
-					'getIntegerWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => false,
-					],
-					'doSomethingWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'void',
-						'isStatic' => false,
-					],
-					'getFooOrBarWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => false,
-					],
-					'methodWithNoReturnTypeWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => false,
-					],
-					'getIntegerStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => true,
-					],
-					'doSomethingStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'void',
-						'isStatic' => true,
-					],
-					'getFooOrBarStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => true,
-					],
-					'methodWithNoReturnTypeStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => true,
-					],
-					'aStaticMethodThatHasAUniqueReturnTypeInThisClass' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'bool',
-						'isStatic' => true,
-					],
-					'aStaticMethodThatHasAUniqueReturnTypeInThisClassWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'string',
-						'isStatic' => true,
-					],
-				],
-			],
-			[
-				\AnnotationsMethods\Bar::class,
-				[
-					'getInteger' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => false,
-					],
-					'doSomething' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'void',
-						'isStatic' => false,
-					],
-					'getFooOrBar' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => false,
-					],
-					'methodWithNoReturnType' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => false,
-					],
-					'getIntegerStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => true,
-					],
-					'doSomethingStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'void',
-						'isStatic' => true,
-					],
-					'getFooOrBarStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => true,
-					],
-					'methodWithNoReturnTypeStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => true,
-					],
-					'getIntegerWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => false,
-					],
-					'doSomethingWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'void',
-						'isStatic' => false,
-					],
-					'getFooOrBarWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => false,
-					],
-					'methodWithNoReturnTypeWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => false,
-					],
-					'getIntegerStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => true,
-					],
-					'doSomethingStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'void',
-						'isStatic' => true,
-					],
-					'getFooOrBarStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => true,
-					],
-					'methodWithNoReturnTypeStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => true,
-					],
-					'aStaticMethodThatHasAUniqueReturnTypeInThisClass' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'bool',
-						'isStatic' => true,
-					],
-					'aStaticMethodThatHasAUniqueReturnTypeInThisClassWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'string',
-						'isStatic' => true,
-					],
-				],
-			],
-			[
-				\AnnotationsMethods\Baz::class,
-				[
-					'getInteger' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => false,
-					],
-					'doSomething' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'void',
-						'isStatic' => false,
-					],
-					'getFooOrBar' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => false,
-					],
-					'getIpsum' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'OtherNamespace\Ipsum',
-						'isStatic' => false,
-					],
-					'methodWithNoReturnType' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => false,
-					],
-					'getIntegerStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => true,
-					],
-					'doSomethingStatically' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'void',
-						'isStatic' => true,
-					],
-					'getFooOrBarStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => true,
-					],
-					'getIpsumStatically' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'OtherNamespace\Ipsum',
-						'isStatic' => true,
-					],
-					'methodWithNoReturnTypeStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => true,
-					],
-					'getIntegerWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => false,
-					],
-					'doSomethingWithDescription' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'void',
-						'isStatic' => false,
-					],
-					'getFooOrBarWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => false,
-					],
-					'getIpsumWithDescription' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'OtherNamespace\Ipsum',
-						'isStatic' => false,
-					],
-					'methodWithNoReturnTypeWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => false,
-					],
-					'getIntegerStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => true,
-					],
-					'doSomethingStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'void',
-						'isStatic' => true,
-					],
-					'getFooOrBarStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => true,
-					],
-					'getIpsumStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'OtherNamespace\Ipsum',
-						'isStatic' => true,
-					],
-					'methodWithNoReturnTypeStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => true,
-					],
-				],
-			],
-			[
-				\AnnotationsMethods\BazBaz::class,
-				[
-					'getInteger' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => false,
-					],
-					'doSomething' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'void',
-						'isStatic' => false,
-					],
-					'getFooOrBar' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => false,
-					],
-					'getIpsum' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'OtherNamespace\Ipsum',
-						'isStatic' => false,
-					],
-					'methodWithNoReturnType' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => false,
-					],
-					'getTest' => [
-						'class' => \AnnotationsMethods\BazBaz::class,
-						'returnType' => 'OtherNamespace\Test',
-						'isStatic' => false,
-					],
-					'getIntegerStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => true,
-					],
-					'doSomethingStatically' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'void',
-						'isStatic' => true,
-					],
-					'getFooOrBarStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => true,
-					],
-					'getIpsumStatically' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'OtherNamespace\Ipsum',
-						'isStatic' => true,
-					],
-					'methodWithNoReturnTypeStatically' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => true,
-					],
-					'getTestStatically' => [
-						'class' => \AnnotationsMethods\BazBaz::class,
-						'returnType' => 'OtherNamespace\Test',
-						'isStatic' => true,
-					],
-					'getIntegerWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => false,
-					],
-					'doSomethingWithDescription' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'void',
-						'isStatic' => false,
-					],
-					'getFooOrBarWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => false,
-					],
-					'getIpsumWithDescription' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'OtherNamespace\Ipsum',
-						'isStatic' => false,
-					],
-					'methodWithNoReturnTypeWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => false,
-					],
-					'getTestWithDescription' => [
-						'class' => \AnnotationsMethods\BazBaz::class,
-						'returnType' => 'OtherNamespace\Test',
-						'isStatic' => false,
-					],
-					'getIntegerStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'int',
-						'isStatic' => true,
-					],
-					'doSomethingStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'void',
-						'isStatic' => true,
-					],
-					'getFooOrBarStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'AnnotationsMethods\Foo|AnnotationsMethods\Bar',
-						'isStatic' => true,
-					],
-					'getIpsumStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Baz::class,
-						'returnType' => 'OtherNamespace\Ipsum',
-						'isStatic' => true,
-					],
-					'methodWithNoReturnTypeStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\Foo::class,
-						'returnType' => 'mixed',
-						'isStatic' => true,
-					],
-					'getTestStaticallyWithDescription' => [
-						'class' => \AnnotationsMethods\BazBaz::class,
-						'returnType' => 'OtherNamespace\Test',
-						'isStatic' => true,
-					],
-				],
-			],
+			[\AnnotationsMethods\Foo::class, $fooMethods],
+			[\AnnotationsMethods\Bar::class, $barMethods],
+			[\AnnotationsMethods\Baz::class, $bazMethods],
+			[\AnnotationsMethods\BazBaz::class, $bazBazMethods],
 		];
 	}
 

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
@@ -24,6 +24,29 @@ use OtherNamespace\Test as OtherTest;
  * @method static methodWithNoReturnTypeStaticallyWithDescription() Do something with a description statically, but what, who knows!
  * @method static bool aStaticMethodThatHasAUniqueReturnTypeInThisClass()
  * @method static string aStaticMethodThatHasAUniqueReturnTypeInThisClassWithDescription() A Description.
+ * @method int getIntegerNoParams
+ * @method void doSomethingNoParams
+ * @method self|Bar getFooOrBarNoParams
+ * @method methodWithNoReturnTypeNoParams
+ * @method static int getIntegerStaticallyNoParams
+ * @method static void doSomethingStaticallyNoParams
+ * @method static self|Bar getFooOrBarStaticallyNoParams
+ * @method static methodWithNoReturnTypeStaticallyNoParams
+ * @method int getIntegerWithDescriptionNoParams Get an integer with a description.
+ * @method void doSomethingWithDescriptionNoParams Do something with a description.
+ * @method self|Bar getFooOrBarWithDescriptionNoParams Get a Foo or a Bar with a description.
+ * @method static int getIntegerStaticallyWithDescriptionNoParams Get an integer with a description statically.
+ * @method static void doSomethingStaticallyWithDescriptionNoParams Do something with a description statically.
+ * @method static self|Bar getFooOrBarStaticallyWithDescriptionNoParams Get a Foo or a Bar with a description statically.
+ * @method static bool|string aStaticMethodThatHasAUniqueReturnTypeInThisClassNoParams
+ * @method static string|float aStaticMethodThatHasAUniqueReturnTypeInThisClassWithDescriptionNoParams A Description.
+ *
+ * Problem signatures
+ * ==================
+ * The following signatures will fail to test correctly as the __highlighted__ part is considered to be the method name.
+ *
+ * 1. methodWithNoReturnTypeWithDescriptionNoParams __Do__ something with a description but what, who knows!
+ * 2. static methodWithNoReturnTypeStaticallyWithDescriptionNoParams __Do__ something with a description statically, but what, who knows!
  */
 class Foo
 {
@@ -44,6 +67,14 @@ class Bar extends Foo
  * @method void doSomethingWithDescription(int $a, $b) Doing something
  * @method static Ipsum getIpsumStaticallyWithDescription($a) Lorem Ipsum Static
  * @method static void doSomethingStaticallyWithDescription(int $a, $b) Statically doing something
+ * @method Ipsum  getIpsumNoParams
+ * @method void doSomethingNoParams
+ * @method static Ipsum  getIpsumStaticallyNoParams
+ * @method static void doSomethingStaticallyNoParams
+ * @method Ipsum getIpsumWithDescriptionNoParams Ipsum Lorem
+ * @method void doSomethingWithDescriptionNoParams Doing something
+ * @method static Ipsum getIpsumStaticallyWithDescriptionNoParams Lorem Ipsum Static
+ * @method static void doSomethingStaticallyWithDescriptionNoParams Statically doing something
  */
 class Baz extends Bar
 {
@@ -55,6 +86,10 @@ class Baz extends Bar
  * @method static OtherTest getTestStatically()
  * @method OtherTest getTestWithDescription() Get a test
  * @method static OtherTest getTestStaticallyWithDescription() Get a test statically
+ * @method OtherTest getTestNoParams
+ * @method static OtherTest getTestStaticallyNoParams
+ * @method OtherTest getTestWithDescriptionNoParams Get a test
+ * @method static OtherTest getTestStaticallyWithDescriptionNoParams Get a test statically
  */
 class BazBaz extends Baz
 {


### PR DESCRIPTION
Fix https://github.com/phpstan/phpstan/issues/193

There are 2 signatures that cannot be parsed appropriately without some
more thought:
```
 * @method IsThisTheMethodNameOrReturnType IsThisTheMethodNameOrTheFirstWordOfTheDescription IsThisTheFirstOrSecondWordOfTheDescription
 * @method static IsThisTheStaticMethodNameOrReturnType IsThisTheStaticMethodNameOrTheFirstWordOfTheDescription IsThisTheFirstOrSecondWordOfTheDescription
```