### PR TITLE
min and max behave differently for single array argument

### DIFF
--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -690,6 +690,14 @@ class Scope
 						return $argumentType->getItemType();
 					}
 				}
+
+				if (count($node->args) === 1) {
+					$argumentType = $this->getType($node->args[0]->value);
+					if ($argumentType instanceof ArrayType) {
+						return $argumentType->getItemType();
+					}
+				}
+
 				$argumentType = null;
 				foreach ($node->args as $arg) {
 					$argType = $this->getType($arg->value);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1034,6 +1034,14 @@ class NodeScopeResolverTest extends \PHPStan\TestCase
 				'__DIR__',
 			],
 			[
+				'int', // if the only argument in min is array, lowest value in that array is returned
+				'min([1, 2, 3])',
+			],
+			[
+				'int[]',
+				'min([1, 2, 3], [4, 5, 5])',
+			],
+			[
 				'int',
 				'min(...[1, 2, 3])',
 			],


### PR DESCRIPTION
Change in commit https://github.com/phpstan/phpstan/commit/3d60b7c7ad363519f98abef605a54fdcef52df2b doesn't take into account a situation when a single array is passed to `min()` or `max()`.

From: http://php.net/min:
> If the first and only parameter is an array, min() returns the lowest value in that array. 

The fix is not perfect, because if in the future, more functions are added into `$functionsThatCombineAllArgumentTypes`, they may behave differently. Would you prefer wrapping the condition in another one which would check specifically for min/max?