### PR TITLE
Complete the list of predefined variables

### DIFF
--- a/src/Rules/Variables/DefinedVariableRule.php
+++ b/src/Rules/Variables/DefinedVariableRule.php
@@ -35,7 +35,6 @@ class DefinedVariableRule implements \PHPStan\Rules\Rule
 			'_SESSION',
 			'_REQUEST',
 			'_ENV',
-			'http_response_header',
 			'argc',
 			'argv',
 		], true)) {

--- a/src/Rules/Variables/DefinedVariableRule.php
+++ b/src/Rules/Variables/DefinedVariableRule.php
@@ -35,6 +35,9 @@ class DefinedVariableRule implements \PHPStan\Rules\Rule
 			'_SESSION',
 			'_REQUEST',
 			'_ENV',
+			'http_response_header',
+			'argc',
+			'argv',
 		], true)) {
 			return [];
 		}

--- a/src/Rules/Variables/DefinedVariableRule.php
+++ b/src/Rules/Variables/DefinedVariableRule.php
@@ -35,10 +35,18 @@ class DefinedVariableRule implements \PHPStan\Rules\Rule
 			'_SESSION',
 			'_REQUEST',
 			'_ENV',
+		], true)) {
+			return [];
+		}
+
+		if (ini_get('register_argc_argv') && in_array($node->name, [
 			'argc',
 			'argv',
 		], true)) {
-			return [];
+			$isInMain = !$scope->isInClass() && !$scope->isInAnonymousFunction() && $scope->getFunction() === null;
+			if ($isInMain) {
+				return [];
+			}
 		}
 
 		if ($scope->isInVariableAssign($node->name)) {

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -86,6 +86,10 @@ class DefinedVariableRuleTest extends \PHPStan\Rules\AbstractRuleTest
 				'Undefined variable: $assignedInKey',
 				204,
 			],
+			[
+				'Undefined variable: $argc',
+				219,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Variables/data/defined-variables.php
+++ b/tests/PHPStan/Rules/Variables/data/defined-variables.php
@@ -213,3 +213,8 @@ if (($isInstanceOf = $fooObject) instanceof Foo && $isInstanceOf) {
 echo $isInstanceOf;
 
 isset($nonexistentVariableInIsset);
+
+echo $argc;
+function () {
+	echo $argc;
+};

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -24,4 +24,7 @@
 		/>
 		<log type="coverage-clover" target="tmp/clover.xml"/>
 	</logging>
+	<php>
+		<ini name="register_argc_argv" value="1"/>
+	</php>
 </phpunit>


### PR DESCRIPTION
I updated the list of predefined variables using [the documentation](http://php.net/manual/en/reserved.variables.php).
However I ignored _[$php_errormsg](http://php.net/manual/en/reserved.variables.phperrormsg.php)_ and _[$HTTP_RAW_POST_DATA](http://php.net/manual/en/reserved.variables.httprawpostdata.php)_ since they are both deprecated.