### PR TITLE
Added a requirement for DOM extension in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 	},
 	"require": {
 		"php": "~7.0",
+		"ext-dom": "*",
 		"nette/bootstrap": "^2.4 || ^3.0",
 		"nette/caching": "^2.4 || ^3.0",
 		"nette/di": "^2.4 || ^3.0",


### PR DESCRIPTION
Added a requirement for DOM extension in the composer.json since PHPStan does require it now.
[PhpDefectClassReflectionExtension.php#L25](https://github.com/phpstan/phpstan/blob/c51f3cb0481fd18a4e2c4cb2f3d8fedb8cab087c/src/Reflection/PhpDefect/PhpDefectClassReflectionExtension.php#L25)