### PR TITLE
Fix printf parameters rule.

### DIFF
--- a/src/Rules/Functions/PrintfParametersRule.php
+++ b/src/Rules/Functions/PrintfParametersRule.php
@@ -82,7 +82,7 @@ class PrintfParametersRule implements \PHPStan\Rules\Rule
 	private function getPlaceholdersCount(string $functionName, string $format): int
 	{
 		$specifiers = in_array($functionName, ['sprintf', 'printf'], true) ? '[bcdeEfFgGosuxX]' : '(?:[cdDeEfinosuxX]|\[\^[^\]]+\])';
-		$pattern = '~(?<before>%*)%(?:(?<position>\d+)\$)?[-+]?(?:[ 0]|(?:\'[^%]))?-?\d*(?:\.\d+)?' . $specifiers . '~';
+		$pattern = '~(?<before>%*)%(?:(?<position>\d+)\$)?[-+]?(?:[ 0]|(?:\'[^%]))?-?\d*(?:\.\d*)?' . $specifiers . '~';
 
 		if (!preg_match_all($pattern, $format, $matches, PREG_SET_ORDER)) {
 			return 0;

--- a/tests/PHPStan/Rules/Functions/data/printf.php
+++ b/tests/PHPStan/Rules/Functions/data/printf.php
@@ -33,3 +33,7 @@ sprintf('%%s'); // ok
 sscanf($str, "%20[^\n]\n%d", $string, $number); // ok
 sscanf($str, "%20[^\n]\r\n%d", $string, $number); // ok
 sscanf($str, "%20[^abcde]a%d", $string, $number); // ok
+printf("%.E", 3.14159); // ok
+sprintf("%.E", 3.14159); // ok
+sscanf($str, '%.E', $number); // ok
+fscanf($str, '%.E', $number); // ok


### PR DESCRIPTION
Fixed [`printf`](http://php.net/manual/en/function.sprintf.php) parameters rule to support optional precision specifier.

> An optional precision specifier in the form of a period (.) followed by an **_optional_** decimal digit string that says how many decimal digits should be displayed for floating-point numbers.