### PR TITLE
Show pretty version in CLI

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -20,7 +20,11 @@ if (!class_exists('PHPStan\Command\AnalyseCommand', true)) {
 	require_once($composerAutoloadFile);
 }
 
-$application = new \Symfony\Component\Console\Application('PHPStan - PHP Static Analysis Tool', 'Version unknown');
+
+$application = new \Symfony\Component\Console\Application(
+	'PHPStan - PHP Static Analysis Tool',
+	\Jean85\PrettyVersions::getVersion('phpstan/phpstan')->getPrettyVersion()
+);
 $application->setCatchExceptions(false);
 $application->add(new AnalyseCommand());
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 		"nette/utils": "^2.4 || ^3.0",
 		"nikic/php-parser": "^3.0.2",
 		"symfony/console": "~2.7 || ~3.0",
-		"symfony/finder": "~2.7 || ~3.0"
+		"symfony/finder": "~2.7 || ~3.0",
+		"jean85/pretty-package-versions": "^1.0"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "^2.0.0",


### PR DESCRIPTION
I've noticed that from CLI it says "Unknown version". With this PR I want to improve that.

Full disclosure: I'm the author of the `jean85/pretty-package-versions` package added with this PR. It's only a very thin wrapper for ocramius/pretty-package-versions.

In this way, the CLI will either show:

    PHPStan - PHP Static Analysis Tool 0.8.9999999.9999999-dev@262909a

or, if it's a tagged version, the prettier

    PHPStan - PHP Static Analysis Tool 0.8.1


PS: I would suggest to you to slowly migrate this project toward PSR-2, any other bigger contribution would be really harder to be done.