### PR TITLE
Fixed mysqli::query parameters count

### DIFF
--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -61,6 +61,13 @@ class FunctionCallParametersCheck
 		) {
 			$functionParametersMinCount = 1;
 			$functionParametersMaxCount = 4;
+		} elseif (
+			$function instanceof MethodReflection
+			&& $function->getDeclaringClass()->getName() === 'mysqli'
+			&& $function->getName() === 'query'
+		) {
+			$functionParametersMinCount = 1;
+			$functionParametersMaxCount = 2;
 		} else {
 			$functionParametersMinCount = 0;
 			$functionParametersMaxCount = 0;

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -453,4 +453,16 @@ class CallMethodsRuleTest extends \PHPStan\Rules\AbstractRuleTest
 		]);
 	}
 
+	public function testMysqliQuery()
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = false;
+		$this->analyse([__DIR__ . '/data/mysqli-query.php'], [
+			[
+				'Method mysqli::query() invoked with 0 parameters, 1-2 required.',
+				4,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/mysqli-query.php
+++ b/tests/PHPStan/Rules/Methods/data/mysqli-query.php
@@ -1,0 +1,5 @@
+<?php
+
+$mysqli = new mysqli();
+$mysqli->query();
+$mysqli->query('query', MYSQLI_USE_RESULT);


### PR DESCRIPTION
Workaround for parameters check of mysqli::query call (needed because ReflectionMethod::getParameters() returns only 1 parameter for mysqli::query instead of 2 (see https://bugs.php.net/bug.php?id=74595)). 