### PR TITLE
Allow paths and level be specified in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ The resolution priority is as such:
 [NEON file format](https://ne-on.org/) is very similar to YAML.
 All the following options are part of the `parameters` section.
 
+#### Configuration variables
+ - `%rootDir%` - root directory where PHPStan resides (i.e. `vendor/phpstan/phpstan` in Composer installation)
+ - `%currentWorkingDirectory%` - current working directory where PHPStan was executed
+
+#### Configuration options
+
+ - `tmpDir` - specifies the temporary directory used by PHPStan cache (defaults to `sys_get_temp_dir() . '/phpstan'`)
+ - `level` - specifies analysis level - if specified, `-l` option is not required
+ - `paths` - specifies analysed paths - if specified, paths are not required to be passed as arguments
+
 ### Autoloading
 
 PHPStan uses Composer autoloader so the easiest way how to autoload classes

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -65,6 +65,10 @@ class AnalyseApplication
 		bool $debug
 	): int
 	{
+		if (count($paths) === 0) {
+			throw new \InvalidArgumentException('At least one path must be specified to analyse.');
+		}
+
 		$errors = [];
 		$files = [];
 


### PR DESCRIPTION
This change allows level and paths be specified in custom configuration file, without the need to specify those as CLI option/argument.

Example:
```yaml
parameters:
    level: 5
    paths:
        - %currentWorkingDirectory%/src
```

It does **not** override arguments specified explicitly on input.

Tests should be green, I'll add more covering this change once this feature is given green.