### PR TITLE
RFC: Support for "dynamic class" return type extensions

### DIFF
--- a/src/Type/DynamicClassReturnTypeExtension.php
+++ b/src/Type/DynamicClassReturnTypeExtension.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+interface DynamicClassReturnTypeExtension
+{
+
+	public function isClassSupported(string $class): bool;
+
+}


### PR DESCRIPTION
This PR is an RFC for allowing dynamic method return type extensions to *also* be dynamic about which classes they support.

This idea came about while implementing [eloquent/phpstan-phony](https://github.com/eloquent/phpstan-phony), which needed to support Phony's method of exposing one static API in multiple namespaces. Phony does this to simplify integration with different test runners; providing, for example, `Eloquent\Phony\Phpunit\Phony::mock()` and `Eloquent\Phony\Kahlan\Phony::mock()`.

Currently I have to use traits to implement multiple copies of the same PHPStan extension for each namespace. I also feel like I have to provide a neon configuration for each namespace rather than forcing users to install PHPStan extensions for the namespaces they're not using.

Using the implementation presented here, I would be able to [significantly reduce the complexity of eloquent/phpstan-phony](https://github.com/eloquent/phpstan-phony/compare/dynamic-class), both in terms of code complexity, and usage instructions for my users.

The implementation in this PR:

- Is backwards compatible with PHPStan `0.8.x`.
- Adds an optional interface that implementors can use to add "dynamic class" behavior to their extensions.
- Uses an `isClassSupported()` method to dynamically assess an extension's relevance to a particular class.
- Conditionally checks for "dynamic class" extensions to help alleviate some performance concerns.

This is definitely not the most performant solution possible. Another way to achieve what I want for Phony would be to implement something like `getAdditionalClasses()` instead of `isClassSupported()`. This would allow the broker to simply add more classes to the existing classname-to-extension map it keeps already.

Relates to #163 (in particular [this comment](https://github.com/phpstan/phpstan/issues/163#issuecomment-344546722)).

*P.S. I also got stuck on the complexity of the existing tests for dynamic return type extensions, and would love some help on that front.*