### PR TITLE
"Caught" not "Catched"

### DIFF
--- a/src/Rules/Exceptions/CatchedExceptionExistenceRule.php
+++ b/src/Rules/Exceptions/CatchedExceptionExistenceRule.php
@@ -49,7 +49,7 @@ class CatchedExceptionExistenceRule implements \PHPStan\Rules\Rule
 
 			$classReflection = $this->broker->getClass($class);
 			if (!$classReflection->isInterface() && !$classReflection->getNativeReflection()->implementsInterface(\Throwable::class)) {
-				$errors[] = sprintf('Catched class %s is not an exception.', $classReflection->getDisplayName());
+				$errors[] = sprintf('Caught class %s is not an exception.', $classReflection->getDisplayName());
 			}
 		}
 


### PR DESCRIPTION
Catched is not an english word unless you count slang and urban dictionary
change to "caught" for output