### PR TITLE
RequireParentConstructCallRule fix: supressed constructor calls are now detected correctly

### DIFF
--- a/src/Rules/Classes/RequireParentConstructCallRule.php
+++ b/src/Rules/Classes/RequireParentConstructCallRule.php
@@ -76,6 +76,7 @@ class RequireParentConstructCallRule implements \PHPStan\Rules\Rule
 		}
 
 		foreach ($parserNode->stmts as $statement) {
+			$statement = $this->ignoreErrorSuppression($statement);
 			if ($statement instanceof \PhpParser\Node\Expr\StaticCall) {
 				if (
 					$statement->class instanceof Name
@@ -121,6 +122,16 @@ class RequireParentConstructCallRule implements \PHPStan\Rules\Rule
 		}
 
 		return false;
+	}
+
+	private function ignoreErrorSuppression(Node $statement): Node
+	{
+		if ($statement instanceof Node\Expr\ErrorSuppress) {
+
+			return $statement->expr;
+		}
+
+		return $statement;
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/data/call-to-parent-constructor.php
+++ b/tests/PHPStan/Rules/Classes/data/call-to-parent-constructor.php
@@ -161,3 +161,13 @@ class ClassThatExtendsAbstractClassWithAbstractConstructor extends AbstractClass
 	}
 
 }
+
+class BarCallToMutedParentConstructor extends FooCallToParentConstructor
+{
+
+	public function __construct()
+	{
+		@parent::__construct();
+	}
+
+}


### PR DESCRIPTION
I found a bug that prevented RequireParentConstructCallRule to detect suppressed calls (@parent::__construct()). I fixed the bug & updated the unit test.