### PR TITLE
Trying to reproduce infinite recursion issue from #591

### DIFF
--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -481,6 +481,21 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 				UnionType::class,
 				'callable|RecursionCallable\Foo',
 			],
+			[
+				[
+					new IntersectionType([
+						new IterableIterableType(new ObjectType(\IterablesInfiniteRecursion\Bar::class)),
+						new ObjectType(\IterablesInfiniteRecursion\Unrelated::class),
+					]),
+					new IntersectionType([
+						new IterableIterableType(new ObjectType(\IterablesInfiniteRecursion\Bar::class)),
+						new ObjectType(\IterablesInfiniteRecursion\Foo::class),
+					]),
+				],
+				MixedType::class,
+				'mixed',
+			],
+
 		];
 	}
 

--- a/tests/PHPStan/Type/data/iterables-infinite-recursion-Bar.php
+++ b/tests/PHPStan/Type/data/iterables-infinite-recursion-Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace IterablesInfiniteRecursion;
+
+abstract class Bar extends Foo
+{
+
+}

--- a/tests/PHPStan/Type/data/iterables-infinite-recursion-Foo.php
+++ b/tests/PHPStan/Type/data/iterables-infinite-recursion-Foo.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace IterablesInfiniteRecursion;
+
+use RecursiveIterator;
+
+abstract class Foo implements RecursiveIterator
+{
+
+	/**
+	 * @return Bar
+	 */
+	public function current()
+	{
+		// TODO: Implement current() method.
+	}
+
+	public function next()
+	{
+		// TODO: Implement next() method.
+	}
+
+	public function key()
+	{
+		// TODO: Implement key() method.
+	}
+
+	public function valid()
+	{
+		// TODO: Implement valid() method.
+	}
+
+	public function rewind()
+	{
+		// TODO: Implement rewind() method.
+	}
+
+	public function hasChildren()
+	{
+		// TODO: Implement hasChildren() method.
+	}
+
+	public function getChildren()
+	{
+		// TODO: Implement getChildren() method.
+	}
+
+}

--- a/tests/PHPStan/Type/data/iterables-infinite-recursion-Unrelated.php
+++ b/tests/PHPStan/Type/data/iterables-infinite-recursion-Unrelated.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace IterablesInfiniteRecursion;
+
+class Unrelated
+{
+
+}


### PR DESCRIPTION
I'm trying to reproduce issue from #591. My findings:

* `Zend_Navigation_Page` extends `Zend_Navigation_Container`
* `Zend_Navigation_Container` implements `RecursiveIterator`
* `Zend_Navigation_Container::current()` returns `Zend_Navigation_Page `
* PHPStan gets into an infinite recursion while trying to do union of types: `"iterable(Zend_Navigation_Page[])&Zend_Config"` and `"iterable(Zend_Navigation_Page[])&Zend_Navigation_Container"` - possibly while analysing and simplifying phpDoc `Zend_Navigation_Page[]|Zend_Config|Zend_Navigation_Container`

The infinite recursion call stack is along the lines:

```
    0.1624    6723912  20. PHPStan\Type\FileTypeMapper->getTypeMap() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Reflection/Php/PhpClassReflectionExtension.php:133
    0.1624    6724248  21. PHPStan\Type\FileTypeMapper->createTypeMap() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/FileTypeMapper.php:42
    0.2002    8413248  22. PHPStan\Type\FileTypeMapper->processNodes() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/FileTypeMapper.php:142
    0.2002    8413248  23. PHPStan\Type\FileTypeMapper->processNodes() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/FileTypeMapper.php:236
    0.2008    8415816  24. PHPStan\Type\FileTypeMapper->processNodes() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/FileTypeMapper.php:232
    0.2040    8492976  25. PHPStan\Type\FileTypeMapper->processNodes() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/FileTypeMapper.php:236
    0.2040    8492976  26. PHPStan\Type\FileTypeMapper->PHPStan\Type\{closure}() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/FileTypeMapper.php:229
    0.2041    8493984  27. PHPStan\Type\FileTypeMapper->getTypeFromTypeString() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/FileTypeMapper.php:122
    0.2049    8556184  28. PHPStan\Type\TypeCombinator::union() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/FileTypeMapper.php:218
    0.2050    8556560  29. PHPStan\Type\IntersectionType->isSupersetOf() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/TypeCombinator.php:129
    0.2070    8591296  30. PHPStan\Type\ObjectType->isSupersetOf() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/IntersectionType.php:58
    0.2070    8591296  31. PHPStan\Type\IntersectionType->isSubsetOf() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/ObjectType.php:72
    0.2070    8591296  32. PHPStan\Type\ObjectType->isSupersetOf() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/IntersectionType.php:72
    0.2070    8591296  33. PHPStan\Type\IterableIterableType->isSubsetOf() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/ObjectType.php:72
    0.2070    8591352  34. PHPStan\Type\ObjectType->getIterableValueType() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/IterableIterableType.php:64
    0.2070    8591352  35. PHPStan\Reflection\ClassReflection->getNativeMethod() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Type/ObjectType.php:264
    0.2070    8591352  36. PHPStan\Reflection\Php\PhpClassReflectionExtension->getNativeMethod() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Reflection/ClassReflection.php:174
    0.2070    8591352  37. PHPStan\Reflection\Php\PhpClassReflectionExtension->createMethods() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Reflection/Php/PhpClassReflectionExtension.php:188
    0.2071    8596088  38. PHPStan\Type\FileTypeMapper->getTypeMap() /Users/ondrej/Downloads/freeze/vendor/phpstan/phpstan/src/Reflection/Php/PhpClassReflectionExtension.php:250
```

But I can't seem to reproduce this with a unit test of TypeCombinator. /cc @JanTvrdik do you have any ideas what I'm missing in order to reproduce this?