### PR TITLE
Find correct constructor for class with legacy constructor extending class with __construct

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -121,6 +121,11 @@ class ClassReflection
 		return $this->methods[$key];
 	}
 
+	public function getConstructor(Scope $scope = null): MethodReflection
+	{
+		return $this->getMethod($this->getNativeReflection()->getConstructor()->getName(), $scope);
+	}
+
 	public function getProperty(string $propertyName, Scope $scope = null): PropertyReflection
 	{
 		$key = $propertyName;

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -111,7 +111,7 @@ class InstantiationRule implements \PHPStan\Rules\Rule
 		}
 
 		return $this->check->check(
-			$classReflection->hasMethod('__construct') ? $classReflection->getMethod('__construct', $scope) : $classReflection->getMethod($class),
+			$classReflection->getConstructor($scope),
 			$scope,
 			$node,
 			[

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -19,58 +19,65 @@ class InstantiationRuleTest extends \PHPStan\Rules\AbstractRuleTest
 
 	public function testInstantiation()
 	{
+		$expectedErrors = [
+			[
+				'Class TestInstantiation\InstantiatingClass constructor invoked with 0 parameters, 1 required.',
+				15,
+			],
+			[
+				'TestInstantiation\InstantiatingClass::doFoo() calls new parent but TestInstantiation\InstantiatingClass does not extend any class.',
+				18,
+			],
+			[
+				'Class TestInstantiation\FooInstantiation does not have a constructor and must be instantiated without any parameters.',
+				26,
+			],
+			[
+				'Instantiated class TestInstantiation\FooBarInstantiation not found.',
+				27,
+			],
+			[
+				'Class TestInstantiation\BarInstantiation constructor invoked with 0 parameters, 1 required.',
+				28,
+			],
+			[
+				'Instantiated class TestInstantiation\LoremInstantiation is abstract.',
+				29,
+			],
+			[
+				'Cannot instantiate interface TestInstantiation\IpsumInstantiation.',
+				30,
+			],
+			[
+				'Class DatePeriod constructor invoked with 0 parameters, 1-4 required.',
+				36,
+			],
+			[
+				'Using self outside of class scope.',
+				39,
+			],
+			[
+				'Using static outside of class scope.',
+				40,
+			],
+			[
+				'Using parent outside of class scope.',
+				41,
+			],
+			[
+				'Class TestInstantiation\InstantiatingClass constructor invoked with 0 parameters, 1 required.',
+				54,
+			],
+		];
+		if (!class_exists('SoapFault')) {
+			$expectedErrors[] = [
+				'Instantiated class SoapFault not found.',
+				61,
+			];
+		}
 		$this->analyse(
 			[__DIR__ . '/data/instantiation.php'],
-			[
-				[
-					'Class TestInstantiation\InstantiatingClass constructor invoked with 0 parameters, 1 required.',
-					15,
-				],
-				[
-					'TestInstantiation\InstantiatingClass::doFoo() calls new parent but TestInstantiation\InstantiatingClass does not extend any class.',
-					18,
-				],
-				[
-					'Class TestInstantiation\FooInstantiation does not have a constructor and must be instantiated without any parameters.',
-					26,
-				],
-				[
-					'Instantiated class TestInstantiation\FooBarInstantiation not found.',
-					27,
-				],
-				[
-					'Class TestInstantiation\BarInstantiation constructor invoked with 0 parameters, 1 required.',
-					28,
-				],
-				[
-					'Instantiated class TestInstantiation\LoremInstantiation is abstract.',
-					29,
-				],
-				[
-					'Cannot instantiate interface TestInstantiation\IpsumInstantiation.',
-					30,
-				],
-				[
-					'Class DatePeriod constructor invoked with 0 parameters, 1-4 required.',
-					36,
-				],
-				[
-					'Using self outside of class scope.',
-					39,
-				],
-				[
-					'Using static outside of class scope.',
-					40,
-				],
-				[
-					'Using parent outside of class scope.',
-					41,
-				],
-				[
-					'Class TestInstantiation\InstantiatingClass constructor invoked with 0 parameters, 1 required.',
-					54,
-				],
-			]
+			$expectedErrors
 		);
 	}
 

--- a/tests/PHPStan/Rules/Classes/data/instantiation.php
+++ b/tests/PHPStan/Rules/Classes/data/instantiation.php
@@ -56,3 +56,7 @@ class ChildInstantiatingClass extends InstantiatingClass
 	}
 
 }
+
+function () {
+	new \SoapFault('', '', '', '');
+};


### PR DESCRIPTION
PHP built in SOAPFault class still uses the legacy constructor(SOAPFault function), but extends Exception, which uses __construct().
Exception takes 3 paramers, SOAPFault takes 6. Without this it will give an error when more than 3 parameters are used.