### PR TITLE
RFC: Type check coverage command

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -2,6 +2,7 @@
 <?php declare(strict_types=1);
 
 use PHPStan\Command\AnalyseCommand;
+use PHPStan\Command\CoverageCommand;
 use PHPStan\FileHelper;
 
 gc_disable(); // performance boost
@@ -23,4 +24,5 @@ if (!class_exists('PHPStan\Command\AnalyseCommand', true)) {
 $application = new \Symfony\Component\Console\Application('PHPStan - PHP Static Analysis Tool', 'Version unknown');
 $application->setCatchExceptions(false);
 $application->add(new AnalyseCommand());
+$application->add(new CoverageCommand());
 $application->run();

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -52,6 +52,10 @@ services:
 			ignoreErrors: %ignoreErrors%
 			reportUnmatchedIgnoredErrors: %reportUnmatchedIgnoredErrors%
 			bootstrapFile: %bootstrap%
+	-
+		class: PHPStan\Analyser\CoverageReporter
+		arguments:
+			bootstrapFile: %bootstrap%
 
 	-
 		class: PHPStan\Analyser\NodeScopeResolver
@@ -68,6 +72,12 @@ services:
 
 	-
 		class: PHPStan\Command\AnalyseApplication
+		arguments:
+			memoryLimitFile: %memoryLimitFile%
+			fileExtensions: %fileExtensions%
+
+	-
+		class: PHPStan\Command\CoverageApplication
 		arguments:
 			memoryLimitFile: %memoryLimitFile%
 			fileExtensions: %fileExtensions%

--- a/src/Analyser/CoverageReporter.php
+++ b/src/Analyser/CoverageReporter.php
@@ -1,0 +1,457 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Broker\Broker;
+use PHPStan\File\FileExcluder;
+use PHPStan\File\FileHelper;
+use PHPStan\Parser\Parser;
+
+class CoverageReporter
+{
+
+	/**
+	 * @var \PHPStan\Parser\Parser
+	 */
+	private $parser;
+
+	/**
+	 * @var \PHPStan\Broker\Broker
+	 */
+	private $broker;
+
+	/**
+	 * @var \PHPStan\Analyser\NodeScopeResolver
+	 */
+	private $nodeScopeResolver;
+
+	/**
+	 * @var \PhpParser\PrettyPrinter\Standard
+	 */
+	private $printer;
+
+	/**
+	 * @var \PHPStan\Analyser\TypeSpecifier
+	 */
+	private $typeSpecifier;
+
+	/**
+	 * @var \PHPStan\File\FileExcluder
+	 */
+	private $fileExcluder;
+
+	/**
+	 * @var string|null
+	 */
+	private $bootstrapFile;
+
+	/**
+	 * @var bool
+	 */
+	private $reportUnmatchedIgnoredErrors;
+
+	/**
+	 * @param \PHPStan\Broker\Broker $broker
+	 * @param \PHPStan\Parser\Parser $parser
+	 * @param \PHPStan\Analyser\NodeScopeResolver $nodeScopeResolver
+	 * @param \PhpParser\PrettyPrinter\Standard $printer
+	 * @param \PHPStan\Analyser\TypeSpecifier $typeSpecifier
+	 * @param \PHPStan\File\FileExcluder $fileExcluder
+	 * @param \PHPStan\File\FileHelper $fileHelper
+	 * @param string|null $bootstrapFile
+	 */
+	public function __construct(
+		Broker $broker,
+		Parser $parser,
+		NodeScopeResolver $nodeScopeResolver,
+		\PhpParser\PrettyPrinter\Standard $printer,
+		TypeSpecifier $typeSpecifier,
+		FileExcluder $fileExcluder,
+		FileHelper $fileHelper,
+		string $bootstrapFile = null
+	)
+	{
+		$this->broker = $broker;
+		$this->parser = $parser;
+		$this->nodeScopeResolver = $nodeScopeResolver;
+		$this->printer = $printer;
+		$this->typeSpecifier = $typeSpecifier;
+		$this->fileExcluder = $fileExcluder;
+		$this->bootstrapFile = $bootstrapFile !== null ? $fileHelper->normalizePath($bootstrapFile) : null;
+	}
+
+	/**
+	 * @param string[] $files
+	 * @param \Closure|null $progressCallback
+	 * @return array
+	 */
+	public function analyse(array $files, \Closure $progressCallback = null): array
+	{
+		if ($this->bootstrapFile !== null) {
+			if (!is_file($this->bootstrapFile)) {
+				throw new \RuntimeException('Bootstrap file %s does not exist.', $this->bootstrapFile);
+			}
+
+			require_once $this->bootstrapFile;
+		}
+
+		$reports = [];
+		$this->nodeScopeResolver->setAnalysedFiles($files);
+		foreach ($files as $file) {
+			if ($this->fileExcluder->isExcludedFromAnalysing($file)) {
+				if ($progressCallback !== null) {
+					$progressCallback($file);
+				}
+
+				continue;
+			}
+
+			$typecheckWarnings = [];
+			$this->nodeScopeResolver->processNodes(
+				$this->parser->parseFile($file),
+				new Scope($this->broker, $this->printer, $this->typeSpecifier, $file),
+				function (\PhpParser\Node $node, Scope $scope) use (&$typecheckWarnings) {
+					if ($node instanceof \PhpParser\Node\Stmt\Trait_) {
+						return;
+					}
+
+					if ($node instanceof \PhpParser\Node\Expr\Variable) {
+						$typecheckWarnings = array_merge(
+							$typecheckWarnings,
+							$this->handleVariableNode($node, $scope)
+						);
+					}
+
+					if ($node instanceof \PhpParser\Node\Expr\PropertyFetch) {
+						$typecheckWarnings = array_merge(
+							$typecheckWarnings,
+							$this->handlePropertyFetch($node, $scope)
+						);
+					}
+
+					if ($node instanceof \PhpParser\Node\Expr\FuncCall) {
+						$typecheckWarnings = array_merge(
+							$typecheckWarnings,
+							$this->handleFuncCall($node, $scope)
+						);
+					}
+
+					if ($node instanceof \PhpParser\Node\Expr\MethodCall) {
+						$typecheckWarnings = array_merge(
+							$typecheckWarnings,
+							$this->handleMethodCall($node, $scope)
+						);
+					}
+
+					if ($node instanceof \PhpParser\Node\Expr\StaticPropertyFetch) {
+						$typecheckWarnings = array_merge(
+							$typecheckWarnings,
+							$this->handleStaticPropertyFetch($node, $scope)
+						);
+					}
+
+					if ($node instanceof \PhpParser\Node\Expr\StaticCall) {
+						$typecheckWarnings = array_merge(
+							$typecheckWarnings,
+							$this->handleStaticMethodCall($node, $scope)
+						);
+					}
+				}
+			);
+			if ($progressCallback !== null) {
+				$progressCallback($file);
+			}
+
+			$report = [];
+			foreach ($typecheckWarnings as $warning) {
+				if (!isset($report[$warning['line']])) {
+					$report[$warning['line']] = [];
+				}
+
+				$report[$warning['line']][] = $warning['reason'];
+			}
+			$reports[$file] = $report;
+		}
+
+		return $reports;
+	}
+
+	private function handleVariableNode($node, $scope)
+	{
+		// A useage, rather than assignment of the variable
+		if (!$scope->isInVariableAssign($node->name)) {
+			if (!$scope->hasVariableType($node->name)) {
+				// Use of undefined variable, we don't have coverage
+				// of this
+				return [
+					$this->buildFailure(
+						$node,
+						'Variable $' . $node->name . ' is not defined'
+					)
+				];
+			} else {
+				$type = $scope->getVariableType($node->name);
+				if ($type instanceof \PHPStan\Type\MixedType) {
+					return [
+						$this->buildFailure(
+							$node,
+							'Variable $' . $node->name . ' does not have a type'
+						)
+					];
+				}
+			}
+		}
+
+		return [];
+	}
+
+	private function handlePropertyFetch($node, $scope)
+	{
+		$maybeClass = $this->getClass($node, $scope);
+		if (is_null($maybeClass)) {
+			return [];
+		} else {
+			$class = $maybeClass;
+		}
+
+		$name = $node->name;
+		if (gettype($name) !== 'string') {
+			// They're probably doing something like
+			// $this->$someVar . We can't know the return
+			// type of this usage.
+			return [
+				$this->buildFailure(
+					$node,
+					'Use of variable ' . $name . ' to access property of class ' . $class->getName()
+				)
+			];
+		}
+		if (!$class->hasProperty($name)) {
+			return [];
+		}
+
+		$propertyReflection = $class->getProperty($name, $scope);
+		$propType = $propertyReflection->getType();
+
+		if ($propType instanceof \PHPStan\Type\MixedType) {
+			return [
+				$this->buildFailure(
+					$node,
+					'Property ' . $name . ' of class ' . $class->getName() . ' does not have a type'
+				)
+			];
+		}
+
+		return [];
+	}
+
+	private function handleStaticPropertyFetch($node, $scope)
+	{
+		if (!is_string($node->name) || !($node->class instanceof \PhpParser\Node\Name)) {
+			return [];
+		}
+
+		$name = $node->name;
+		$class = (string) $node->class;
+		if ($class === 'self' || $class === 'static') {
+			if (!$scope->isInClass()) {
+				return [];
+			}
+			$classReflection = $scope->getClassReflection();
+		} elseif ($class === 'parent') {
+			if (!$scope->isInClass()) {
+				return [];
+			}
+			if ($scope->getClassReflection()->getParentClass() === false) {
+				return [];
+			}
+
+			if ($scope->getFunctionName() === null) {
+				throw new \PHPStan\ShouldNotHappenException();
+			}
+
+			$classReflection = $scope->getClassReflection()->getParentClass();
+		} else {
+			if (!$this->broker->hasClass($class)) {
+				return [
+					$this->buildFailure(
+						$node,
+						'Can\'t find class ' . $class
+					)
+				];
+			}
+			$classReflection = $this->broker->getClass($class);
+		}
+
+		if (!$classReflection->hasProperty($name)) {
+			return [
+				$this->buildFailure(
+					$node,
+					'Static property ' . $name . ' does not exist on ' . $class
+				)
+			];
+		}
+
+		$property = $classReflection->getProperty($name, $scope);
+		$propType = $property->getType();
+
+		if ($propType instanceof \PHPStan\Type\MixedType) {
+			return [
+				$this->buildFailure(
+					$node,
+					'Static property ' . $name . ' of class ' . $class . ' does not have a type'
+				)
+			];
+		}
+
+		return [];
+	}
+
+	private function handleFuncCall($node, $scope)
+	{
+		if (!($node->name instanceof \PhpParser\Node\Name)) {
+			return [];
+		}
+
+		if (!$this->broker->hasFunction($node->name, $scope)) {
+			return [];
+		}
+
+		$function = $this->broker->getFunction($node->name, $scope);
+		$type = $function->getReturnType();
+
+		if ($type instanceof \PHPStan\Type\MixedType) {
+			return [
+				$this->buildFailure(
+					$node,
+					'Function ' . $node->name . ' does not have a defined return type'
+				)
+			];
+		}
+
+		return [];
+	}
+
+	private function handleMethodCall($node, $scope)
+	{
+		$maybeClass = $this->getClass($node, $scope);
+		if (is_null($maybeClass)) {
+			return [];
+		} else {
+			$class = $maybeClass;
+		}
+
+		$name = $node->name;
+		if (!$class->hasMethod($name)) {
+			return [];
+		}
+
+		$methodReflection = $class->getMethod($name, $scope);
+		$type = $methodReflection->getReturnType();
+
+		if ($type instanceof \PHPStan\Type\MixedType) {
+			return [
+				$this->buildFailure(
+					$node,
+					'Method ' . $name . ' does not have a defined return type'
+				)
+			];
+		}
+
+		return [];
+	}
+
+	private function handleStaticMethodCall($node, $scope)
+	{
+		if (!is_string($node->name) || !($node->class instanceof \PhpParser\Node\Name)) {
+			return [];
+		}
+
+		$name = $node->name;
+		$class = (string) $node->class;
+		if ($class === 'self' || $class === 'static') {
+			if (!$scope->isInClass()) {
+				return [];
+			}
+			$classReflection = $scope->getClassReflection();
+		} elseif ($class === 'parent') {
+			if (!$scope->isInClass()) {
+				return [];
+			}
+			if ($scope->getClassReflection()->getParentClass() === false) {
+				return [];
+			}
+
+			if ($scope->getFunctionName() === null) {
+				throw new \PHPStan\ShouldNotHappenException();
+			}
+
+			$classReflection = $scope->getClassReflection()->getParentClass();
+		} else {
+			if (!$this->broker->hasClass($class)) {
+				return [
+					$this->buildFailure(
+						$node,
+						'Can\'t find class ' . $class
+					)
+				];
+			}
+			$classReflection = $this->broker->getClass($class);
+		}
+
+		if (!$classReflection->hasMethod($name)) {
+			return [
+				$this->buildFailure(
+					$node,
+					'Static method ' . $name . ' does not exist on ' . $class
+				)
+			];
+		}
+
+		$method = $classReflection->getMethod($name, $scope);
+		$type = $method->getReturnType();
+
+		if ($type instanceof \PHPStan\Type\MixedType) {
+			return [
+				$this->buildFailure(
+					$node,
+					'Static method ' . $name . ' on class ' . $class . ' does not have a defined return type'
+				)
+			];
+		}
+
+		return [];
+	}
+
+	private function getClass($node, $scope)
+	{
+		$classType = $scope->getType($node->var);
+		if (!$classType->canAccessProperties()) {
+			return null;
+		}
+
+		$propertyClass = $classType->getClass();
+		if ($propertyClass === null) {
+			return null;
+		}
+
+		if (!$this->broker->hasClass($propertyClass)) {
+			return null;
+		}
+
+		return $this->broker->getClass($propertyClass);
+	}
+
+	/**
+	 * @param \PhpParser\Node $node
+	 * @param string $reason
+	 * @return array
+	 */
+	private function buildFailure($node, $reason)
+	{
+		return [
+			'line' => $node->getLine(),
+			'reason' => $reason
+		];
+	}
+}

--- a/src/Command/CoverageApplication.php
+++ b/src/Command/CoverageApplication.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command;
+
+use PHPStan\Analyser\CoverageReporter;
+use PHPStan\Analyser\Error;
+use PHPStan\File\FileHelper;
+use Symfony\Component\Console\Style\OutputStyle;
+use Symfony\Component\Finder\Finder;
+
+class CoverageApplication
+{
+
+	/**
+	 * @var \PHPStan\Analyser\CoverageReporter
+	 */
+	private $coverageReporter;
+
+	/**
+	 * @var string
+	 */
+	private $memoryLimitFile;
+
+	/**
+	 * @var string[]
+	 */
+	private $fileExtensions;
+
+	/** @var \PHPStan\File\FileHelper */
+	private $fileHelper;
+
+	public function __construct(
+		CoverageReporter $coverageReporter,
+		string $memoryLimitFile,
+		FileHelper $fileHelper,
+		array $fileExtensions
+	)
+	{
+		$this->coverageReporter = $coverageReporter;
+		$this->memoryLimitFile = $memoryLimitFile;
+		$this->fileExtensions = $fileExtensions;
+		$this->fileHelper = $fileHelper;
+	}
+
+	/**
+	 * @param string[] $paths
+	 * @param \Symfony\Component\Console\Style\OutputStyle $style
+	 * @return int Error code.
+	 */
+	public function coverage(
+		array $paths,
+		OutputStyle $style
+	): int
+	{
+		$errors = [];
+		$files = [];
+
+		$this->updateMemoryLimitFile();
+
+		$paths = array_map(function (string $path): string {
+			return $this->fileHelper->absolutizePath($path);
+		}, $paths);
+
+		foreach ($paths as $path) {
+			if (!file_exists($path)) {
+				throw new \RuntimeException(sprintf('<error>Path %s does not exist</error>', $path));
+			} elseif (is_file($path)) {
+				$files[] = $this->fileHelper->normalizePath($path);
+			} else {
+				$finder = new Finder();
+				$finder->followLinks();
+				foreach ($finder->files()->name('*.{' . implode(',', $this->fileExtensions) . '}')->in($path) as $fileInfo) {
+					$files[] = $this->fileHelper->normalizePath($fileInfo->getPathname());
+				}
+			}
+		}
+
+		$this->updateMemoryLimitFile();
+
+		$progressStarted = false;
+
+		$fileOrder = 0;
+		$reports = $this->coverageReporter->analyse(
+			$files,
+			function () use ($style, &$progressStarted, $files, &$fileOrder) {
+				if (!$progressStarted) {
+					$style->progressStart(count($files));
+					$progressStarted = true;
+				}
+				$style->progressAdvance();
+				if ($fileOrder % 100 === 0) {
+					$this->updateMemoryLimitFile();
+				}
+				$fileOrder++;
+			}
+		);
+
+		if ($progressStarted) {
+			$style->progressFinish();
+		}
+
+		$f = $style->getFormatter();
+		foreach ($reports as $filePath => $warningMap) {
+			$style->writeln('-- ' . $filePath);
+
+			$handle = fopen($filePath, 'r');
+			if ($handle) {
+				$lineCounter = 1;
+				while (($line = fgets($handle)) !== false) {
+					$hasWarnings = isset($warningMap[$lineCounter]);
+
+					if ($hasWarnings) {
+						$style->writeln('<question>-  ' . $f->escape(rtrim($line)) . '</>');
+
+						foreach ($warningMap[$lineCounter] as $warning) {
+							$style->writeln('<info>? ' . $f->escape($warning) . '</>');
+						}
+					} else {
+						$style->write('+  ' . $f->escape($line));
+					}
+					$lineCounter++;
+				}
+
+				fclose($handle);
+			} else {
+				throw new \RuntimeException('Could not open file: ' . $filePath);
+			}
+		}
+
+		return 0;
+	}
+
+	private function updateMemoryLimitFile()
+	{
+		$bytes = memory_get_peak_usage(true);
+		$megabytes = ceil($bytes / 1024 / 1024);
+		file_put_contents($this->memoryLimitFile, sprintf('%d MB', $megabytes));
+
+		if (function_exists('pcntl_signal_dispatch')) {
+			pcntl_signal_dispatch();
+		}
+	}
+
+}

--- a/src/Command/CoverageCommand.php
+++ b/src/Command/CoverageCommand.php
@@ -1,0 +1,174 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command;
+
+use Nette\Configurator;
+use Nette\DI\Config\Loader;
+use Nette\DI\Extensions\ExtensionsExtension;
+use Nette\DI\Extensions\PhpExtension;
+use Nette\DI\Helpers;
+use PhpParser\Node\Stmt\Catch_;
+use PHPStan\File\FileHelper;
+use PHPStan\Type\TypeCombinator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class CoverageCommand extends \Symfony\Component\Console\Command\Command
+{
+
+	const NAME = 'coverage';
+
+	const DEFAULT_LEVEL = 0;
+
+	protected function configure()
+	{
+		$this->setName(self::NAME)
+			->setDescription('Produces a report of which parts of a file are type checked')
+			->setDefinition([
+				new InputArgument('paths', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'Paths with source code to run analysis on'),
+				new InputOption('configuration', 'c', InputOption::VALUE_REQUIRED, 'Path to project configuration file'),
+				new InputOption('autoload-file', 'a', InputOption::VALUE_OPTIONAL, 'Project\'s additional autoload file path'),
+			]);
+	}
+
+
+	public function getAliases(): array
+	{
+		return [];
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int
+	{
+		$consoleStyle = new ErrorsConsoleStyle($input, $output);
+
+		$currentWorkingDirectory = getcwd();
+		$fileHelper = new FileHelper($currentWorkingDirectory);
+
+		$autoloadFile = $input->getOption('autoload-file');
+		if ($autoloadFile !== null && is_file($autoloadFile)) {
+			$autoloadFile = $fileHelper->normalizePath($autoloadFile);
+			if (is_file($autoloadFile)) {
+				require_once $autoloadFile;
+			}
+		}
+
+		$rootDir = $fileHelper->normalizePath(__DIR__ . '/../..');
+		$confDir = $rootDir . '/conf';
+
+		$parameters = [
+			'rootDir' => $rootDir,
+			'currentWorkingDirectory' => $currentWorkingDirectory,
+			'cliArgumentsVariablesRegistered' => ini_get('register_argc_argv') === '1',
+		];
+
+		$projectConfigFile = $input->getOption('configuration');
+		$configFiles = [$confDir . '/config.neon'];
+
+		if ($projectConfigFile !== null) {
+			if (!is_file($projectConfigFile)) {
+				$output->writeln(sprintf('Project config file at path %s does not exist.', $projectConfigFile));
+				return 1;
+			}
+
+			$configFiles[] = $projectConfigFile;
+
+			$loader = new Loader();
+			$projectConfig = $loader->load($projectConfigFile, null);
+			if (isset($projectConfig['parameters']['tmpDir'])) {
+				$tmpDir = Helpers::expand($projectConfig['parameters']['tmpDir'], $parameters);
+			}
+		}
+
+		if (!isset($tmpDir)) {
+			$tmpDir = sys_get_temp_dir() . '/phpstan';
+			if (!@mkdir($tmpDir, 0777, true) && !is_dir($tmpDir)) {
+				$consoleStyle->error(sprintf('Cannot create a temp directory %s', $tmpDir));
+				return 1;
+			}
+		}
+
+		$configurator = new Configurator();
+		$configurator->defaultExtensions = [
+			'php' => PhpExtension::class,
+			'extensions' => ExtensionsExtension::class,
+		];
+		$configurator->setDebugMode(true);
+		$configurator->setTempDirectory($tmpDir);
+
+		foreach ($configFiles as $configFile) {
+			$configurator->addConfig($configFile);
+		}
+
+		$parameters['tmpDir'] = $tmpDir;
+
+		$configurator->addParameters($parameters);
+		$container = $configurator->createContainer();
+		$memoryLimitFile = $container->parameters['memoryLimitFile'];
+		if (file_exists($memoryLimitFile)) {
+			$consoleStyle->note(sprintf(
+				"PHPStan crashed in the previous run probably because of excessive memory consumption.\nIt consumed around %s of memory.\n\nTo avoid this issue, increase the memory_limit directive in your php.ini file here:\n%s\n\nIf you can't or don't want to change the system-wide memory limit, run PHPStan like this:\n%s",
+				file_get_contents($memoryLimitFile),
+				php_ini_loaded_file(),
+				sprintf('php -d memory_limit=XX %s', implode(' ', $_SERVER['argv']))
+			));
+			unlink($memoryLimitFile);
+		}
+		if (PHP_VERSION_ID >= 70100 && !property_exists(Catch_::class, 'types')) {
+			$consoleStyle->note(
+				'You\'re running PHP >= 7.1, but you still have PHP-Parser version 2.x. This will lead to parse errors in case you use PHP 7.1 syntax like nullable parameters, iterable and void typehints, union exception types, or class constant visibility. Update to PHP-Parser 3.x to dismiss this message.'
+			);
+		}
+
+		foreach ($container->parameters['autoload_files'] as $autoloadFile) {
+			require_once $fileHelper->normalizePath($autoloadFile);
+		}
+
+		if (count($container->parameters['autoload_directories']) > 0) {
+			$robotLoader = new \Nette\Loaders\RobotLoader();
+
+			$robotLoader->acceptFiles = '*.' . implode(', *.', $container->parameters['fileExtensions']);
+
+			$robotLoader->setTempDirectory($tmpDir);
+			foreach ($container->parameters['autoload_directories'] as $directory) {
+				$robotLoader->addDirectory($fileHelper->normalizePath($directory));
+			}
+
+			$robotLoader->register();
+		}
+
+		TypeCombinator::setUnionTypesEnabled($container->parameters['checkUnionTypes']);
+
+		/** @var \PHPStan\Command\CoverageApplication $application */
+		$application = $container->getByType(CoverageApplication::class);
+		return $this->handleReturn(
+			$application->coverage(
+				$input->getArgument('paths'),
+				$consoleStyle
+			),
+			$memoryLimitFile
+		);
+	}
+
+	private function handleReturn(int $code, string $memoryLimitFile): int
+	{
+		unlink($memoryLimitFile);
+		return $code;
+	}
+
+	private function setUpSignalHandler(StyleInterface $consoleStyle, string $memoryLimitFile)
+	{
+		if (function_exists('pcntl_signal')) {
+			pcntl_signal(SIGINT, function () use ($consoleStyle, $memoryLimitFile) {
+				if (file_exists($memoryLimitFile)) {
+					unlink($memoryLimitFile);
+				}
+				$consoleStyle->newLine();
+				exit(1);
+			});
+		}
+	}
+
+}


### PR DESCRIPTION
I wanted to gauge the interest in having a second command in PHPStan that indicates which parts of a file are not type checked. The idea is that you would use the existing analyse command to check your code, and the coverage command to find areas where you could add more type annotations to extend what analyse will check.

I've made a proof of concept of this command in this PR. I've attached a screenshot of the invocation and output:

![typechecker-coverage](https://user-images.githubusercontent.com/9328736/28305782-5b6b64ae-6be0-11e7-9cdd-45ae393b5cc6.png)

The reason for a separate command, and not some additional custom rules is that this tool is pretty aggressive in what it flags (which may be perfectly functional code). Any dynamic property access ($this->$someVar) is untypable for example. I could be persuaded that this should be done using the existing rules system however.

The tool checks that the return types from functions, and the types of variables are known at the point they are used. It does this at present by checking the type is not 'mixed'. Since functions can be explicitly marked as mixed we would need to make changes to be able to disambiguate between 'explicity of the type mixed', and 'no type known'.