### PR TITLE
TypeSpecifier: fallback to union in case where intersection is required

### DIFF
--- a/src/Analyser/SpecifiedTypes.php
+++ b/src/Analyser/SpecifiedTypes.php
@@ -64,6 +64,15 @@ class SpecifiedTypes
 		$sureTypeUnion = $this->sureTypes + $other->sureTypes;
 		$sureNotTypeUnion = $this->sureNotTypes + $other->sureNotTypes;
 
+		foreach ($this->sureTypes as $exprString => list($exprNode, $type)) {
+			if (isset($other->sureTypes[$exprString])) {
+				$sureTypeUnion[$exprString] = [
+					$exprNode,
+					$type->combineWith($other->sureTypes[$exprString][1]),
+				];
+			}
+		}
+
 		foreach ($this->sureNotTypes as $exprString => list($exprNode, $type)) {
 			if (isset($other->sureNotTypes[$exprString])) {
 				$sureNotTypeUnion[$exprString] = [


### PR DESCRIPTION
This should restore 0.7 behavior.

Closes https://github.com/phpstan/phpstan/issues/417