### PR TITLE
Fix "incorrect case" error when using trait aliases

### DIFF
--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -259,6 +259,13 @@ class CallMethodsRuleTest extends \PHPStan\Rules\AbstractRuleTest
 		]);
 	}
 
+	public function testCallTraitOverridenMethods()
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->analyse([__DIR__ . '/data/call-trait-overridden-methods.php'], []);
+	}
+
 	public function testCallInterfaceMethods()
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/data/call-trait-overridden-methods.php
+++ b/tests/PHPStan/Rules/Methods/data/call-trait-overridden-methods.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace CallTraitOverriddenMethods;
+
+trait TraitA {
+	function sameName() {}
+}
+
+trait TraitB {
+	use TraitA {
+		sameName as someOtherName;
+	}
+	function sameName() {
+		$this->someOtherName();
+	}
+}
+
+trait TraitC {
+	use TraitB {
+		sameName as YetAnotherName;
+	}
+	function sameName()
+	{
+		$this->YetAnotherName();
+	}
+}
+
+class SomeClass {
+	use TraitC {
+		sameName as wowSoManyNames;
+	}
+
+	function sameName()
+	{
+		$this->wowSoManyNames();
+	}
+}


### PR DESCRIPTION
This fixes a bug in the Reflection API, which returns the incorrect case for aliased methods when traits are nested.

I hope that I didn't miss anything and that it's a valid addition to the project - it's my first PR here, so please tell me what to change eventually. :-)

Fixes #379 