### PR TITLE
TypeSpecifier: fixed some cases & refactoring

### DIFF
--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -1465,13 +1465,13 @@ class Scope
 
 	public function filterByTruthyValue(Expr $expr): self
 	{
-		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition(new SpecifiedTypes(), $this, $expr, false);
+		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($this, $expr, false);
 		return $this->filterBySpecifiedTypes($specifiedTypes);
 	}
 
 	public function filterByFalseyValue(Expr $expr): self
 	{
-		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition(new SpecifiedTypes(), $this, $expr, true);
+		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($this, $expr, true);
 		return $this->filterBySpecifiedTypes($specifiedTypes);
 	}
 

--- a/src/Analyser/SpecifiedTypes.php
+++ b/src/Analyser/SpecifiedTypes.php
@@ -100,15 +100,6 @@ class SpecifiedTypes
 			}
 		}
 
-		foreach ($this->sureNotTypes as $sureNotTypeString => list($exprNode, $type)) {
-			if (isset($b->sureNotTypes[$sureNotTypeString])) {
-				$sureNotTypeUnion[$sureNotTypeString] = [
-					$exprNode,
-					$type->combineWith($b->sureNotTypes[$sureNotTypeString][1]),
-				];
-			}
-		}
-
 		return new self($sureTypeUnion, $sureNotTypeUnion);
 	}
 

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -127,21 +127,22 @@ class TypeSpecifier
 				return $this->apply($types, $argumentExpression, $negated, $source, $specifiedType);
 			}
 		} elseif ($expr instanceof BooleanAnd) {
-			if ($source !== self::SOURCE_FROM_OR) {
+			if ($negated) {
+				$leftTypes = $this->specifyTypesInCondition($types, $scope, $expr->left, $negated, $source);
+				$rightTypes = $this->specifyTypesInCondition($types, $scope, $expr->right, $negated, $source);
+				$types = $leftTypes->unionWith($rightTypes);
+			} else {
 				$types = $this->specifyTypesInCondition($types, $scope, $expr->left, $negated, self::SOURCE_FROM_AND);
 				$types = $this->specifyTypesInCondition($types, $scope, $expr->right, $negated, self::SOURCE_FROM_AND);
 			}
-
 		} elseif ($expr instanceof BooleanOr) {
-			if ($source !== self::SOURCE_FROM_AND) {
-				if ($negated) {
-					$types = $this->specifyTypesInCondition($types, $scope, $expr->left, $negated, self::SOURCE_FROM_OR);
-					$types = $this->specifyTypesInCondition($types, $scope, $expr->right, $negated, self::SOURCE_FROM_OR);
-				} else {
-					$leftTypes = $this->specifyTypesInCondition($types, $scope, $expr->left, $negated, $source);
-					$rightTypes = $this->specifyTypesInCondition($types, $scope, $expr->right, $negated, $source);
-					$types = $leftTypes->unionWith($rightTypes);
-				}
+			if ($negated) {
+				$types = $this->specifyTypesInCondition($types, $scope, $expr->left, $negated, self::SOURCE_FROM_OR);
+				$types = $this->specifyTypesInCondition($types, $scope, $expr->right, $negated, self::SOURCE_FROM_OR);
+			} else {
+				$leftTypes = $this->specifyTypesInCondition($types, $scope, $expr->left, $negated, $source);
+				$rightTypes = $this->specifyTypesInCondition($types, $scope, $expr->right, $negated, $source);
+				$types = $leftTypes->unionWith($rightTypes);
 			}
 
 		} elseif ($expr instanceof Node\Expr\BooleanNot) {

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -38,11 +38,11 @@ class TypeSpecifierTest extends \PHPStan\TestCase
 	 */
 	public function testCondition(Expr $expr, array $expectedPositiveResult, array $expectedNegatedResult)
 	{
-		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition(new SpecifiedTypes(), $this->scope, $expr);
+		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($this->scope, $expr);
 		$actualResult = $this->toReadableResult($specifiedTypes);
 		$this->assertSame($expectedPositiveResult, $actualResult);
 
-		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition(new SpecifiedTypes(), $this->scope, $expr, true);
+		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($this->scope, $expr, true);
 		$actualResult = $this->toReadableResult($specifiedTypes);
 		$this->assertSame($expectedNegatedResult, $actualResult);
 	}

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -165,6 +165,61 @@ class TypeSpecifierTest extends \PHPStan\TestCase
 				[],
 				['$foo' => '~int', '$bar' => '~string'],
 			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					new Expr\BinaryOp\BooleanOr(
+						$this->createFunctionCall('is_int', 'foo'),
+						$this->createFunctionCall('is_string', 'foo')
+					),
+					$this->createFunctionCall('random')
+				),
+				['$foo' => 'int|string'],
+				[],
+			],
+			[
+				new Expr\BinaryOp\BooleanOr(
+					new Expr\BinaryOp\BooleanAnd(
+						$this->createFunctionCall('is_int', 'foo'),
+						$this->createFunctionCall('is_string', 'foo')
+					),
+					$this->createFunctionCall('random')
+				),
+				[],
+				[],
+			],
+			[
+				new Expr\BinaryOp\BooleanOr(
+					new Expr\BinaryOp\BooleanAnd(
+						$this->createFunctionCall('is_int', 'foo'),
+						$this->createFunctionCall('is_string', 'bar')
+					),
+					$this->createFunctionCall('random')
+				),
+				[],
+				[],
+			],
+			[
+				new Expr\BinaryOp\BooleanOr(
+					new Expr\BinaryOp\BooleanAnd(
+						new Expr\BooleanNot($this->createFunctionCall('is_int', 'foo')),
+						new Expr\BooleanNot($this->createFunctionCall('is_string', 'foo'))
+					),
+					$this->createFunctionCall('random')
+				),
+				[],
+				['$foo' => 'int|string'],
+			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					new Expr\BinaryOp\BooleanOr(
+						new Expr\BooleanNot($this->createFunctionCall('is_int', 'foo')),
+						new Expr\BooleanNot($this->createFunctionCall('is_string', 'foo'))
+					),
+					$this->createFunctionCall('random')
+				),
+				[],
+				[],
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Analyser;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PHPStan\Type\ObjectType;
@@ -136,6 +137,33 @@ class TypeSpecifierTest extends \PHPStan\TestCase
 				new Expr\BooleanNot(new Variable('bar')),
 				['$bar' => '~Bar'],
 				['$bar' => '~false|null'],
+			],
+
+			[
+				new PropertyFetch(new Variable('this'), 'foo'),
+				['$this->foo' => '~false|null'],
+				[],
+			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					new PropertyFetch(new Variable('this'), 'foo'),
+					$this->createFunctionCall('random')
+				),
+				['$this->foo' => '~false|null'],
+				[],
+			],
+			[
+				new Expr\BinaryOp\BooleanOr(
+					new PropertyFetch(new Variable('this'), 'foo'),
+					$this->createFunctionCall('random')
+				),
+				[],
+				[],
+			],
+			[
+				new Expr\BooleanNot(new PropertyFetch(new Variable('this'), 'foo')),
+				[],
+				['$this->foo' => '~false|null'],
 			],
 
 			[


### PR DESCRIPTION
I finally figured out, how to write `TypeSpecifier` without passing `$types` and `$source` all the time. This makes the whole code a lot simpler.
It also included commented out code for intersection types, once they are ready.