### PR TITLE
Change dynamic return type interface getClass() methods to be non-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ interface PropertyReflection
 {
 
 	public function getType(): Type;
-	
+
 	public function getDeclaringClass(): ClassReflection;
 
 	public function isStatic(): bool;
@@ -459,7 +459,7 @@ interface MethodReflection
 	public function isPrivate(): bool;
 
 	public function isPublic(): bool;
-	
+
 	public function getName(): string;
 
 	/**
@@ -510,7 +510,7 @@ use PHPStan\Reflection\MethodReflection;
 interface DynamicMethodReturnTypeExtension
 {
 
-	public static function getClass(): string;
+	public function getClass(): string;
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool;
 
@@ -522,7 +522,7 @@ interface DynamicMethodReturnTypeExtension
 And this is how you'd write the extension that correctly resolves the EntityManager::merge() return type:
 
 ```php
-public static function getClass(): string
+public function getClass(): string
 {
 	return \Doctrine\ORM\EntityManager::class;
 }
@@ -577,14 +577,14 @@ This project adheres to a [Contributor Code of Conduct](https://github.com/phpst
 
 ## Contributing
 
-Any contributions are welcome. 
+Any contributions are welcome.
 
 ### Building
 
 You can either run the whole build including linting and coding standards using
 
 `vendor/bin/phing`
- 
+
 or run only tests using
 
 `vendor/bin/phing tests`

--- a/build/PHPStan/Build/ServiceLocatorDynamicReturnTypeExtension.php
+++ b/build/PHPStan/Build/ServiceLocatorDynamicReturnTypeExtension.php
@@ -13,7 +13,7 @@ use PHPStan\Type\TypeCombinator;
 class ServiceLocatorDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
-	public static function getClass(): string
+	public function getClass(): string
 	{
 		return \Nette\DI\Container::class;
 	}

--- a/src/Type/DynamicMethodReturnTypeExtension.php
+++ b/src/Type/DynamicMethodReturnTypeExtension.php
@@ -9,7 +9,7 @@ use PHPStan\Reflection\MethodReflection;
 interface DynamicMethodReturnTypeExtension
 {
 
-	public static function getClass(): string;
+	public function getClass(): string;
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool;
 

--- a/src/Type/DynamicStaticMethodReturnTypeExtension.php
+++ b/src/Type/DynamicStaticMethodReturnTypeExtension.php
@@ -9,7 +9,7 @@ use PHPStan\Reflection\MethodReflection;
 interface DynamicStaticMethodReturnTypeExtension
 {
 
-	public static function getClass(): string;
+	public function getClass(): string;
 
 	public function isStaticMethodSupported(MethodReflection $methodReflection): bool;
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -2433,7 +2433,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 			[
 				new class() implements DynamicMethodReturnTypeExtension {
 
-					public static function getClass(): string
+					public function getClass(): string
 					{
 						return \DynamicMethodReturnTypesNamespace\EntityManager::class;
 					}
@@ -2466,7 +2466,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 			[
 				new class() implements DynamicStaticMethodReturnTypeExtension {
 
-					public static function getClass(): string
+					public function getClass(): string
 					{
 						return \DynamicMethodReturnTypesNamespace\EntityManager::class;
 					}


### PR DESCRIPTION
Relates to #593 and #163.

This PR changes the `getClass()` methods of the `DynamicFunctionReturnTypeExtension` and `DynamicStaticMethodReturnTypeExtension` interfaces to be non-static, which facilitates registration of the same extension for multiple class names via DI configuration.

Note that the build will fail because there is a dev dependency on `phpstan/phpstan-phpunit`, which implements these interfaces. I can't do much about that right now, because it's a circular dependency.

There's also some diff churn due to trailing whitespace, which my editor trims automatically. Let me know if this is a problem.