### PR TITLE
Fix: anonymous class with a final __construct in parent class

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -532,9 +532,7 @@ class NodeScopeResolver
 
 			$code = 'class ' . $uniqidClass . ' ' . substr($code, 10);
 			eval($code);
-
-			$classReflection = new \ReflectionClass('\\' . $uniqidClass);
-
+			$classReflection = new \PHPStan\Reflection\Php\DummyAnonymousClassReflection('\\' . $uniqidClass);
 			$this->anonymousClassReflection = $this->broker->getClassFromReflection(
 				$classReflection,
 				sprintf('class@anonymous%s:%s', $scope->getFile(), $node->getLine())

--- a/src/Reflection/Php/DummyAnonymousClassReflection.php
+++ b/src/Reflection/Php/DummyAnonymousClassReflection.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Php;
+
+class DummyAnonymousClassReflection extends \ReflectionClass
+{
+
+	public function isAnonymous(): bool
+	{
+		return true;
+	}
+
+}

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -68,12 +68,13 @@ class PhpClassReflectionExtension
 	private function createProperties(ClassReflection $classReflection): array
 	{
 		$properties = [];
+		$anonymousClass = $classReflection->getNativeReflection()->isAnonymous();
 		foreach ($classReflection->getNativeReflection()->getProperties() as $propertyReflection) {
 			$propertyName = $propertyReflection->getName();
 			$declaringClassReflection = $this->broker->getClass($propertyReflection->getDeclaringClass()->getName());
 			if ($propertyReflection->getDocComment() === false) {
 				$type = new MixedType();
-			} elseif (!$declaringClassReflection->getNativeReflection()->isAnonymous() && $declaringClassReflection->getNativeReflection()->getFileName() !== false) {
+			} elseif (!$anonymousClass && !$declaringClassReflection->getNativeReflection()->isAnonymous() && $declaringClassReflection->getNativeReflection()->getFileName() !== false) {
 				$phpDocBlock = PhpDocBlock::resolvePhpDocBlockForProperty(
 					$this->broker,
 					$propertyReflection->getDocComment(),
@@ -81,7 +82,9 @@ class PhpClassReflectionExtension
 					$propertyName,
 					$declaringClassReflection->getNativeReflection()->getFileName()
 				);
+
 				$typeMap = $this->fileTypeMapper->getTypeMap($phpDocBlock->getFile());
+
 				$typeString = $this->getPropertyAnnotationTypeString($phpDocBlock->getDocComment());
 				if (isset($typeMap[$typeString])) {
 					$type = $typeMap[$typeString];

--- a/tests/PHPStan/Analyser/data/anonymous-class-with-inherited-constructor.php
+++ b/tests/PHPStan/Analyser/data/anonymous-class-with-inherited-constructor.php
@@ -19,3 +19,19 @@ function () {
 
 	};
 };
+
+class Bar 
+{
+	final public function __construct(int $i, int $j)
+	{
+		echo $i;
+		echo $j;
+	}	
+}
+
+function () {
+	new class (1, 2) extends Bar
+	{
+		
+	};
+};


### PR DESCRIPTION
Anonymous classes that has a inheritance with a final __construct method will throw a PHP fatal error.

```php
class Foo 
{
    final public function __construct($a,$b)
    {
          echo $a;
          echo $b;
    }
}

$x = new class extends Foo {
    public function bar($z)
    {
           echo $z;
    }
};
```
Maybe we can emulate a new class instead of create a new object of the anonymous class and then create a ReflectionClass of this "new" class 

Fixes #142