### PR TITLE
Improvement of parsing class annotations - write only properties, method parameters

### DIFF
--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -21,12 +21,20 @@ class AnnotationMethodReflection implements MethodReflection
 	/** @var bool */
 	private $isStatic;
 
-	public function __construct(string $name, ClassReflection $declaringClass, Type $returnType, bool $isStatic)
+	/** @var \PHPStan\Reflection\Annotations\AnnotationsMethodParameterReflection[] */
+	private $parameters;
+
+	/** @var bool */
+	private $isVariadic;
+
+	public function __construct(string $name, ClassReflection $declaringClass, Type $returnType, array $parameters, bool $isStatic, bool $isVariadic)
 	{
 		$this->name = $name;
 		$this->declaringClass = $declaringClass;
 		$this->returnType = $returnType;
+		$this->parameters = $parameters;
 		$this->isStatic = $isStatic;
+		$this->isVariadic = $isVariadic;
 	}
 
 	public function getDeclaringClass(): ClassReflection
@@ -46,12 +54,12 @@ class AnnotationMethodReflection implements MethodReflection
 
 	public function getParameters(): array
 	{
-		return [];
+		return $this->parameters;
 	}
 
 	public function isVariadic(): bool
 	{
-		return true;
+		return $this->isVariadic;
 	}
 
 	public function isPrivate(): bool

--- a/src/Reflection/Annotations/AnnotationPropertyReflection.php
+++ b/src/Reflection/Annotations/AnnotationPropertyReflection.php
@@ -15,13 +15,23 @@ class AnnotationPropertyReflection implements PropertyReflection
 	/** @var \PHPStan\Type\Type */
 	private $type;
 
+	/** @var bool */
+	private $readable;
+
+	/** @var bool */
+	private $writable;
+
 	public function __construct(
 		ClassReflection $declaringClass,
-		Type $type
+		Type $type,
+		bool $readable = true,
+		bool $writable = true
 	)
 	{
 		$this->declaringClass = $declaringClass;
 		$this->type = $type;
+		$this->readable = $readable;
+		$this->writable = $writable;
 	}
 
 	public function getDeclaringClass(): ClassReflection
@@ -47,6 +57,16 @@ class AnnotationPropertyReflection implements PropertyReflection
 	public function getType(): Type
 	{
 		return $this->type;
+	}
+
+	public function isReadable(): bool
+	{
+		return $this->readable;
+	}
+
+	public function isWritable(): bool
+	{
+		return $this->writable;
 	}
 
 }

--- a/src/Reflection/Annotations/AnnotationsMethodParameterReflection.php
+++ b/src/Reflection/Annotations/AnnotationsMethodParameterReflection.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Annotations;
+
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Type\Type;
+
+class AnnotationsMethodParameterReflection implements ParameterReflection
+{
+
+	/** @var string */
+	private $name;
+
+	/** @var Type */
+	private $type;
+
+	/** @var bool */
+	private $isPassedByReference;
+
+	/** @var bool */
+	private $isOptional;
+
+	/** @var bool */
+	private $isVariadic;
+
+	public function __construct(string $name, Type $type, bool $isPassedByReference, bool $isOptional, bool $isVariadic)
+	{
+		$this->name = $name;
+		$this->type = $type;
+		$this->isPassedByReference = $isPassedByReference;
+		$this->isOptional = $isOptional;
+		$this->isVariadic = $isVariadic;
+	}
+
+	public function getName(): string
+	{
+		return $this->name;
+	}
+
+	public function isOptional(): bool
+	{
+		return $this->isOptional;
+	}
+
+	public function getType(): Type
+	{
+		return $this->type;
+	}
+
+	public function isPassedByReference(): bool
+	{
+		return $this->isPassedByReference;
+	}
+
+	public function isVariadic(): bool
+	{
+		return $this->isVariadic;
+	}
+
+}

--- a/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
@@ -73,7 +73,7 @@ class AnnotationsPropertiesClassReflectionExtension implements PropertiesClassRe
 
 		$typeMap = $this->fileTypeMapper->getTypeMap($fileName);
 
