### PR TITLE
Fix glob patterns in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,11 +10,11 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
-[*.{xml}]
+[*.xml]
 indent_style = tab
 indent_size = 4
 
-[*.{neon}]
+[*.neon]
 indent_style = tab
 indent_size = 4
 
@@ -22,6 +22,6 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-[{composer.json}]
+[composer.json]
 indent_style = tab
 indent_size = 4


### PR DESCRIPTION
If a glob pattern contains braces (`{}`) and there isn't any comma in between them, the pattern isn't considered to be a list with only one item but braces are part of the expected string (see [editorconfig/editorconfig-core-test](https://github.com/editorconfig/editorconfig-core-test/tree/172eb8324225f09f3e331af26454a5b45e314edb/glob)). 

Therefore, `[*.{xml}]` matched eg. `foo.{xml}` but not `foo.xml` or `phpunit.xml`.