### PR TITLE
Add support for number type

### DIFF
--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -66,6 +66,8 @@ class TypehintHelper
 			case $lowercasedTypehintString === 'float':
 			case $lowercasedTypehintString === 'double' && !$fromReflection:
 				return new FloatType();
+			case $lowercasedTypehintString === 'number' && !$fromReflection:
+				return new CommonUnionType([new IntegerType(), new FloatType()]);
 			case $lowercasedTypehintString === 'scalar' && !$fromReflection:
 				return new CommonUnionType([new IntegerType(), new FloatType(), new StringType(), new TrueOrFalseBooleanType()]);
 			case $lowercasedTypehintString === 'array':


### PR DESCRIPTION
There is a a little used meta type, ['number'][docs], which is the
union of int and float. It's not part of PHPDoc, however it is used in
[interfaces generated from the PHP SPL documentation][eg-1] and
[interfaces that offer polyfils][eg-2].

It's used in the PHP SPL for [NumberFormatter::format][format], possibly
other places too.

[eg-1]: https://github.com/JetBrains/phpstorm-stubs/blob/master/intl/intl.php#L920
[eg-2]: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php#L371
[format]: http://www.php.net/manual/en/numberformatter.format.php
[docs]: https://secure.php.net/manual/en/language.pseudo-types.php#language.types.number