-		preg_match_all('#@property(-read|-write)?\s+' . FileTypeMapper::TYPE_PATTERN . '\s+\$([a-zA-Z0-9_]+)#', $docComment, $matches, PREG_SET_ORDER);
+		preg_match_all('#@property(-read|-write)?\s+(\??)' . FileTypeMapper::TYPE_PATTERN . '\s+\$([a-zA-Z0-9_]+)#', $docComment, $matches, PREG_SET_ORDER);
 		foreach ($matches as $match) {
 			$typeString = $match[3];
 			if (!isset($typeMap[$typeString])) {

--- a/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
@@ -6,6 +6,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Type\FileTypeMapper;
+use PHPStan\Type\TypeCombinator;
 
 class AnnotationsPropertiesClassReflectionExtension implements PropertiesClassReflectionExtension
 {
@@ -72,14 +73,23 @@ class AnnotationsPropertiesClassReflectionExtension implements PropertiesClassRe
 
 		$typeMap = $this->fileTypeMapper->getTypeMap($fileName);
 
-		preg_match_all('#@property(?:-read)?\s+' . FileTypeMapper::TYPE_PATTERN . '\s+\$([a-zA-Z0-9_]+)#', $docComment, $matches, PREG_SET_ORDER);
+		preg_match_all('#@property(-read|-write)?\s+' . FileTypeMapper::TYPE_PATTERN . '\s+\$([a-zA-Z0-9_]+)#', $docComment, $matches, PREG_SET_ORDER);
 		foreach ($matches as $match) {
-			$typeString = $match[1];
+			$typeString = $match[3];
 			if (!isset($typeMap[$typeString])) {
 				continue;
 			}
-
-			$properties[$match[2]] = new AnnotationPropertyReflection($declaringClass, $typeMap[$typeString]);
+			$readable = $writable = true;
+			if ($match[1] === '-read') {
+				$writable = false;
+			} elseif ($match[1] === '-write') {
+				$readable = false;
+			}
+			$type = $typeMap[$typeString];
+			if ($match[2] === '?') {
+				$type = TypeCombinator::addNull($type);
+			}
+			$properties[$match[4]] = new AnnotationPropertyReflection($classReflection, $type, $readable, $writable);
 		}
 
 		return $properties;

--- a/src/Reflection/Php/PhpPropertyReflection.php
+++ b/src/Reflection/Php/PhpPropertyReflection.php
@@ -54,4 +54,14 @@ class PhpPropertyReflection implements PropertyReflection
 		return $this->type;
 	}
 
+	public function isReadable(): bool
+	{
+		return $this->reflection->isPublic();
+	}
+
+	public function isWritable(): bool
+	{
+		return $this->reflection->isPublic();
+	}
+
 }

--- a/src/Reflection/Php/UniversalObjectCrateProperty.php
+++ b/src/Reflection/Php/UniversalObjectCrateProperty.php
@@ -42,4 +42,14 @@ class UniversalObjectCrateProperty implements \PHPStan\Reflection\PropertyReflec
 		return new MixedType();
 	}
 
+	public function isReadable(): bool
+	{
+		return true;
+	}
+
+	public function isWritable(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Reflection/PhpDefect/PhpDefectPropertyReflection.php
+++ b/src/Reflection/PhpDefect/PhpDefectPropertyReflection.php
@@ -49,4 +49,14 @@ class PhpDefectPropertyReflection implements PropertyReflection
 		return $this->type;
 	}
 
+	public function isReadable(): bool
+	{
+		return true;
+	}
+
+	public function isWritable(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Reflection/PhpParser/NamespacedNameProperty.php
+++ b/src/Reflection/PhpParser/NamespacedNameProperty.php
@@ -43,4 +43,14 @@ class NamespacedNameProperty implements \PHPStan\Reflection\PropertyReflection
 		return new ObjectType(Name::class);
 	}
 
