### PR TITLE
Failing test

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1544,6 +1544,10 @@ class NodeScopeResolverTest extends \PHPStan\TestCase
 				'static(InstanceOfNamespace\Foo)',
 				'clone $static',
 			],
+			[
+				'mixed',
+				'$mixed',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/instanceof.php
+++ b/tests/PHPStan/Analyser/data/instanceof.php
@@ -14,6 +14,11 @@ class Foo
 		$bar = $foo;
 		$baz = doFoo();
 
+		$mixed = doFoo();
+		if ($mixed instanceof Foo) {
+
+		}
+
 		if ($baz instanceof Foo) {
 			// ...
 		} else {


### PR DESCRIPTION
cc @JanTvrdik can you try to fix it? I think the type of an expression should not be touched after an `if instanceof`.