### PR TITLE
[PoC] Broker: Handle fatal errors when autoloading unknown classes/interfaces/traits

### DIFF
--- a/src/Broker/Broker.php
+++ b/src/Broker/Broker.php
@@ -143,13 +143,23 @@ class Broker
 
 	public function hasClass(string $className): bool
 	{
+		spl_autoload_register($autoloader = function (string $autoloadedClassName) use ($className) {
+			if ($autoloadedClassName !== $className) {
+				throw new \PHPStan\Broker\ClassAutoloadingException($autoloadedClassName);
+			}
+		});
+
 		try {
 			return class_exists($className) || interface_exists($className) || trait_exists($className);
+		} catch (\PHPStan\Broker\ClassAutoloadingException $e) {
+			throw $e;
 		} catch (\Throwable $t) {
 			throw new \PHPStan\Broker\ClassAutoloadingException(
 				$className,
 				$t
 			);
+		} finally {
+			spl_autoload_unregister($autoloader);
 		}
 	}
 

--- a/src/Broker/ClassAutoloadingException.php
+++ b/src/Broker/ClassAutoloadingException.php
@@ -10,15 +10,23 @@ class ClassAutoloadingException extends \PHPStan\AnalysedCodeException
 
 	public function __construct(
 		string $functionName,
-		\Throwable $previous
+		\Throwable $previous = null
 	)
 	{
-		parent::__construct(sprintf(
-			'%s (%s) thrown while autoloading class %s.',
-			get_class($previous),
-			$previous->getMessage(),
-			$functionName
-		), 0, $previous);
+		if ($previous !== null) {
+			parent::__construct(sprintf(
+				'%s (%s) thrown while autoloading class %s.',
+				get_class($previous),
+				$previous->getMessage(),
+				$functionName
+			), 0, $previous);
+		} else {
+			parent::__construct(sprintf(
+				'Class %s not found and could not be autoloaded.',
+				$functionName
+			), 0, $previous);
+		}
+
 		$this->className = $functionName;
 	}
 


### PR DESCRIPTION
Possible fix for #168 & #159. This could be completely wrong or broken.

---

Note that this doesn't handle other fatal errors, like:
```
class Foo extends Foo {}
```
or
```
use Foo\Bar;
class Bar {}
```

Those would have to be checked on different level (parser?). This targets solely autoload failures.