### PR TITLE
Correctly report (class|interface|trait)_exists calls

### DIFF
--- a/src/Broker/Broker.php
+++ b/src/Broker/Broker.php
@@ -322,10 +322,7 @@ class Broker
 		return null;
 	}
 
-	/**
-	 * @return bool
-	 */
-	private function isExistsCheckCall()
+	private function isExistsCheckCall(): bool
 	{
 		$debugBacktrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
@@ -347,4 +344,5 @@ class Broker
 
 		return false;
 	}
+
 }

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\File\FileHelper;
+use PHPStan\Broker\Broker;
 
 class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 {
@@ -70,7 +71,11 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 	public function testExtendingKnownClassWithCheck()
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/extending-known-class-with-check.php');
-		$this->assertCount(0, $errors);
+		$this->assertCount(1, $errors);
+		$this->assertSame('Class ExtendingKnownClassWithCheck\Bar not found.', $errors[0]->getMessage());
+
+		$broker = $this->getContainer()->getByType(Broker::class);
+		$this->assertTrue($broker->hasClass(\ExtendingKnownClassWithCheck\Foo::class));
 	}
 
 	public function testInfiniteRecursionWithCallable()

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -2,8 +2,8 @@
 
 namespace PHPStan\Analyser;
 
-use PHPStan\File\FileHelper;
 use PHPStan\Broker\Broker;
+use PHPStan\File\FileHelper;
 
 class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 {

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -67,6 +67,12 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 		$this->assertSame('Class ExtendingUnknownClass\Bar not found and could not be autoloaded.', $errors[0]->getMessage());
 	}
 
+	public function testExtendingKnownClassWithCheck()
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/extending-known-class-with-check.php');
+		$this->assertCount(0, $errors);
+	}
+
 	public function testInfiniteRecursionWithCallable()
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/Foo-callable.php');

--- a/tests/PHPStan/Analyser/data/extending-known-class-with-check.php
+++ b/tests/PHPStan/Analyser/data/extending-known-class-with-check.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ExtendingKnownClassWithCheck;
+
+if (class_exists(Bar::class)) {
+    class Foo extends Bar
+    {}
+} else {
+    class Foo extends \Exception
+    {}
+}


### PR DESCRIPTION
Following https://github.com/phpstan/phpstan/pull/751 here's the solution. (I also messed up with git in https://github.com/phpstan/phpstan/pull/752 ...)

The `debug_backtrace` is called only when the class doesn't exists, so it is not called in a normal run.

If only I would have had more time, I could have pushed the commit in the original PR without spamming creating a new PR...