### PR TITLE
Variable is considered null inside is null condition even if assigned 

### DIFF
--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -391,4 +391,15 @@ class CallMethodsRuleTest extends \PHPStan\Rules\AbstractRuleTest
 		]);
 	}
 
+	public function testStaticAssignmentAfterIsNull()
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/static-assignment-after-is-null.php'], [
+			[
+				'',
+				15,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/static-assignment-after-is-null.php
+++ b/tests/PHPStan/Rules/Methods/data/static-assignment-after-is-null.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace StaticAssignmentAfterIsNull;
+
+class MyClass
+{
+	private $object;
+
+	protected function getObject()
+	{
+		if ($this->object === null) {
+			$this->object = new Object();
+			$this->object->method();
+		}
+	}
+
+}
+
+class Object
+{
+	public function method()
+	{
+	}
+}


### PR DESCRIPTION
I tried to dig into why it's considered empty, but kind of got lost in the parsing part to be honest :( 

I was unsure on where to put the failing test. I put it in the rule's tests, but the actual rule that emits the error is IMO actually correct. It emits the error because it considers the variable null and in that case it's correct to not be able to call anything on it. 

Problem is it's not null, because it has been set on the line above. But that information falls through from nikic\php-parser if I understand it correctly. 

Note that this is the issue only if the variable is member variable of the class. It the variable is in local scope there is no error. 