+	public function isReadable(): bool
+	{
+		return true;
+	}
+
+	public function isWritable(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Reflection/PropertyReflection.php
+++ b/src/Reflection/PropertyReflection.php
@@ -9,4 +9,8 @@ interface PropertyReflection extends ClassMemberReflection
 
 	public function getType(): Type;
 
+	public function isReadable(): bool;
+
+	public function isWritable(): bool;
+
 }

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -32,7 +32,7 @@ class FileTypeMapper
 
 	public function getTypeMap(string $fileName): array
 	{
-		$cacheKey = sprintf('%s-%d-v32', $fileName, filemtime($fileName));
+		$cacheKey = sprintf('%s-%d-v33', $fileName, filemtime($fileName));
 		if (isset($this->memoryCache[$cacheKey])) {
 			return $this->memoryCache[$cacheKey];
 		}
@@ -57,7 +57,7 @@ class FileTypeMapper
 			'#@var\s+' . self::TYPE_PATTERN . '#',
 			'#@var\s+\$[a-zA-Z0-9_]+\s+' . self::TYPE_PATTERN . '#',
 			'#@return\s+' . self::TYPE_PATTERN . '#',
-			'#@property(?:-read)?\s+' . self::TYPE_PATTERN . '\s+\$[a-zA-Z0-9_]+#',
+			'#@property(?:-read|-write)?\s+' . self::TYPE_PATTERN . '\s+\$[a-zA-Z0-9_]+#',
 			'#@method\s+(?:static\s+)?' . self::TYPE_PATTERN . '\s*?[a-zA-Z0-9_]+(?:\(.*\))?#',
 		];
 

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -14,176 +14,366 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'int',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [
+					[
+						'name' => 'a',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+					[
+						'name' => 'b',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+				],
 			],
 			'doSomething' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'void',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [
+					[
+						'name' => 'a',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+					[
+						'name' => 'b',
+						'type' => 'mixed',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+				],
 			],
 			'getFooOrBar' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'AnnotationsMethods\Bar|AnnotationsMethods\Foo',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'methodWithNoReturnType' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'mixed',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getIntegerStatically' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'int',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [
+					[
+						'name' => 'a',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+					[
+						'name' => 'b',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+				],
 			],
 			'doSomethingStatically' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'void',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [
+					[
+						'name' => 'a',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+					[
+						'name' => 'b',
+						'type' => 'mixed',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+				],
 			],
 			'getFooOrBarStatically' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'AnnotationsMethods\Bar|AnnotationsMethods\Foo',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'methodWithNoReturnTypeStatically' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'mixed',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getIntegerWithDescription' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'int',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [
+					[
+						'name' => 'a',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+					[
+						'name' => 'b',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+				],
 			],
 			'doSomethingWithDescription' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'void',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [
+					[
+						'name' => 'a',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+					[
+						'name' => 'b',
+						'type' => 'mixed',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+				],
 			],
 			'getFooOrBarWithDescription' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'AnnotationsMethods\Bar|AnnotationsMethods\Foo',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'methodWithNoReturnTypeWithDescription' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'mixed',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getIntegerStaticallyWithDescription' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'int',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [
+					[
+						'name' => 'a',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+					[
+						'name' => 'b',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+				],
 			],
 			'doSomethingStaticallyWithDescription' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'void',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [
+					[
+						'name' => 'a',
+						'type' => 'int',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+					[
+						'name' => 'b',
+						'type' => 'mixed',
+						'isPassedByReference' => false,
+						'isOptional' => false,
+						'isVariadic' => false,
+					],
+				],
 			],
 			'getFooOrBarStaticallyWithDescription' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'AnnotationsMethods\Bar|AnnotationsMethods\Foo',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'methodWithNoReturnTypeStaticallyWithDescription' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'mixed',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'aStaticMethodThatHasAUniqueReturnTypeInThisClass' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'bool',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'aStaticMethodThatHasAUniqueReturnTypeInThisClassWithDescription' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'string',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getIntegerNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'int',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'doSomethingNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'void',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getFooOrBarNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'AnnotationsMethods\Bar|AnnotationsMethods\Foo',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'methodWithNoReturnTypeNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'mixed',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getIntegerStaticallyNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'int',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'doSomethingStaticallyNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'void',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getFooOrBarStaticallyNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'AnnotationsMethods\Bar|AnnotationsMethods\Foo',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'methodWithNoReturnTypeStaticallyNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'mixed',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getIntegerWithDescriptionNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'int',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'doSomethingWithDescriptionNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'void',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getFooOrBarWithDescriptionNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'AnnotationsMethods\Bar|AnnotationsMethods\Foo',
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getIntegerStaticallyWithDescriptionNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'int',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'doSomethingStaticallyWithDescriptionNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'void',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'getFooOrBarStaticallyWithDescriptionNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'AnnotationsMethods\Bar|AnnotationsMethods\Foo',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'aStaticMethodThatHasAUniqueReturnTypeInThisClassNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'bool|string',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'aStaticMethodThatHasAUniqueReturnTypeInThisClassWithDescriptionNoParams' => [
 				'class' => \AnnotationsMethods\Foo::class,
 				'returnType' => 'float|string',
 				'isStatic' => true,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 			'methodFromInterface' => [
 				'class' => \AnnotationsMethods\FooInterface::class,
 				'returnType' => \AnnotationsMethods\FooInterface::class,
 				'isStatic' => false,
+				'isVariadic' => false,
+				'parameters' => [],
 			],
 		];
 		$barMethods = $fooMethods;
@@ -194,66 +384,184 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'void',
 					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'int',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'b',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
 				],
 				'getIpsum' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'OtherNamespace\Ipsum',
 					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
 				],
 				'getIpsumStatically' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'OtherNamespace\Ipsum',
 					'isStatic' => true,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
 				],
 				'getIpsumWithDescription' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'OtherNamespace\Ipsum',
 					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
 				],
 				'getIpsumStaticallyWithDescription' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'OtherNamespace\Ipsum',
 					'isStatic' => true,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
 				],
 				'doSomethingStatically' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'void',
 					'isStatic' => true,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'int',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'b',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
 				],
 				'doSomethingWithDescription' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'void',
 					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'int',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'b',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
 				],
 				'doSomethingStaticallyWithDescription' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'void',
 					'isStatic' => true,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'int',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'b',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
 				],
 				'doSomethingNoParams' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'void',
 					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [],
 				],
 				'doSomethingStaticallyNoParams' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'void',
 					'isStatic' => true,
