### PR TITLE
Fix coalesce and short ternary nullability

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -996,6 +996,10 @@ class NodeScopeResolverTest extends \PHPStan\TestCase
 			],
 			[
 				'string',
+				"null ?? 'foo'"
+			],
+			[
+				'string',
 				'\Foo::class',
 			],
 		];

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -991,6 +991,10 @@ class NodeScopeResolverTest extends \PHPStan\TestCase
 				'12 ?: null',
 			],
 			[
+				'int',
+				'null ?: 12',
+			],
+			[
 				'string|null',
 				"'foo' ?? null",
 			],


### PR DESCRIPTION
Hi, I have eventually come up with a fix for #213. I'm not sure if `Scope` is the right place for the `removeNullIfNotAcceptedBySubType` method, maybe it could be implemented in `TypeCombinator` somehow. Looking forward for any hints :)

(closes #213)