### PR TITLE
simplify and improve ImpossibleInstanceOfRule

### DIFF
--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -7,7 +7,7 @@ class ImpossibleInstanceOfRuleTest extends \PHPStan\Rules\AbstractRuleTest
 
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
-		return new ImpossibleInstanceOfRule($this->createBroker());
+		return new ImpossibleInstanceOfRule();
 	}
 
 	public function testInstantiation()
@@ -16,8 +16,16 @@ class ImpossibleInstanceOfRuleTest extends \PHPStan\Rules\AbstractRuleTest
 			[__DIR__ . '/data/impossible-instanceof.php'],
 			[
 				[
+					'Instanceof between ImpossibleInstanceOf\Lorem and ImpossibleInstanceOf\Lorem will always evaluate to true.',
+					59,
+				],
+				[
 					'Instanceof between ImpossibleInstanceOf\Ipsum and ImpossibleInstanceOf\Lorem will always evaluate to true.',
 					65,
+				],
+				[
+					'Instanceof between ImpossibleInstanceOf\Ipsum and ImpossibleInstanceOf\Ipsum will always evaluate to true.',
+					68,
 				],
 				[
 					'Instanceof between ImpossibleInstanceOf\Dolor and ImpossibleInstanceOf\Lorem will always evaluate to false.',


### PR DESCRIPTION
The tests will fail because in phpstan's own code base there are multiple places where `instanceof` always evaluates to true.