### PR TITLE
Make PHPStan a single command application

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -26,10 +26,12 @@ try {
 
 }
 
+$command = new AnalyseCommand();
 $application = new \Symfony\Component\Console\Application(
 	'PHPStan - PHP Static Analysis Tool',
 	$version
 );
 $application->setCatchExceptions(false);
-$application->add(new AnalyseCommand());
+$application->add($command);
+$application->setDefaultCommand($command->getName(), true);
 $application->run();


### PR DESCRIPTION
From:
```bash
$ vendor/bin/phpstan analyse -c phpstan.neon src/ tests/
```
To:
```bash
$ vendor/bin/phpstan -c phpstan.neon src/ tests/
```

With https://github.com/phpstan/phpstan/pull/508 and https://github.com/phpstan/phpstan/pull/509 this would enable to run PHPStan directly without options nor arguments.

#### WARNING

This is a BC Break since the added `analyse` word would be interpreted as a path instead of the command name.