### PR TITLE
Cache resolved node types

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -133,6 +133,7 @@ class Analyser
 		}
 
 		$this->nodeScopeResolver->setAnalysedFiles($files);
+		$resolvedNodeTypes = [];
 		foreach ($files as $file) {
 			try {
 				if ($this->fileExcluder->isExcludedFromAnalysing($file)) {
@@ -146,7 +147,7 @@ class Analyser
 				$fileErrors = [];
 				$this->nodeScopeResolver->processNodes(
 					$this->parser->parseFile($file),
-					new Scope($this->broker, $this->printer, $this->typeSpecifier, $file),
+					new Scope($this->broker, $this->printer, $this->typeSpecifier, $file, $resolvedNodeTypes),
 					function (\PhpParser\Node $node, Scope $scope) use (&$fileErrors) {
 						if ($node instanceof \PhpParser\Node\Stmt\Trait_) {
 							return;

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -2537,13 +2537,15 @@ class NodeScopeResolverTest extends \PHPStan\TestCase
 
 	private function processFile(string $file, \Closure $callback, array $dynamicMethodReturnTypeExtensions = [], array $dynamicStaticMethodReturnTypeExtensions = [])
 	{
+		$resolvedTypes = [];
 		$this->resolver->processNodes(
 			$this->getParser()->parseFile($file),
 			new Scope(
 				$this->createBroker($dynamicMethodReturnTypeExtensions, $dynamicStaticMethodReturnTypeExtensions),
 				$this->printer,
 				new TypeSpecifier($this->printer),
-				$file
+				$file,
+				$resolvedTypes
 			),
 			$callback
 		);


### PR DESCRIPTION
This partially fixes https://github.com/phpstan/phpstan/issues/254 and https://github.com/phpstan/phpstan/issues/191. There is still the fatal error for maximum function nesting, but the type resolution for long chained calls is much faster.

Two issues with this. First, two tests are failing, and I have no idea why. And second, I cache the node types using `spl_object_hash`, which I don't like very much, but I couldn't think of a better way. Any thoughts? I just want to know if this is a viable way to address those issues, or if you'd prefer some other approach.