+					'isVariadic' => false,
+					'parameters' => [],
 				],
 				'doSomethingWithDescriptionNoParams' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'void',
 					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [],
 				],
 				'doSomethingStaticallyWithDescriptionNoParams' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => 'void',
 					'isStatic' => true,
+					'isVariadic' => false,
+					'parameters' => [],
 				],
 				'methodFromTrait' => [
 					'class' => \AnnotationsMethods\Baz::class,
 					'returnType' => \AnnotationsMethods\BazBaz::class,
 					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [],
 				],
 			]
 		);
@@ -264,21 +572,233 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 					'class' => \AnnotationsMethods\BazBaz::class,
 					'returnType' => 'OtherNamespace\Test',
 					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [],
 				],
 				'getTestStatically' => [
 					'class' => \AnnotationsMethods\BazBaz::class,
 					'returnType' => 'OtherNamespace\Test',
 					'isStatic' => true,
+					'isVariadic' => false,
+					'parameters' => [],
 				],
 				'getTestWithDescription' => [
 					'class' => \AnnotationsMethods\BazBaz::class,
 					'returnType' => 'OtherNamespace\Test',
 					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [],
 				],
 				'getTestStaticallyWithDescription' => [
 					'class' => \AnnotationsMethods\BazBaz::class,
 					'returnType' => 'OtherNamespace\Test',
 					'isStatic' => true,
+					'isVariadic' => false,
+					'parameters' => [],
+				],
+				'doSomethingWithSpecificScalarParamsWithoutDefault' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'int',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'b',
+							'type' => 'int|null',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'c',
+							'type' => 'int',
+							'isPassedByReference' => true,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'd',
+							'type' => 'int|null',
+							'isPassedByReference' => true,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
+				],
+				'doSomethingWithSpecificScalarParamsWithDefault' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'int',
+							'isPassedByReference' => false,
+							'isOptional' => true,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'b',
+							'type' => 'int|null',
+							'isPassedByReference' => false,
+							'isOptional' => true,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'c',
+							'type' => 'int',
+							'isPassedByReference' => true,
+							'isOptional' => true,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'd',
+							'type' => 'int|null',
+							'isPassedByReference' => true,
+							'isOptional' => true,
+							'isVariadic' => false,
+						],
+					],
+				],
+				'doSomethingWithSpecificObjectParamsWithoutDefault' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'OtherNamespace\Ipsum',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'b',
+							'type' => 'OtherNamespace\Ipsum|null',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'c',
+							'type' => 'OtherNamespace\Ipsum',
+							'isPassedByReference' => true,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'd',
+							'type' => 'OtherNamespace\Ipsum|null',
+							'isPassedByReference' => true,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
+				],
+				'doSomethingWithSpecificObjectParamsWithDefault' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'OtherNamespace\Ipsum',
+							'isPassedByReference' => false,
+							'isOptional' => true,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'b',
+							'type' => 'OtherNamespace\Ipsum|null',
+							'isPassedByReference' => false,
+							'isOptional' => true,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'c',
+							'type' => 'OtherNamespace\Ipsum',
+							'isPassedByReference' => true,
+							'isOptional' => true,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'd',
+							'type' => 'OtherNamespace\Ipsum|null',
+							'isPassedByReference' => true,
+							'isOptional' => true,
+							'isVariadic' => false,
+						],
+					],
+				],
+				'doSomethingWithSpecificVariadicScalarParamsNotNullable' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+					'isVariadic' => true,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'int',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => true,
+						],
+					],
+				],
+				'doSomethingWithSpecificVariadicScalarParamsNullable' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+					'isVariadic' => true,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'int|null',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => true,
+						],
+					],
+				],
+				'doSomethingWithSpecificVariadicObjectParamsNotNullable' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+					'isVariadic' => true,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'OtherNamespace\Ipsum',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => true,
+						],
+					],
+				],
+				'doSomethingWithSpecificVariadicObjectParamsNullable' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+					'isVariadic' => true,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'OtherNamespace\Ipsum|null',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => true,
+						],
+					],
 				],
 			]
 		);
