### PR TITLE
Add better description to "call on nullable" error

### DIFF
--- a/src/Rules/Methods/CallMethodsOnPossiblyNullRule.php
+++ b/src/Rules/Methods/CallMethodsOnPossiblyNullRule.php
@@ -58,7 +58,7 @@ class CallMethodsOnPossiblyNullRule implements \PHPStan\Rules\Rule
 		if (\PHPStan\Type\TypeCombinator::containsNull($type)) {
 			return [
 				sprintf(
-					'Calling method %s() on possibly nullable type %s.',
+					'Calling method %s() on possibly null value of type %s.',
 					$node->name,
 					$type->describe()
 				),

--- a/tests/PHPStan/Rules/Methods/CallMethodsOnPossiblyNullRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsOnPossiblyNullRuleTest.php
@@ -16,7 +16,7 @@ class CallMethodsOnPossiblyNullRuleTest extends \PHPStan\Rules\AbstractRuleTest
 	{
 		$this->analyse([__DIR__ . '/data/possibly-nullable.php'], [
 			[
-				'Calling method format() on possibly nullable type DateTimeImmutable|null.',
+				'Calling method format() on possibly null value of type DateTimeImmutable|null.',
 				11,
 			],
 		]);


### PR DESCRIPTION
Hi.

Just a little semantic change to the error description.  We already know the type is "possibly nullable" so that information is unnecessary, plus we really don't call anything on a *type* but rather a *value*.

Great job implementing this check by the way, love it!