### PR TITLE
Fix type issues in src/Analyser

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -142,6 +142,8 @@ class Analyser
 			return $errors;
 		}
 
+		$errors = [];
+
 		$this->nodeScopeResolver->setAnalysedFiles($files);
 		$internalErrorsCount = 0;
 		$reachedInternalErrorsCountLimit = false;

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -115,8 +115,6 @@ class Analyser
 		bool $debug = false
 	): array
 	{
-		$errors = [];
-
 		if ($this->bootstrapFile !== null) {
 			if (!is_file($this->bootstrapFile)) {
 				return [
@@ -130,16 +128,18 @@ class Analyser
 			}
 		}
 
+		$regexErrors = [];
+
 		foreach ($this->ignoreErrors as $ignoreError) {
 			try {
 				\Nette\Utils\Strings::match('', $ignoreError);
 			} catch (\Nette\Utils\RegexpException $e) {
-				$errors[] = $e->getMessage();
+				$regexErrors[] = $e->getMessage();
 			}
 		}
 
-		if (count($errors) > 0) {
-			return $errors;
+		if (count($regexErrors) > 0) {
+			return $regexErrors;
 		}
 
 		$errors = [];

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -97,7 +97,7 @@ class NodeScopeResolver
 	private $anonymousClassReflection;
 
 	/** @var bool[] filePath(string) => bool(true) */
-	private $analysedFiles;
+	private $analysedFiles = [];
 
 	public function __construct(
 		Broker $broker,
@@ -122,6 +122,8 @@ class NodeScopeResolver
 
 	/**
 	 * @param string[] $files
+	 *
+	 * @return void
 	 */
 	public function setAnalysedFiles(array $files)
 	{
@@ -133,6 +135,8 @@ class NodeScopeResolver
 	 * @param \PHPStan\Analyser\Scope $scope
 	 * @param \Closure $nodeCallback
 	 * @param \PHPStan\Analyser\Scope $closureBindScope
+	 *
+	 * @return void
 	 */
 	public function processNodes(
 		array $nodes,
@@ -150,6 +154,8 @@ class NodeScopeResolver
 			if ($scope->getInFunctionCall() !== null && $node instanceof Arg) {
 				$functionCall = $scope->getInFunctionCall();
 				$value = $node->value;
+
+				assert($functionCall !== null);
 
 				$parametersAcceptor = $this->findParametersAcceptorInFunctionCall($functionCall, $scope);
 
@@ -232,7 +238,7 @@ class NodeScopeResolver
 				&& $node->name instanceof Name
 				&& $this->broker->resolveFunctionName($node->name, $scope) === 'property_exists'
 				&& count($node->args) === 2
-				&& $node->args[1]->value instanceof  Node\Scalar\String_
+				&& $node->args[1]->value instanceof Node\Scalar\String_
 			) {
 				$scope = $scope->specifyFetchedPropertyFromIsset(
 					new PropertyFetch($node->args[0]->value, $node->args[1]->value->value)
@@ -363,6 +369,7 @@ class NodeScopeResolver
 					$scopeClass = $argValueType->getReferencedClasses()[0];
 				} elseif (
 					$argValue instanceof Expr\ClassConstFetch
+					&& is_string($argValue->name)
 					&& strtolower($argValue->name) === 'class'
 					&& $argValue->class instanceof Name
 				) {
@@ -522,6 +529,7 @@ class NodeScopeResolver
 						$switchConditionGetClassExpression !== null
 						&& $caseNode->cond instanceof Expr\ClassConstFetch
 						&& $caseNode->cond->class instanceof Name
+						&& is_string($caseNode->cond->name)
 						&& strtolower($caseNode->cond->name) === 'class'
 					) {
 						$caseScope = $caseScope->specifyExpressionType(
@@ -793,11 +801,7 @@ class NodeScopeResolver
 				if ($listItem === null) {
 					continue;
 				}
-				$listItemValue = $listItem;
-				if ($listItemValue instanceof Expr\ArrayItem) {
-					$listItemValue = $listItemValue->value;
-				}
-				$scope = $this->lookForEnterVariableAssign($scope, $listItemValue);
+				$scope = $this->lookForEnterVariableAssign($scope, $listItem->value);
 			}
 		} else {
 			$scope = $scope->enterExpressionAssign($node);
@@ -1388,11 +1392,16 @@ class NodeScopeResolver
 	 * @param string $traitName
 	 * @param \PHPStan\Analyser\Scope $classScope
 	 * @param \Closure $nodeCallback
+	 *
+	 * @return void
 	 */
 	private function processNodesForTraitUse($node, string $traitName, Scope $classScope, \Closure $nodeCallback)
 	{
 		if ($node instanceof Node) {
-			if ($node instanceof Node\Stmt\Trait_ && $traitName === (string) $node->namespacedName) {
+			if ($node instanceof Node\Stmt\Trait_
+				&& isset($node->namespacedName)
+				&& $traitName === (string) $node->namespacedName
+			) {
 				$this->processNodes($node->stmts, $classScope->enterFirstLevelStatements(), $nodeCallback);
 				return;
 			}
@@ -1425,8 +1434,9 @@ class NodeScopeResolver
 	{
 		$phpDocParameterTypes = [];
 		$phpDocReturnType = null;
-		if ($functionLike->getDocComment() !== null) {
-			$docComment = $functionLike->getDocComment()->getText();
+		$docComment = $functionLike->getDocComment();
+		if ($docComment !== null) {
+			$docComment = $docComment->getText();
 			$file = $scope->getFile();
 			$class = $scope->isInClass() ? $scope->getClassReflection()->getName() : null;
 			if ($functionLike instanceof Node\Stmt\ClassMethod) {
@@ -1450,7 +1460,8 @@ class NodeScopeResolver
 			$phpDocParameterTypes = array_map(function (ParamTag $tag): Type {
 				return $tag->getType();
 			}, $resolvedPhpDoc->getParamTags());
-			$phpDocReturnType = $resolvedPhpDoc->getReturnTag() !== null ? $resolvedPhpDoc->getReturnTag()->getType() : null;
+			$resolvedPhpDocReturnTag = $resolvedPhpDoc->getReturnTag();
+			$phpDocReturnType = $resolvedPhpDocReturnTag !== null ? $resolvedPhpDocReturnTag->getType() : null;
 		}
 
 		return [$phpDocParameterTypes, $phpDocReturnType];

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -151,11 +151,9 @@ class NodeScopeResolver
 				continue;
 			}
 
-			if ($scope->getInFunctionCall() !== null && $node instanceof Arg) {
-				$functionCall = $scope->getInFunctionCall();
+			$functionCall = $scope->getInFunctionCall();
+			if ($functionCall !== null && $node instanceof Arg) {
 				$value = $node->value;
-
-				assert($functionCall !== null);
 
 				$parametersAcceptor = $this->findParametersAcceptorInFunctionCall($functionCall, $scope);
 

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -782,7 +782,7 @@ class Scope
 			} elseif ($originalClass === 'parent') {
 				$currentClassReflection = $this->getClassReflection();
 				$parentClassReflection = $currentClassReflection->getParentClass();
-				if ($parentClassReflection instanceof \ReflectionClass) {
+				if ($parentClassReflection instanceof ClassReflection) {
 					return $parentClassReflection->getName();
 				}
 			}
@@ -1123,7 +1123,7 @@ class Scope
 			) {
 				if ($this->isInClass()) {
 					$parentReflectionClass = $this->getClassReflection()->getParentClass();
-					if ($parentReflectionClass instanceof \ReflectionClass) {
+					if ($parentReflectionClass instanceof ClassReflection) {
 						return new ObjectType($parentReflectionClass->getName());
 					}
 				}


### PR DESCRIPTION
This fixes some impossible null conditions since https://github.com/phpstan/phpstan/commit/276046ac9bbd898b0846d72102bd4abb30b828c5 and converts
```php
if ($a->foo()) {
  $this->bar($a->foo());
}
```
to
```php
$aFoo = $a->foo();
if ($aFoo) {
  $this->bar($aFoo);
}
```
where `$this->bar()` requires a non-null value.

in src/Analyser