@@ -320,7 +840,38 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 				$method->isStatic(),
 				sprintf('Scope of method %s::%s does not match', $className, $methodName)
 			);
-
+			$this->assertEquals(
+				$expectedMethodData['isVariadic'],
+				$method->isVariadic(),
+				sprintf('Method %s::%s does not match expected variadicity', $className, $methodName)
+			);
+			$this->assertCount(
+				count($expectedMethodData['parameters']),
+				$method->getParameters(),
+				sprintf('Method %s::%s does not match expected count of parameters', $className, $methodName)
+			);
+			foreach ($method->getParameters() as $i => $parameter) {
+				$this->assertEquals(
+					$expectedMethodData['parameters'][$i]['name'],
+					$parameter->getName()
+				);
+				$this->assertEquals(
+					$expectedMethodData['parameters'][$i]['type'],
+					$parameter->getType()->describe()
+				);
+				$this->assertEquals(
+					$expectedMethodData['parameters'][$i]['isPassedByReference'],
+					$parameter->isPassedByReference()
+				);
+				$this->assertEquals(
+					$expectedMethodData['parameters'][$i]['isOptional'],
+					$parameter->isOptional()
+				);
+				$this->assertEquals(
+					$expectedMethodData['parameters'][$i]['isVariadic'],
+					$parameter->isVariadic()
+				);
+			}
 		}
 	}
 

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -182,7 +182,10 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 		$broker = $this->getContainer()->getByType(Broker::class);
 		$class = $broker->getClass($className);
 		foreach ($properties as $propertyName => $expectedPropertyData) {
-			$this->assertTrue($class->hasProperty($propertyName));
+			$this->assertTrue(
+				$class->hasProperty($propertyName),
+				sprintf('Class %s does not define property %s.', $className, $propertyName)
+			);
 
 			$property = $class->getProperty($propertyName);
 			$this->assertSame(

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -108,14 +108,14 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 						'readable' => true,
 					],
 					'traitProperty' => [
-						'class' => \AnnotationsProperties\Baz::class,
+						'class' => \AnnotationsProperties\FooTrait::class,
 						'type' => 'AnnotationsProperties\BazBaz',
 						'writable' => true,
 						'readable' => true,
 					],
 					'writeOnlyProperty' => [
 						'class' => \AnnotationsProperties\Baz::class,
-						'type' => 'AnnotationsProperties\Lorem',
+						'type' => 'AnnotationsProperties\Lorem|null',
 						'writable' => true,
 						'readable' => false,
 					],
@@ -155,14 +155,14 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 						'readable' => true,
 					],
 					'traitProperty' => [
-						'class' => \AnnotationsProperties\Baz::class,
+						'class' => \AnnotationsProperties\FooTrait::class,
 						'type' => 'AnnotationsProperties\BazBaz',
 						'writable' => true,
 						'readable' => true,
 					],
 					'writeOnlyProperty' => [
 						'class' => \AnnotationsProperties\Baz::class,
-						'type' => 'AnnotationsProperties\Lorem',
+						'type' => 'AnnotationsProperties\Lorem|null',
 						'writable' => true,
 						'readable' => false,
 					],

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -16,22 +16,32 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 					'otherTest' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Test',
+						'writable' => true,
+						'readable' => true,
 					],
 					'otherTestReadOnly' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Ipsum',
