### PR TITLE
Fixed parsing multiple types with extra spaces around pipe character

### DIFF
--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -74,7 +74,7 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 
 		$typeMap = $this->fileTypeMapper->getTypeMap($fileName);
 
-		preg_match_all('#@method\s+(?:(?P<IsStatic>static)\s+)?(?:(?P<Type>[^\s\(]*)\s+)?(?P<MethodName>[a-zA-Z0-9_]+)(?P<Parameters>(?:\([^\)]*\))?)#', $docComment, $matches, PREG_SET_ORDER);
+		preg_match_all('#@method\s+(?:(?P<IsStatic>static)\s+)?(?:(?P<Type>[^\(\*]+?)(?<!\|)\s+)?(?P<MethodName>[a-zA-Z0-9_]+)(?P<Parameters>(?:\([^\)]*\))?)#', $docComment, $matches, PREG_SET_ORDER);
 		foreach ($matches as $match) {
 			$isStatic = $match['IsStatic'] === 'static';
 			$typeStringCandidate = $match['Type'];

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -10,7 +10,7 @@ class FileTypeMapper
 {
 
 	const CONST_FETCH_CONSTANT = '__PHPSTAN_CLASS_REFLECTION_CONSTANT__';
-	const TYPE_PATTERN = '((?:(?:\$this|\\??\\\?[0-9a-zA-Z_][0-9a-zA-Z_\\\]+)(?:\[\])*(?:\|)?)+)';
+	const TYPE_PATTERN = '((?:(?:\$this|\\??\\\?[0-9a-zA-Z_][0-9a-zA-Z_\\\]+)(?:\[\])*(?:\s*\|\s*)?)+)';
 
 	/** @var \PHPStan\Parser\Parser */
 	private $parser;
@@ -32,7 +32,7 @@ class FileTypeMapper
 
 	public function getTypeMap(string $fileName): array
 	{
-		$cacheKey = sprintf('%s-%d-v35', $fileName, filemtime($fileName));
+		$cacheKey = sprintf('%s-%d-v36', $fileName, filemtime($fileName));
 		if (isset($this->memoryCache[$cacheKey])) {
 			return $this->memoryCache[$cacheKey];
 		}
@@ -147,6 +147,7 @@ class FileTypeMapper
 		/** @var \PHPStan\Type\Type|null $type */
 		$type = null;
 		foreach (explode('|', $typeString) as $typePart) {
+			$typePart = trim($typePart);
 			if (substr($typePart, 0, 1) === '?') {
 				$typePart = substr($typePart, 1);
 				$type = $type ? TypeCombinator::addNull($type) : new NullType();

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -873,6 +873,28 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\TestCase
 						],
 					],
 				],
+				'paramMultipleTypesWithExtraSpaces' => [
+					'class' => \AnnotationsMethods\BazBaz::class,
+					'returnType' => 'float|int',
+					'isStatic' => false,
+					'isVariadic' => false,
+					'parameters' => [
+						[
+							'name' => 'string',
+							'type' => 'string|null',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+						[
+							'name' => 'object',
+							'type' => 'OtherNamespace\\Test|null',
+							'isPassedByReference' => false,
+							'isOptional' => false,
+							'isVariadic' => false,
+						],
+					],
+				],
 			]
 		);
 

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -166,6 +166,12 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\TestCas
 						'writable' => true,
 						'readable' => false,
 					],
+					'numericBazBazProperty' => [
+						'class' => \AnnotationsProperties\BazBaz::class,
+						'type' => 'float|int',
+						'writable' => true,
+						'readable' => true,
+					],
 				],
 			],
 		];

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
@@ -104,6 +104,8 @@ class Baz extends Bar
  * @method void doSomethingWithSpecificVariadicObjectParamsNotNullable(Ipsum ...$a)
  * @method void doSomethingWithSpecificVariadicObjectParamsNullable(?Ipsum ...$a)
  * @method void doSomethingWithComplicatedParameters($a, $b = null, string|bool|int|float|OtherTest $c, string|bool|int|float|OtherTest $d = null)
+ *
+ * @method int | float paramMultipleTypesWithExtraSpaces(string | null $string, OtherTest | null $object)
  */
 class BazBaz extends Baz
 {

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-properties.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-properties.php
@@ -33,6 +33,9 @@ class Baz extends Bar
 
 }
 
+/**
+ * @property int | float $numericBazBazProperty
+ */
 class BazBaz extends Baz
 {
 

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -14,6 +14,7 @@ class FileTypeMapperTest extends \PHPStan\TestCase
 		$typeMap = $fileTypeMapper->getTypeMap(__DIR__ . '/data/annotations.php');
 
 		$expected = [
+			'int | float' => 'float|int',
 			'void' => 'void',
 			'string' => 'string',
 			'?float' => 'float|null',
@@ -23,6 +24,8 @@ class FileTypeMapperTest extends \PHPStan\TestCase
 			'string|?int' => 'int|string|null',
 			'Image' => 'Image',
 			'float' => 'float',
+			'string | null' => 'string|null',
+			'stdClass | null' => 'stdClass|null',
 		];
 
 		$this->assertEquals(array_keys($expected), array_keys($typeMap));

--- a/tests/PHPStan/Type/data/annotations.php
+++ b/tests/PHPStan/Type/data/annotations.php
@@ -1,12 +1,15 @@
 <?php declare(strict_types=1);
 
 /**
+ * @property int | float $numericBazBazProperty
+ *
  * @method void simpleMethod
  * @method string returningMethod()
  * @method ?float returningNullableScalar()
  * @method ?\stdClass returningNullableObject()
  * @method void complicatedParameters(string $a, ?int|?float|?\stdClass $b, \stdClass $c = null, string|?int $d)
  * @method Image rotate(float $angle, $backgroundColor)
+ * @method int | float paramMultipleTypesWithExtraSpaces(string | null $string, stdClass | null $object)
  */
 class Foo
 {


### PR DESCRIPTION
It is used in some libraries, for example, older version of OAuth2 server from PHP League https://github.com/thephpleague/oauth2-server/blob/4.1.6/src/Storage/AccessTokenInterface.php