### PR TITLE
Checkstyle formatter

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -162,3 +162,6 @@ services:
 
 	errorFormatter.table:
 		class: PHPStan\Command\ErrorFormatter\TableErrorFormatter
+
+	errorFormatter.checkstyle:
+		class: PHPStan\Command\ErrorFormatter\CheckstyleErrorFormatter

--- a/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
+++ b/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use Symfony\Component\Console\Style\OutputStyle;
+
+class CheckstyleErrorFormatter implements ErrorFormatter
+{
+
+	/**
+	 * Formats the errors and outputs them to the console.
+	 *
+	 * @param \PHPStan\Command\AnalysisResult $analysisResult
+	 * @param \Symfony\Component\Console\Style\OutputStyle $style
+	 * @return int Error code.
+	 */
+	public function formatErrors(
+		AnalysisResult $analysisResult,
+		OutputStyle $style
+	): int
+	{
+		$returnCode = 1;
+		if (!$analysisResult->hasErrors()) {
+			$returnCode = 0;
+		}
+
+		$out = '';
+
+		/** @var \PHPStan\Analyser\Error $fileSpecificError */
+		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+			$out .= '<file name="' . $this->escape($fileSpecificError->getFile()) . '">' . "\n";
+			$out .= ' ';
+			$out .= '<error';
+			$out .= ' line="' . $this->escape((string) $fileSpecificError->getLine()) . '"';
+			$out .= ' column="1"';
+			$out .= ' severity="error"';
+			$out .= ' message="' . $this->escape($fileSpecificError->getMessage()) . '"';
+			$out .= '/>' . "\n";
+			$out .= '</file>' . "\n";
+		}
+
+		$style->write('<?xml version="1.0" encoding="UTF-8"?>' . "\n");
+		$style->write('<checkstyle>' . "\n");
+		if ($out) {
+			$style->write($out);
+		}
+		$style->write('</checkstyle>' . "\n");
+
+		return $returnCode;
+	}
+
+	/**
+	 * Escapes values for using in XML
+	 *
+	 * @param string $string
+	 * @return string
+	 */
+	protected function escape(string $string): string
+	{
+		return htmlspecialchars($string, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+	}
+
+}

--- a/src/Command/ErrorsConsoleStyle.php
+++ b/src/Command/ErrorsConsoleStyle.php
@@ -24,7 +24,7 @@ class ErrorsConsoleStyle extends \Symfony\Component\Console\Style\SymfonyStyle
 	public function __construct(InputInterface $input, OutputInterface $output)
 	{
 		parent::__construct($input, $output);
-		$this->showProgress = !$input->getOption(self::OPTION_NO_PROGRESS);
+		$this->showProgress = $input->hasOption(self::OPTION_NO_PROGRESS) && !$input->getOption(self::OPTION_NO_PROGRESS);
 		$this->output = $output;
 	}
 

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use PHPStan\Analyser\Error;
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\ErrorsConsoleStyle;
+use PHPStan\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class CheckstyleErrorFormatterTest extends TestCase
+{
+
+	/**
+	 * @var CheckstyleErrorFormatter
+	 */
+	protected $formatter;
+
+	/**
+	 * Set up method
+	 *
+	 * @return void
+	 */
+	protected function setUp()
+	{
+		$this->formatter = new CheckstyleErrorFormatter();
+	}
+
+	/**
+	 * Test FormatErrors method
+	 *
+	 * @return void
+	 */
+	public function testFormatErrors()
+	{
+		$analysisResultMock = $this->createMock(AnalysisResult::class);
+		$analysisResultMock
+			->expects($this->at(0))
+			->method('hasErrors')
+			->willReturn(true);
+
+		$analysisResultMock
+			->expects($this->at(1))
+			->method('getFileSpecificErrors')
+			->willReturn([
+				new Error('Foo', 'foo.php', 1),
+				new Error('Bar', 'file name with "spaces" and unicode 😃.php', 2),
+			]);
+
+		$outputStream = new StreamOutput(fopen('php://memory', 'w', false));
+		$style = new ErrorsConsoleStyle(new StringInput(''), $outputStream);
+
+		$this->assertEquals(1, $this->formatter->formatErrors($analysisResultMock, $style));
+
+		rewind($outputStream->getStream());
+		$output = stream_get_contents($outputStream->getStream());
+
+		$expected = '<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+<file name="foo.php">
+ <error line="1" column="1" severity="error" message="Foo"/>
+</file>
+<file name="file name with &quot;spaces&quot; and unicode 😃.php">
+ <error line="2" column="1" severity="error" message="Bar"/>
+</file>
+</checkstyle>
+';
+		$this->assertEquals($expected, $output);
+	}
+
+	/**
+	 * Test FormatErrors method
+	 *
+	 * @return void
+	 */
+	public function testFormatErrorsEmpty()
+	{
+		$analysisResultMock = $this->createMock(AnalysisResult::class);
+		$analysisResultMock
+			->expects($this->at(0))
+			->method('hasErrors')
+			->willReturn(false);
+
+		$outputStream = new StreamOutput(fopen('php://memory', 'w', false));
+		$style = new ErrorsConsoleStyle(new StringInput(''), $outputStream);
+
+		$this->assertEquals(0, $this->formatter->formatErrors($analysisResultMock, $style));
+
+		rewind($outputStream->getStream());
+		$output = stream_get_contents($outputStream->getStream());
+
+		$expected = '<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+</checkstyle>
+';
+		$this->assertEquals($expected, $output);
+	}
+
+}


### PR DESCRIPTION
Enabled PHPStan to create reports in checkstyle.xml format #271.

Support for this format is currently limited: all violations have a severity of "error".
All violations are marked as found in column 1.