+						'writable' => false,
+						'readable' => true,
 					],
 					'fooOrBar' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'AnnotationsProperties\Bar|AnnotationsProperties\Foo',
+						'writable' => true,
+						'readable' => true,
 					],
 					'conflictingProperty' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Ipsum',
+						'writable' => true,
+						'readable' => true,
 					],
 					'interfaceProperty' => [
 						'class' => \AnnotationsProperties\FooInterface::class,
 						'type' => \AnnotationsProperties\FooInterface::class,
+						'writable' => true,
+						'readable' => true,
 					],
 				],
 			],
@@ -41,18 +51,26 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 					'otherTest' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Test',
+						'writable' => true,
+						'readable' => true,
 					],
 					'otherTestReadOnly' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Ipsum',
+						'writable' => false,
+						'readable' => true,
 					],
 					'fooOrBar' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'AnnotationsProperties\Bar|AnnotationsProperties\Foo',
+						'writable' => true,
+						'readable' => true,
 					],
 					'conflictingProperty' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Ipsum',
+						'writable' => true,
+						'readable' => true,
 					],
 				],
 			],
@@ -62,26 +80,44 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 					'otherTest' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Test',
+						'writable' => true,
+						'readable' => true,
 					],
 					'otherTestReadOnly' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Ipsum',
+						'writable' => false,
+						'readable' => true,
 					],
 					'fooOrBar' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'AnnotationsProperties\Bar|AnnotationsProperties\Foo',
+						'writable' => true,
+						'readable' => true,
 					],
 					'conflictingProperty' => [
 						'class' => \AnnotationsProperties\Baz::class,
 						'type' => 'AnnotationsProperties\Dolor',
+						'writable' => true,
+						'readable' => true,
 					],
 					'bazProperty' => [
 						'class' => \AnnotationsProperties\Baz::class,
 						'type' => 'AnnotationsProperties\Lorem',
+						'writable' => true,
+						'readable' => true,
 					],
 					'traitProperty' => [
 						'class' => \AnnotationsProperties\Baz::class,
 						'type' => 'AnnotationsProperties\BazBaz',
+						'writable' => true,
+						'readable' => true,
+					],
+					'writeOnlyProperty' => [
+						'class' => \AnnotationsProperties\Baz::class,
+						'type' => 'AnnotationsProperties\Lorem',
+						'writable' => true,
+						'readable' => false,
 					],
 				],
 			],
@@ -91,26 +127,44 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 					'otherTest' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Test',
+						'writable' => true,
+						'readable' => true,
 					],
 					'otherTestReadOnly' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'OtherNamespace\Ipsum',
+						'writable' => false,
+						'readable' => true,
 					],
 					'fooOrBar' => [
 						'class' => \AnnotationsProperties\Foo::class,
 						'type' => 'AnnotationsProperties\Bar|AnnotationsProperties\Foo',
+						'writable' => true,
+						'readable' => true,
 					],
 					'conflictingProperty' => [
 						'class' => \AnnotationsProperties\Baz::class,
 						'type' => 'AnnotationsProperties\Dolor',
+						'writable' => true,
+						'readable' => true,
 					],
 					'bazProperty' => [
 						'class' => \AnnotationsProperties\Baz::class,
 						'type' => 'AnnotationsProperties\Lorem',
+						'writable' => true,
+						'readable' => true,
 					],
 					'traitProperty' => [
 						'class' => \AnnotationsProperties\Baz::class,
 						'type' => 'AnnotationsProperties\BazBaz',
+						'writable' => true,
+						'readable' => true,
+					],
+					'writeOnlyProperty' => [
+						'class' => \AnnotationsProperties\Baz::class,
+						'type' => 'AnnotationsProperties\Lorem',
+						'writable' => true,
+						'readable' => false,
 					],
 				],
 			],
