### PR TITLE
Failing test - misleading autoloading message

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -73,6 +73,13 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 		$this->assertCount(0, $errors);
 	}
 
+	public function testClassExtendingNotAutoloadedClass()
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/class-autoloading.php');
+		$this->assertCount(1, $errors);
+		$this->assertSame('Class PHPStan\Tests\Baz not found and could not be autoloaded.', $errors[0]->getMessage());
+	}
+
 	/**
 	 * @param string $file
 	 * @return \PHPStan\Analyser\Error[]

--- a/tests/PHPStan/Analyser/data/class-autoloading-2.php
+++ b/tests/PHPStan/Analyser/data/class-autoloading-2.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ClassAutoloading;
+
+class Bar extends \PHPStan\Tests\Baz
+{
+
+}

--- a/tests/PHPStan/Analyser/data/class-autoloading.php
+++ b/tests/PHPStan/Analyser/data/class-autoloading.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ClassAutoloading;
+
+class Foo extends Bar
+{
+
+}


### PR DESCRIPTION
In case of this class hierarchy:

```
ClassAutoloading\Foo
- extends ClassAutoloading\Bar
- extends \PHPStan\Tests\Baz // Baz is unknown by the autoloader
```

When trying to analyse `ClassAutoloading\Foo`, we're met with this error message:

```
Class ClassAutoloading\Foo was not found while trying to analyse it - autoloading is probably not configured properly.
```

But the message is misleading - autoloading is fine for `Foo`, the problem is in the parent class. The problem is somewhere around `Broker::hasClass/getClass()`. This problem was first discovered here: https://github.com/phpstan/phpstan/issues/540#issuecomment-343877712

cc @Majkl578 any idea how to fix this?