### PR TITLE
Broker::hasClass bug proof on legit case

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -67,6 +67,12 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 		$this->assertSame('Class ExtendingUnknownClass\Bar not found and could not be autoloaded.', $errors[0]->getMessage());
 	}
 
+	public function testExtendingKnownClassWithCheck()
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/extending-known-class-with-check.php');
+		$this->assertCount(0, $errors);
+	}
+
 	public function testInfiniteRecursionWithCallable()
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/Foo-callable.php');

--- a/tests/PHPStan/Analyser/data/extending-known-class-with-check.php
+++ b/tests/PHPStan/Analyser/data/extending-known-class-with-check.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ExtendingKnownClassWithCheck;
+
+if (class_exists(Bar::class)) {
+    class Foo extends Bar
+    {}
+} else {
+    class Foo extends \Exception
+    {}
+}


### PR DESCRIPTION
Real case: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.10.0/tests/TestCase.php

The bug should be likely fixed here:
https://github.com/phpstan/phpstan/blob/5a23f084f89e7111980382ead9b77f4c29ac285a/src/Broker/Broker.php#L213-L217

- [x] Prove the bug
- [ ] Apply a fix: don't know how at the time of writing