### PR TITLE
FileExcluder should match case-insensitively on Windows

### DIFF
--- a/src/File/FileExcluder.php
+++ b/src/File/FileExcluder.php
@@ -37,7 +37,7 @@ class FileExcluder
 
 			$isWindows = DIRECTORY_SEPARATOR === '\\';
 			if ($isWindows) {
-				$fnmatchFlags = FNM_NOESCAPE;
+				$fnmatchFlags = FNM_NOESCAPE | FNM_CASEFOLD;
 			} else {
 				$fnmatchFlags = 0;
 			}

--- a/src/File/FileExcluder.php
+++ b/src/File/FileExcluder.php
@@ -35,7 +35,14 @@ class FileExcluder
 				return true;
 			}
 
-			if ($this->isFnmatchPattern($exclude) && fnmatch($exclude, $file, DIRECTORY_SEPARATOR === '\\' ? FNM_NOESCAPE : 0)) {
+			$isWindows = DIRECTORY_SEPARATOR === '\\';
+			if ($isWindows) {
+				$fnmatchFlags = FNM_NOESCAPE;
+			} else {
+				$fnmatchFlags = 0;
+			}
+
+			if ($this->isFnmatchPattern($exclude) && fnmatch($exclude, $file, $fnmatchFlags)) {
 				return true;
 			}
 		}

--- a/tests/PHPStan/File/FileExcluderTest.php
+++ b/tests/PHPStan/File/FileExcluderTest.php
@@ -96,6 +96,21 @@ class FileExcluderTest extends \PHPStan\TestCase
 				['C:/Temp/*'],
 				false,
 			],
+			[
+				'c:\Temp\data\parse-error.php',
+				['C:/Temp/*'],
+				true,
+			],
+			[
+				'C:\Temp\data\parse-error.php',
+				['C:/temp/*'],
+				true,
+			],
+			[
+				'c:\Data\data\parse-error.php',
+				['C:/Temp/*'],
+				false,
+			],
 		];
 	}
 

--- a/tests/PHPStan/File/FileExcluderTest.php
+++ b/tests/PHPStan/File/FileExcluderTest.php
@@ -1,0 +1,182 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+class FileExcluderTest extends \PHPStan\TestCase
+{
+
+	private function skipIfNotOnWindows()
+	{
+		if (DIRECTORY_SEPARATOR !== '\\') {
+			$this->markTestSkipped();
+		}
+	}
+
+	private function skipIfNotOnUnix()
+	{
+		if (DIRECTORY_SEPARATOR !== '/') {
+			$this->markTestSkipped();
+		}
+	}
+
+	/**
+	 * @dataProvider dataExcludeOnWindows
+	 * @param string $filePath
+	 * @param string[] $analyseExcludes
+	 * @param bool $isExcluded
+	 */
+	public function testFilesAreExcludedFromAnalysingOnWindows(
+		string $filePath,
+		array $analyseExcludes,
+		bool $isExcluded
+	)
+	{
+		$this->skipIfNotOnWindows();
+
+		$fileExcluder = new FileExcluder($this->getFileHelper(), $analyseExcludes);
+
+		$this->assertSame($isExcluded, $fileExcluder->isExcludedFromAnalysing($filePath));
+	}
+
+	public function dataExcludeOnWindows(): array
+	{
+		return [
+			[
+				__DIR__ . '/data/excluded-file.php',
+				[],
+				false,
+			],
+			[
+				__DIR__ . '/data/excluded-file.php',
+				[__DIR__],
+				true,
+			],
+			[
+				__DIR__ . '\Foo\data\excluded-file.php',
+				[__DIR__ . '/*/data/*'],
+				true,
+			],
+			[
+				__DIR__ . '\data\func-call.php',
+				[],
+				false,
+			],
+			[
+				__DIR__ . '\data\parse-error.php',
+				[__DIR__ . '/*'],
+				true,
+			],
+			[
+				__DIR__ . '\data\parse-error.php',
+				[__DIR__ . '/data/?a?s?-error.?h?'],
+				true,
+			],
+			[
+				__DIR__ . '\data\parse-error.php',
+				[__DIR__ . '/data/[pP]arse-[eE]rror.ph[pP]'],
+				true,
+			],
+			[
+				__DIR__ . '\data\parse-error.php',
+				['tests/PHPStan/File/data'],
+				true,
+			],
+			[
+				__DIR__ . '\data\parse-error.php',
+				[__DIR__ . '/aaa'],
+				false,
+			],
+			[
+				'C:\Temp\data\parse-error.php',
+				['C:/Temp/*'],
+				true,
+			],
+			[
+				'C:\Data\data\parse-error.php',
+				['C:/Temp/*'],
+				false,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataExcludeOnUnix
+	 * @param string $filePath
+	 * @param string[] $analyseExcludes
+	 * @param bool $isExcluded
+	 */
+	public function testFilesAreExcludedFromAnalysingOnUnix(
+		string $filePath,
+		array $analyseExcludes,
+		bool $isExcluded
+	)
+	{
+		$this->skipIfNotOnUnix();
+
+		$fileExcluder = new FileExcluder($this->getFileHelper(), $analyseExcludes);
+
+		$this->assertSame($isExcluded, $fileExcluder->isExcludedFromAnalysing($filePath));
+	}
+
+	public function dataExcludeOnUnix(): array
+	{
+		return [
+			[
+				__DIR__ . '/data/excluded-file.php',
+				[],
+				false,
+			],
+			[
+				__DIR__ . '/data/excluded-file.php',
+				[__DIR__],
+				true,
+			],
+			[
+				__DIR__ . '/Foo/data/excluded-file.php',
+				[__DIR__ . '/*/data/*'],
+				true,
+			],
+			[
+				__DIR__ . '/data/func-call.php',
+				[],
+				false,
+			],
+			[
+				__DIR__ . '/data/parse-error.php',
+				[__DIR__ . '/*'],
+				true,
+			],
+			[
+				__DIR__ . '/data/parse-error.php',
+				[__DIR__ . '/data/?a?s?-error.?h?'],
+				true,
+			],
+			[
+				__DIR__ . '/data/parse-error.php',
+				[__DIR__ . '/data/[pP]arse-[eE]rror.ph[pP]'],
+				true,
+			],
+			[
+				__DIR__ . '/data/parse-error.php',
+				['tests/PHPStan/File/data'],
+				true,
+			],
+			[
+				__DIR__ . '/data/parse-error.php',
+				[__DIR__ . '/aaa'],
+				false,
+			],
+			[
+				'/tmp/data/parse-error.php',
+				['/tmp/*'],
+				true,
+			],
+			[
+				'/home/myname/data/parse-error.php',
+				['/tmp/*'],
+				false,
+			],
+		];
+	}
+
+}


### PR DESCRIPTION
Otherwise running phpstan on itself fails when run in cmd opened with `c:` instead of `C:`.

They had similar issue in VSCode https://github.com/Microsoft/vscode/issues/9448