### PR TITLE
Exclude new sniffs from the Slevomat CS, which were not part of the standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"satooshi/php-coveralls": "^1.0",
 		"phing/phing": "^2.16.0",
 		"phpunit/phpunit": "^6.3",
-		"slevomat/coding-standard": "^3.1.1"
+		"slevomat/coding-standard": "^3.3.0"
 	},
 	"autoload": {
 		"psr-4": {"PHPStan\\": "src/"}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,6 +12,8 @@
 		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification"/>
 		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation.NonFullyQualifiedClassName"/>
+		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
+		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
 		<exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 	</rule>
 	<rule ref="Squiz.PHP.InnerFunctions.NotAllowed">


### PR DESCRIPTION
There are two new sniffs in the Slevomat CS repo as of [3.3.0](https://github.com/slevomat/coding-standard/releases/tag/3.3.0), which were not part of the standard, but there is AFAIK no easy way currently to exclude them from the standard, that is defining them.

More long term solution will require probably a major release in Slevomat CS.

This is currently breaking builds here, see for example #469:

https://travis-ci.org/phpstan/phpstan/jobs/268627720#L565