### PR TITLE
add some more randomness to tmpDir name generation

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -106,7 +106,7 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 		}
 
 		if (!isset($tmpDir)) {
-			$tmpDir = sys_get_temp_dir() . '/phpstan';
+			$tmpDir = sys_get_temp_dir() . '/' . mt_rand() . '/phpstan-' . time();
 			if (!@mkdir($tmpDir, 0777, true) && !is_dir($tmpDir)) {
 				$consoleStyle->error(sprintf('Cannot create a temp directory %s', $tmpDir));
 				return 1;


### PR DESCRIPTION
so to allow multiple instances of phpstan to be run at the same time without clashes on such folder (and its contents, such as the `.memory_limit` file).

eg: 
```
parallel bin/phpstan analyze --level=1 {} ::: src/Foo src/Bar src/Baz
```

or

```
bin/phpstan analyze --level=1 src/Foo &
bin/phpstan analyze --level=1 src/Bar &
bin/phpstan analyze --level=1 src/Baz &

wait
```