### PR TITLE
Fix version shown in the PHAR

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"nikic/php-parser": "^3.1",
 		"symfony/console": "~3.2 || ~4.0",
 		"symfony/finder": "~3.2 || ~4.0",
-		"jean85/pretty-package-versions": "^1.0.2",
+		"jean85/pretty-package-versions": "^1.0.3",
 		"phpstan/phpdoc-parser": "^0.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
The original issue was reported in https://github.com/Jean85/pretty-package-versions/issues/3

Basically, the version shown in the PHAR was normalized, so `0.8.5.0` instead of the correct `0.8.5`. This version bump will fix the issue.