### PR TITLE
Fixed parsing of multiple types for method parameters from annotation

### DIFF
--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\TypeCombinator;
 
 class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflectionExtension
@@ -111,20 +112,24 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 			if (preg_match('#(?P<IsNullable>\?)?(?:(?P<Type>' . FileTypeMapper::TYPE_PATTERN . ')\s+)?(?P<IsVariadic>...)?(?P<IsPassedByReference>\&)?\$(?P<Name>[a-zA-Z0-9_]+)(?:\s*=\s*(?P<DefaultValue>.+))?#', $parameter, $parameterMatches)) {
 				$name = $parameterMatches['Name'];
 				$typeString = $parameterMatches['Type'];
+				$defaultValue = $parameterMatches['DefaultValue'] ?? null;
 				if ($typeString) {
-					if (!isset($typeMap[$typeString])) {
-						continue;
+					$type = null;
+					foreach (explode('|', $typeString) as $typePart) {
+						if (!isset($typeMap[$typePart])) {
+							continue;
+						}
+						$type = $type ? TypeCombinator::combine($type, $typeMap[$typePart]) : $typeMap[$typePart];
 					}
-					$type = $typeMap[$typeString];
-					if ($parameterMatches['IsNullable'] === '?') {
-						$type = TypeCombinator::addNull($type);
+					if ($parameterMatches['IsNullable'] === '?' || $defaultValue === 'null') {
+						$type = $type ? TypeCombinator::addNull($type) : new NullType();
 					}
 				} else {
 					$type = new MixedType();
 				}
 				$isVariadic = !empty($parameterMatches['IsVariadic']);
 				$isPassedByReference = !empty($parameterMatches['IsPassedByReference']);
-				$isOptional = !empty($parameterMatches['DefaultValue']);
+				$isOptional = !empty($defaultValue);
 				$parameters[] = new AnnotationsMethodParameterReflection($name, $type, $isPassedByReference, $isOptional, $isVariadic);
 			}
 		}

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -677,7 +677,7 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 					'parameters' => [
 						[
 							'name' => 'a',
-							'type' => 'int',
+							'type' => 'int|null',
 							'isPassedByReference' => false,
 							'isOptional' => true,
 							'isVariadic' => false,
@@ -691,7 +691,7 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 						],
 						[
 							'name' => 'c',
-							'type' => 'int',
+							'type' => 'int|null',
 							'isPassedByReference' => true,
 							'isOptional' => true,
 							'isVariadic' => false,
@@ -749,7 +749,7 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 					'parameters' => [
 						[
 							'name' => 'a',
-							'type' => 'OtherNamespace\Ipsum',
+							'type' => 'OtherNamespace\Ipsum|null',
 							'isPassedByReference' => false,
 							'isOptional' => true,
 							'isVariadic' => false,
@@ -763,7 +763,7 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 						],
 						[
 							'name' => 'c',
-							'type' => 'OtherNamespace\Ipsum',
+							'type' => 'OtherNamespace\Ipsum|null',
 							'isPassedByReference' => true,
 							'isOptional' => true,
 							'isVariadic' => false,
@@ -834,6 +834,42 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 							'isPassedByReference' => false,
 							'isOptional' => false,
 							'isVariadic' => true,
+						],
+					],
+				],
+				'doSomethingWithComplicatedParameters' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'void',
+					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'a',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'b',
+							'type' => 'mixed',
+							'isPassedByReference' => false,
+							'isOptional' => true,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'c',
+							'type' => 'bool|float|int|OtherNamespace\\Test|string',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'd',
+							'type' => 'bool|float|int|OtherNamespace\\Test|string|null',
+							'isPassedByReference' => false,
+							'isOptional' => true,
+							'isVariadic' => false,
 						],
 					],
 				],

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
@@ -103,6 +103,7 @@ class Baz extends Bar
  * @method void doSomethingWithSpecificVariadicScalarParamsNullable(?int ...$a)
  * @method void doSomethingWithSpecificVariadicObjectParamsNotNullable(Ipsum ...$a)
  * @method void doSomethingWithSpecificVariadicObjectParamsNullable(?Ipsum ...$a)
+ * @method void doSomethingWithComplicatedParameters($a, $b = null, string|bool|int|float|OtherTest $c, string|bool|int|float|OtherTest $d = null)
  */
 class BazBaz extends Baz
 {


### PR DESCRIPTION
Fixes following

1. Detection of possible nullable type from default value because `?` does not have to be used everywhere in annotations yet. Detection of other types that could be default value is too complicated and probably unwanted since I do not think it is a good idea to specify another type just by default value other than `NULL`.
2. Detection of multiple types specified in the annotation that could cause omitting the parameter from all so "wrong parameter count" error could be thrown.