### PR TITLE
Report get_defined_functions correct

### DIFF
--- a/src/Reflection/FunctionReflection.php
+++ b/src/Reflection/FunctionReflection.php
@@ -223,6 +223,19 @@ class FunctionReflection implements ParametersAcceptorWithPhpDocs
 					true
 				);
 			}
+
+			if (
+				$this->reflection->getName() === 'get_defined_functions'
+			    && $this->reflection->getNumberOfRequiredParameters() === 1
+			    && count($this->parameters) === 1
+			) {
+				// PHP bug #75799
+				$this->parameters[0] = new DummyParameter(
+					'exclude_disabled',
+					new TrueOrFalseBooleanType(),
+					true
+				);
+			}
 		}
 
 		return $this->parameters;

--- a/tests/PHPStan/Rules/Functions/data/call-to-weird-functions.php
+++ b/tests/PHPStan/Rules/Functions/data/call-to-weird-functions.php
@@ -39,3 +39,6 @@ openssl_open('', $open, '', openssl_get_privatekey(''), 'foo', 'bar', 'baz'); //
 openssl_x509_parse('foo'); // OK
 openssl_x509_parse('foo', true); // OK
 openssl_x509_parse('foo', true, 'bar'); // should report 3 parameters given, 1-2 required
+
+get_defined_functions(); // OK for PHP <7.1.10
+get_defined_functions(true); // OK for PHP >7.1.10


### PR DESCRIPTION
[`get_defined_functions`](http://php.net/manual/en/function.get-defined-functions.php) has one parameter `$exclude_disabled` _optional_, not mandatory.

[Since PHP 7.1.10](https://3v4l.org/pRaFj), this is wrong.

Already discussed in #748 :+1: 