### PR TITLE
Annotations can overwrite method return types

### DIFF
--- a/src/Broker/BrokerFactory.php
+++ b/src/Broker/BrokerFactory.php
@@ -40,7 +40,7 @@ class BrokerFactory
 
 		return new Broker(
 			array_merge([$phpClassReflectionExtension, $phpDefectClassReflectionExtension], $tagToService($this->container->findByTag(self::PROPERTIES_CLASS_REFLECTION_EXTENSION_TAG)), [$annotationsPropertiesClassReflectionExtension]),
-			array_merge([$phpClassReflectionExtension], $tagToService($this->container->findByTag(self::METHODS_CLASS_REFLECTION_EXTENSION_TAG)), [$annotationsMethodsClassReflectionExtension]),
+			array_merge($tagToService($this->container->findByTag(self::METHODS_CLASS_REFLECTION_EXTENSION_TAG)), [$annotationsMethodsClassReflectionExtension, $phpClassReflectionExtension]),
 			$tagToService($this->container->findByTag(self::DYNAMIC_METHOD_RETURN_TYPE_EXTENSION_TAG)),
 			$tagToService($this->container->findByTag(self::DYNAMIC_STATIC_METHOD_RETURN_TYPE_EXTENSION_TAG)),
 			$this->container->getByType(FunctionReflectionFactory::class),

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -109,7 +109,7 @@ class ClassReflection
 					if ($scope !== null && $scope->canCallMethod($method)) {
 						return $this->methods[$key] = $method;
 					}
-					$this->methods[$key] = $method;
+					$this->methods[$key] = $this->methods[$key] ?? $method;
 				}
 			}
 		}

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-methods.php
@@ -52,7 +52,13 @@ use OtherNamespace\Test as OtherTest;
  */
 class Foo implements FooInterface
 {
-
+	/**
+	 * @return string
+	 */
+	public function getIpsum($a)
+	{
+		return '';
+	}
 }
 
 class Bar extends Foo
@@ -61,7 +67,7 @@ class Bar extends Foo
 }
 
 /**
- * @method Ipsum  getIpsum($a)
+ * @method Ipsum getIpsum($a)
  * @method void doSomething(int $a, $b)
  * @method static Ipsum  getIpsumStatically($a)
  * @method static void doSomethingStatically(int $a, $b)


### PR DESCRIPTION
When a subclass has the knowledge that it will return a more specific type, annotations should be able to override this.