### PR TITLE
Calling methods on null issue - failing test

### DIFF
--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -470,4 +470,11 @@ class CallMethodsRuleTest extends \PHPStan\Rules\AbstractRuleTest
 		]);
 	}
 
+	public function testCallMethodsNullIssue()
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = false;
+		$this->analyse([__DIR__ . '/data/order.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/order.php
+++ b/tests/PHPStan/Rules/Methods/data/order.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace CallMethodsNullIssue;
+
+class Foo
+{
+
+	/**
+	 * @return int|null
+	 */
+	public function lorem()
+	{
+
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function ipsum()
+	{
+
+	}
+
+}
+
+class Bar
+{
+
+	/**
+	 * @return int|null
+	 */
+	public function lorem()
+	{
+
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function ipsum()
+	{
+
+	}
+
+}
+
+class Baz
+{
+
+	/**
+	 * @return Foo|null
+	 */
+	public function getFoo(): Foo
+	{
+
+	}
+
+	/**
+	 * @return Bar|null
+	 */
+	public function getBar(): Bar
+	{
+
+	}
+
+	public function process(): string
+	{
+		if ($this->getFoo() === null && $this->getBar() === null) {
+			return '';
+		}
+		if ($this->getFoo() !== null && $this->getBar() === null) {
+			return '';
+		} elseif ($this->getBar() !== null && $this->getFoo() === null) {
+			return '';
+		}
+
+		$foo = $this->getFoo();
+		$bar = $this->getBar();
+		if ($bar->lorem() !== null && $foo->lorem() === null) {
+			return '';
+		} elseif ($bar->lorem() === null && $foo->lorem() !== null) {
+			return '';
+		} elseif ($bar->lorem() !== null && $foo->lorem() !== null) {
+			return $bar->lorem() > $foo->lorem() ? '' : '';
+		}
+		if ($foo->ipsum() < $bar->ipsum()) {
+			return '';
+		}
+
+		return '';
+	}
+
+}


### PR DESCRIPTION
```
1) PHPStan\Rules\Methods\CallMethodsRuleTest::testCallMethodsNullIssue
Failed asserting that two strings are identical.
--- Expected
+++ Actual


test
@@ @@
-''
+'79: Cannot call method lorem() on null.
+81: Cannot call method lorem() on null.
+83: Cannot call method lorem() on null.
+84: Cannot call method lorem() on null.
+86: Cannot call method ipsum() on null.'

/Users/ondrej/Development/phpstan/tests/PHPStan/Rules/AbstractRuleTest.php:81
/Users/ondrej/Development/phpstan/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php:476
```