### PR TITLE
Specify ext- dependencies in require-dev in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"symfony/finder": "~2.7 || ~3.0"
 	},
 	"require-dev": {
+		"ext-gd": "*",
 		"consistence/coding-standard": "~0.13.0",
 		"jakub-onderka/php-parallel-lint": "^0.9.2",
 		"satooshi/php-coveralls": "^1.0",


### PR DESCRIPTION
It is better to have it explicitly stated in the `composer.json`, so it is easier to setup e.g. the CI (I guess that [this one](https://github.com/phpstan/phpstan/blob/51d202c6e64f13410d280e9eb39c83c3da505675/appveyor.yml#L47) was unnecessarily found by trial and error)