### PR TITLE
error tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ parameters:
 		- %rootDir%/../../../tests/*/data/*
 ```
 
+### Tolerate errors
+
+If your codebase is not yet fully ready for phpstan but you would like to have it already you can allow "error tolerance".
+This way phpstan will exit with code 0 if number errors does not exceed tolerance number. Example:
+
+```bash
+phpstan analyse --error-tolerance=5 src
+```
+
+This is useful to include in CI on early stages of phpstan adoption and incrementally fix errors and reduce error tolerance.
+
 ### Include custom extensions
 
 If your codebase contains php files with extensions other than the standard .php extension then you can add them
@@ -282,7 +293,7 @@ parameters:
 			- sendResponse
 ```
 
-### Ignore error messages with regular expresions
+### Ignore error messages with regular expressions
 
 If some issue in your code base is not easy to fix or just simply want to deal with it later,
 you can exclude error messages from the analysis result with regular expressions:
@@ -339,11 +350,13 @@ interface ErrorFormatter
 	 *
 	 * @param \PHPStan\Command\AnalysisResult $analysisResult
 	 * @param \Symfony\Component\Console\Style\OutputStyle $style
+	 * @param int $errorsThreshold of errors which can be considered as ok
 	 * @return int Error code.
 	 */
 	public function formatErrors(
 		AnalysisResult $analysisResult,
-		\Symfony\Component\Console\Style\OutputStyle $style
+		\Symfony\Component\Console\Style\OutputStyle $style,
+		int $errorsThreshold = 0
 	): int;
 
 }
@@ -397,7 +410,7 @@ interface PropertyReflection
 {
 
 	public function getType(): Type;
-	
+
 	public function getDeclaringClass(): ClassReflection;
 
 	public function isStatic(): bool;
@@ -453,7 +466,7 @@ interface MethodReflection
 	public function isPrivate(): bool;
 
 	public function isPublic(): bool;
-	
+
 	public function getName(): string;
 
 	/**
@@ -568,14 +581,14 @@ This project adheres to a [Contributor Code of Conduct](https://github.com/phpst
 
 ## Contributing
 
-Any contributions are welcome. 
+Any contributions are welcome.
 
 ### Building
 
 You can either run the whole build including linting and coding standards using
 
 `vendor/bin/phing`
- 
+
 or run only tests using
 
 `vendor/bin/phing tests`

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -48,13 +48,15 @@ class AnalyseApplication
 	 * @param \Symfony\Component\Console\Style\OutputStyle $style
 	 * @param \PHPStan\Command\ErrorFormatter\ErrorFormatter $errorFormatter
 	 * @param bool $defaultLevelUsed
+	 * @param int $errorsThreshold
 	 * @return int Error code.
 	 */
 	public function analyse(
 		array $paths,
 		OutputStyle $style,
 		ErrorFormatter $errorFormatter,
-		bool $defaultLevelUsed
+		bool $defaultLevelUsed,
+		int $errorsThreshold = 0
 	): int
 	{
 		$errors = [];
@@ -126,7 +128,8 @@ class AnalyseApplication
 				$defaultLevelUsed,
 				$this->fileHelper->normalizePath(dirname($paths[0]))
 			),
-			$style
+			$style,
+			$errorsThreshold
 		);
 	}
 

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -37,6 +37,7 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 				new InputOption(ErrorsConsoleStyle::OPTION_NO_PROGRESS, null, InputOption::VALUE_NONE, 'Do not show progress bar, only results'),
 				new InputOption('autoload-file', 'a', InputOption::VALUE_OPTIONAL, 'Project\'s additional autoload file path'),
 				new InputOption('errorFormat', null, InputOption::VALUE_REQUIRED, 'Format in which to print the result of the analysis', 'table'),
+				new InputOption('error-tolerance', null, InputOption::VALUE_REQUIRED, 'How many errors consider to be critical and return exit code 1', 0),
 			]);
 	}
 

--- a/src/Command/ErrorFormatter/ErrorFormatter.php
+++ b/src/Command/ErrorFormatter/ErrorFormatter.php
@@ -12,11 +12,13 @@ interface ErrorFormatter
 	 *
 	 * @param \PHPStan\Command\AnalysisResult $analysisResult
 	 * @param \Symfony\Component\Console\Style\OutputStyle $style
+	 * @param int $errorsThreshold of errors which can be considered as ok
 	 * @return int Error code.
 	 */
 	public function formatErrors(
 		AnalysisResult $analysisResult,
-		\Symfony\Component\Console\Style\OutputStyle $style
+		\Symfony\Component\Console\Style\OutputStyle $style,
+		int $errorsThreshold = 0
 	): int;
 
 }

--- a/src/Command/ErrorFormatter/RawErrorFormatter.php
+++ b/src/Command/ErrorFormatter/RawErrorFormatter.php
@@ -9,7 +9,8 @@ class RawErrorFormatter implements ErrorFormatter
 
 	public function formatErrors(
 		AnalysisResult $analysisResult,
-		\Symfony\Component\Console\Style\OutputStyle $style
+		\Symfony\Component\Console\Style\OutputStyle $style,
+		int $errorsThreshold = 0
 	): int
 	{
 		if (!$analysisResult->hasErrors()) {
@@ -25,13 +26,13 @@ class RawErrorFormatter implements ErrorFormatter
 				sprintf(
 					'%s:%d:%s',
 					$fileSpecificError->getFile(),
-					$fileSpecificError->getLine() !== null ? $fileSpecificError->getLine() : '?',
+					$fileSpecificError->getLine() ?? '?',
 					$fileSpecificError->getMessage()
 				)
 			);
 		}
 
-		return 1;
+		return $analysisResult->getTotalErrorsCount() > $errorsThreshold ? 1 : 0;
 	}
 
 }

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -10,7 +10,8 @@ class TableErrorFormatter implements ErrorFormatter
 
 	public function formatErrors(
 		AnalysisResult $analysisResult,
-		\Symfony\Component\Console\Style\OutputStyle $style
+		\Symfony\Component\Console\Style\OutputStyle $style,
+		int $errorsThreshold = 0
 	): int
 	{
 		if (!$analysisResult->hasErrors()) {
@@ -63,7 +64,8 @@ class TableErrorFormatter implements ErrorFormatter
 		}
 
 		$style->error(sprintf($analysisResult->getTotalErrorsCount() === 1 ? 'Found %d error' : 'Found %d errors', $analysisResult->getTotalErrorsCount()));
-		return 1;
+
+		return $analysisResult->getTotalErrorsCount() > $errorsThreshold ? 1 : 0;
 	}
 
 }


### PR DESCRIPTION
If your codebase is not yet fully ready for phpstan but you would like to have it already you can allow "error tolerance".
This way phpstan will exit with code 0 if number errors does not exceed tolerance number.  You can find it useful to include in CI on early stages of phpstan adoption.

Incrementally fix errors and reduce error tolerance.

P.S. Naming is hard, i'm open for other names
P.P.S. Stupid question - do I need test coverage? Haven't seen that error formatters are covered 