### PR TITLE
Use assertSame() instead of assertEquals() in tests

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4134,7 +4134,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 
 	private function assertTypeDescribe(string $expectedDescription, string $actualDescription, string $label = '')
 	{
-		$this->assertEquals(
+		$this->assertSame(
 			$expectedDescription,
 			$actualDescription,
 			$label

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -50,7 +50,7 @@ class CheckstyleErrorFormatterTest extends \PHPStan\Testing\TestCase
 		$outputStream = new StreamOutput(fopen('php://memory', 'w', false));
 		$style = new ErrorsConsoleStyle(new StringInput(''), $outputStream);
 
-		$this->assertEquals(1, $this->formatter->formatErrors($analysisResultMock, $style));
+		$this->assertSame(1, $this->formatter->formatErrors($analysisResultMock, $style));
 
 		rewind($outputStream->getStream());
 		$output = stream_get_contents($outputStream->getStream());
@@ -65,7 +65,7 @@ class CheckstyleErrorFormatterTest extends \PHPStan\Testing\TestCase
 </file>
 </checkstyle>
 ';
-		$this->assertEquals($expected, $output);
+		$this->assertSame($expected, $output);
 	}
 
 	/**
@@ -84,7 +84,7 @@ class CheckstyleErrorFormatterTest extends \PHPStan\Testing\TestCase
 		$outputStream = new StreamOutput(fopen('php://memory', 'w', false));
 		$style = new ErrorsConsoleStyle(new StringInput(''), $outputStream);
 
-		$this->assertEquals(0, $this->formatter->formatErrors($analysisResultMock, $style));
+		$this->assertSame(0, $this->formatter->formatErrors($analysisResultMock, $style));
 
 		rewind($outputStream->getStream());
 		$output = stream_get_contents($outputStream->getStream());
@@ -93,7 +93,7 @@ class CheckstyleErrorFormatterTest extends \PHPStan\Testing\TestCase
 <checkstyle>
 </checkstyle>
 ';
-		$this->assertEquals($expected, $output);
+		$this->assertSame($expected, $output);
 	}
 
 }

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -970,17 +970,17 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\Testing\Te
 				$method->getDeclaringClass()->getName(),
 				sprintf('Declaring class of method %s() does not match.', $methodName)
 			);
-			$this->assertEquals(
+			$this->assertSame(
 				$expectedMethodData['returnType'],
 				$method->getReturnType()->describe(),
 				sprintf('Return type of method %s::%s() does not match', $className, $methodName)
 			);
-			$this->assertEquals(
+			$this->assertSame(
 				$expectedMethodData['isStatic'],
 				$method->isStatic(),
 				sprintf('Scope of method %s::%s() does not match', $className, $methodName)
 			);
-			$this->assertEquals(
+			$this->assertSame(
 				$expectedMethodData['isVariadic'],
 				$method->isVariadic(),
 				sprintf('Method %s::%s() does not match expected variadicity', $className, $methodName)
@@ -991,23 +991,23 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\Testing\Te
 				sprintf('Method %s::%s() does not match expected count of parameters', $className, $methodName)
 			);
 			foreach ($method->getParameters() as $i => $parameter) {
-				$this->assertEquals(
+				$this->assertSame(
 					$expectedMethodData['parameters'][$i]['name'],
 					$parameter->getName()
 				);
-				$this->assertEquals(
+				$this->assertSame(
 					$expectedMethodData['parameters'][$i]['type'],
 					$parameter->getType()->describe()
 				);
-				$this->assertEquals(
+				$this->assertSame(
 					$expectedMethodData['parameters'][$i]['isPassedByReference'],
 					$parameter->isPassedByReference()
 				);
-				$this->assertEquals(
+				$this->assertSame(
 					$expectedMethodData['parameters'][$i]['isOptional'],
 					$parameter->isOptional()
 				);
-				$this->assertEquals(
+				$this->assertSame(
 					$expectedMethodData['parameters'][$i]['isVariadic'],
 					$parameter->isVariadic()
 				);


### PR DESCRIPTION
`assertEquals()` does not compare strictly, so it may hide bugs.