### PR TITLE
Auto-discover phpstan.neon{,.dist} config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ vendor/bin/phpstan analyse -l 4 -c phpstan.neon src tests
 When using a custom project config file, you have to pass the `--level` (`-l`)
 option to `analyse` command (default value does not apply here).
 
+If you do not provide config file explicitly, PHPStan will look for
+files named `phpstan.neon` or `phpstan.neon.dist` in current directory.
+
+The resolution priority is as such:
+1. If config file is provided on command line, it is used.
+2. If config file `phpstan.neon` exists in current directory, it will be used.
+3. If config file `phpstan.neon.dist` exists in current directory, it will be used.
+4. If none of the above is true, no config will be used.
+
 [NEON file format](https://ne-on.org/) is very similar to YAML.
 All the following options are part of the `parameters` section.
 

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+use Nette\DI\Config\Loader;
+
+class Configurator extends \Nette\Configurator
+{
+
+	/** @var LoaderFactory */
+	private $loaderFactory;
+
+	public function __construct(LoaderFactory $loaderFactory)
+	{
+		$this->loaderFactory = $loaderFactory;
+
+		parent::__construct();
+	}
+
+	protected function createLoader(): Loader
+	{
+		return $this->loaderFactory->createLoader();
+	}
+
+}

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\DependencyInjection;
 
-use Nette\Configurator;
 use Nette\DI\Extensions\PhpExtension;
 use PHPStan\File\FileHelper;
 
@@ -37,7 +36,7 @@ class ContainerFactory
 		array $additionalConfigFiles
 	): \Nette\DI\Container
 	{
-		$configurator = new Configurator();
+		$configurator = new Configurator(new LoaderFactory());
 		$configurator->defaultExtensions = [
 			'php' => PhpExtension::class,
 			'extensions' => \Nette\DI\Extensions\ExtensionsExtension::class,

--- a/src/DependencyInjection/LoaderFactory.php
+++ b/src/DependencyInjection/LoaderFactory.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+use Nette\DI\Config\Adapters\NeonAdapter;
+use Nette\DI\Config\Loader;
+
+class LoaderFactory
+{
+
+	public function createLoader(): Loader
+	{
+		$loader = new Loader();
+		$loader->addAdapter('dist', NeonAdapter::class);
+
+		return $loader;
+	}
+
+}

--- a/tests/PHPStan/Command/AnalyseCommandTest.php
+++ b/tests/PHPStan/Command/AnalyseCommandTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command;
+
+use Symfony\Component\Console\Tester\CommandTester;
+
+class AnalyseCommandTest extends \PHPStan\Testing\TestCase
+{
+
+	/**
+	 * @param string $dir
+	 * @param string $file
+	 * @dataProvider autoDiscoveryPathsProvider
+	 */
+	public function testConfigurationAutoDiscovery(string $dir, string $file)
+	{
+		$originalDir = getcwd();
+		chdir($dir);
+
+		try {
+			$output = $this->runCommand(1);
+			$this->assertContains('Note: Using configuration file ' . $file . '.', $output);
+		} catch (\Throwable $e) {
+			chdir($originalDir);
+			throw $e;
+		}
+	}
+
+	/**
+	 * @return string[][]
+	 */
+	public static function autoDiscoveryPathsProvider(): array
+	{
+		return [
+			[
+				__DIR__ . '/test-autodiscover',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover' . DIRECTORY_SEPARATOR . 'phpstan.neon',
+			],
+			[
+				__DIR__ . '/test-autodiscover-dist',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-dist' . DIRECTORY_SEPARATOR . 'phpstan.neon.dist',
+			],
+			[
+				__DIR__ . '/test-autodiscover-priority',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-priority' . DIRECTORY_SEPARATOR . 'phpstan.neon',
+			],
+		];
+	}
+
+	private function runCommand(int $expectedStatusCode): string
+	{
+		$commandTester = new CommandTester(new AnalyseCommand());
+
+		$commandTester->execute([
+			'paths' => [__DIR__ . DIRECTORY_SEPARATOR . 'test'],
+		]);
+
+		$this->assertSame($expectedStatusCode, $commandTester->getStatusCode());
+
+		return $commandTester->getDisplay();
+	}
+
+}

--- a/tests/PHPStan/Command/test-autodiscover-dist/phpstan.neon.dist
+++ b/tests/PHPStan/Command/test-autodiscover-dist/phpstan.neon.dist
@@ -1,0 +1,1 @@
+parameters:

--- a/tests/PHPStan/Command/test-autodiscover-priority/phpstan.neon
+++ b/tests/PHPStan/Command/test-autodiscover-priority/phpstan.neon
@@ -1,0 +1,1 @@
+parameters:

--- a/tests/PHPStan/Command/test-autodiscover-priority/phpstan.neon.dist
+++ b/tests/PHPStan/Command/test-autodiscover-priority/phpstan.neon.dist
@@ -1,0 +1,1 @@
+parameters:

--- a/tests/PHPStan/Command/test-autodiscover/phpstan.neon
+++ b/tests/PHPStan/Command/test-autodiscover/phpstan.neon
@@ -1,0 +1,1 @@
+parameters:


### PR DESCRIPTION
Allow auto-discovery of phpstan.neon and phpstan.neon.dist files.

Closes #237.

Tests should be green, I'll add more covering this change once this feature is given green.