### PR TITLE
FileTypeMapper: fix type pattern to support class names with length 1

### DIFF
--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -11,7 +11,7 @@ class FileTypeMapper
 {
 
 	const CONST_FETCH_CONSTANT = '__PHPSTAN_CLASS_REFLECTION_CONSTANT__';
-	const TYPE_PATTERN = '((?:(?:\$this|\\??\\\?[0-9a-zA-Z_][0-9a-zA-Z_\\\]+)(?:\[\])*(?:\s*\|\s*)?)+)';
+	const TYPE_PATTERN = '((?:(?:\$this|\\??\\\?[0-9a-zA-Z_][0-9a-zA-Z_\\\]*+)(?:\[\])*(?:\s*\|\s*)?)+)';
 
 	/** @var \PHPStan\Parser\Parser */
 	private $parser;
@@ -33,7 +33,7 @@ class FileTypeMapper
 
 	public function getTypeMap(string $fileName): array
 	{
-		$cacheKey = sprintf('%s-%d-v7', $fileName, filemtime($fileName));
+		$cacheKey = sprintf('%s-%d-v8', $fileName, filemtime($fileName));
 		if (isset($this->memoryCache[$cacheKey])) {
 			return $this->memoryCache[$cacheKey];
 		}

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -17,6 +17,7 @@ class FileTypeMapperTest extends \PHPStan\TestCase
 
 		$expected = [
 			'int | float' => 'float|int',
+			'X' => 'X',
 			'void' => 'void',
 			'string' => 'string',
 			'?float' => 'float|null',

--- a/tests/PHPStan/Type/data/annotations.php
+++ b/tests/PHPStan/Type/data/annotations.php
@@ -2,6 +2,7 @@
 
 /**
  * @property int | float $numericBazBazProperty
+ * @property X $singleLetterObjectName
  *
  * @method void simpleMethod
  * @method string returningMethod()


### PR DESCRIPTION
minor fix, issue discovered when testing code provided by @Majkl578 