### PR TITLE
Fix "incorrect case" error when using trait aliases

### DIFF
--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -106,7 +106,43 @@ class PhpMethodReflection implements MethodReflection
 
 	public function getName(): string
 	{
-		return $this->reflection->getName();
+		$name = $this->reflection->getName();
+		$lowercaseName = strtolower($name);
+		if ($lowercaseName === $name) {
+			// fix for https://bugs.php.net/bug.php?id=74939
+			foreach ($this->getDeclaringClass()->getNativeReflection()->getTraitAliases() as $traitTarget) {
+				$correctName = $this->getMethodNameWithCorrectCase($name, $traitTarget);
+				if ($correctName !== null) {
+					$name = $correctName;
+					break;
+				}
+			}
+		}
+
+		return $name;
+	}
+
+	/**
+	 * @param string $lowercaseMethodName
+	 * @param string $traitTarget
+	 * @return string|null
+	 */
+	private function getMethodNameWithCorrectCase(string $lowercaseMethodName, string $traitTarget)
+	{
+		list ($trait, $method) = explode('::', $traitTarget);
+		$traitReflection = $this->broker->getClass($trait)->getNativeReflection();
+		foreach ($traitReflection->getTraitAliases() as $methodAlias => $traitTarget) {
+			if ($lowercaseMethodName === strtolower($methodAlias)) {
+				return $methodAlias;
+			}
+
+			$correctName = $this->getMethodNameWithCorrectCase($lowercaseMethodName, $traitTarget);
+			if ($correctName !== null) {
+				return $correctName;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -259,6 +259,13 @@ class CallMethodsRuleTest extends \PHPStan\Rules\AbstractRuleTest
 		]);
 	}
 
+	public function testCallTraitOverridenMethods()
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->analyse([__DIR__ . '/data/call-trait-overridden-methods.php'], []);
+	}
+
 	public function testCallInterfaceMethods()
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/data/call-trait-overridden-methods.php
+++ b/tests/PHPStan/Rules/Methods/data/call-trait-overridden-methods.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace CallTraitOverriddenMethods;
+
+trait TraitA {
+	function sameName() {}
+}
+
+trait TraitB {
+	use TraitA {
+		sameName as someOtherName;
+	}
+	function sameName() {
+		$this->someOtherName();
+	}
+}
+
+trait TraitC {
+	use TraitB {
+		sameName as YetAnotherName;
+	}
+	function sameName()
+	{
+		$this->YetAnotherName();
+	}
+}
+
+class SomeClass {
+	use TraitC {
+		sameName as wowSoManyNames;
+	}
+
+	function sameName()
+	{
+		$this->wowSoManyNames();
+	}
+}


### PR DESCRIPTION
This fixes a bug in the PHP scripting engine, which causes
Reflection API to return the incorrect case for aliased methods
when traits are nested.

Fixes #379

This is an alternative implementation to PR #380, as requested.