@@ -124,6 +178,7 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 	 */
 	public function testProperties(string $className, array $properties)
 	{
+		/** @var Broker $broker */
 		$broker = $this->getContainer()->getByType(Broker::class);
 		$class = $broker->getClass($className);
 		foreach ($properties as $propertyName => $expectedPropertyData) {
@@ -139,6 +194,16 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 				$expectedPropertyData['type'],
 				$property->getType()->describe(),
 				sprintf('Type of property %s::$%s does not match.', $property->getDeclaringClass()->getName(), $propertyName)
+			);
+			$this->assertSame(
+				$expectedPropertyData['readable'],
+				$property->isReadable(),
+				sprintf('Property %s::$%s readability is not as expected.', $property->getDeclaringClass()->getName(), $propertyName)
+			);
+			$this->assertSame(
+				$expectedPropertyData['writable'],
+				$property->isWritable(),
+				sprintf('Property %s::$%s writability is not as expected.', $property->getDeclaringClass()->getName(), $propertyName)
 			);
 		}
 	}

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
@@ -92,6 +92,15 @@ class Baz extends Bar
  * @method static OtherTest getTestStaticallyNoParams
  * @method OtherTest getTestWithDescriptionNoParams Get a test
  * @method static OtherTest getTestStaticallyWithDescriptionNoParams Get a test statically
+ *
+ * @method void doSomethingWithSpecificScalarParamsWithoutDefault(int $a, ?int $b, int &$c, ?int &$d)
+ * @method void doSomethingWithSpecificScalarParamsWithDefault(int $a = null, ?int $b = null, int &$c = null, ?int &$d = null)
+ * @method void doSomethingWithSpecificObjectParamsWithoutDefault(Ipsum $a, ?Ipsum $b, Ipsum &$c, ?Ipsum &$d)
+ * @method void doSomethingWithSpecificObjectParamsWithDefault(Ipsum $a = null, ?Ipsum $b = null, Ipsum &$c = null, ?Ipsum &$d = null)
+ * @method void doSomethingWithSpecificVariadicScalarParamsNotNullable(int ...$a)
+ * @method void doSomethingWithSpecificVariadicScalarParamsNullable(?int ...$a)
+ * @method void doSomethingWithSpecificVariadicObjectParamsNotNullable(Ipsum ...$a)
+ * @method void doSomethingWithSpecificVariadicObjectParamsNullable(?Ipsum ...$a)
  */
 class BazBaz extends Baz
 {

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-properties.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-properties.php
@@ -24,7 +24,7 @@ class Bar extends Foo
 /**
  * @property   Lorem  $bazProperty
  * @property Dolor $conflictingProperty
- * @property-write Lorem $writeOnlyProperty
+ * @property-write ?Lorem $writeOnlyProperty
  */
 class Baz extends Bar
 {

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-properties.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-properties.php
@@ -24,6 +24,7 @@ class Bar extends Foo
 /**
  * @property   Lorem  $bazProperty
  * @property Dolor $conflictingProperty
+ * @property-write Lorem $writeOnlyProperty
  */
 class Baz extends Bar
 {


### PR DESCRIPTION
1. I am not sure why to write-only properties are omitted but let me know if there is a reason to keep it that way.
2. Parsing nullable types using a question mark (`?`) for all annotations is not implemented in general type regexp. I am thinking if it makes sense or not. It makes sense for method annotation parameters IMHO. However, I am not sure about general annotations because using `type|null` is used generally. On the other hand, without implementing it there is a problem with type map that does not have the type used in method annotation as method parameter type only (without any other reference) and then the type is assumed as mixed.

I will update this PR by comments.