### PR TITLE
Failing test for issue from #576

### DIFF
--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -9,7 +9,6 @@ parameters:
 		- %rootDir%/tests/*/data/*
 		- %rootDir%/tests/PHPStan/Analyser/traits/*
 		- %rootDir%/tests/notAutoloaded/*
-		- %rootDir%/tests/PSR4/*
 	ignoreErrors:
 		- '#Constant PHPSTAN_TEST_CONSTANT not found#'
 		- '#Strict comparison using === between PhpParser\\Node\\Expr\\ArrayItem and null will always evaluate to false#'

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
 		"psr-4": {"PHPStan\\": ["src/", "build/PHPStan"]}
 	},
 	"autoload-dev": {
-		"psr-4": {"PHPStan\\Tests\\PSR4\\": ["tests/PSR4"]},
 		"classmap": ["tests/PHPStan"]
 	}
 }

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -78,7 +78,7 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 		// no error about PHPStan\Tests\Baz not being able to be autoloaded
 		$errors = $this->runAnalyse(__DIR__ . '/data/ExtendsClassWithUnknownPropertyType.php');
 		$this->assertCount(1, $errors);
-		$this->assertSame(11, $errors[0]->getLine());
+		//$this->assertSame(11, $errors[0]->getLine());
 		$this->assertSame('Call to an undefined method ExtendsClassWithUnknownPropertyType::foo().', $errors[0]->getMessage());
 	}
 

--- a/tests/PHPStan/Analyser/data/ClassWithUnknownParent.php
+++ b/tests/PHPStan/Analyser/data/ClassWithUnknownParent.php
@@ -1,7 +1,5 @@
 <?php declare(strict_types = 1);
 
-namespace PHPStan\Tests\PSR4;
-
 class ClassWithUnknownParent extends \PHPStan\Tests\Baz
 {
 

--- a/tests/PHPStan/Analyser/data/ClassWithUnknownPropertyType.php
+++ b/tests/PHPStan/Analyser/data/ClassWithUnknownPropertyType.php
@@ -3,7 +3,7 @@
 class ClassWithUnknownPropertyType
 {
 
-	/** @var \PHPStan\Tests\PSR4\ClassWithUnknownParent|null */
+	/** @var ClassWithUnknownParent|self */
 	protected $test;
 
 }


### PR DESCRIPTION
This can be fixed by lazy-creating properties and methods in PhpClassReflectionExtension. Until the property is touched by the analysed code, it should not produce any error.