### PR TITLE
refs #TECH: declare php extensions required in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
 		"phpstan/phpdoc-parser": "^0.2"
 	},
 	"require-dev": {
+		"ext-intl": "*",
+		"ext-gd": "*",
+		"ext-mysqli": "*",
 		"consistence/coding-standard": "2.2.1",
 		"jakub-onderka/php-parallel-lint": "^0.9.2",
 		"phing/phing": "^2.16.0",


### PR DESCRIPTION
PHPStan require some php extension to execute tests:

 - `locale_get_display_language`
 - `mysqli_fetch_all`
 - `imagepng`

Some of them should be missing (due to missing php extensions) and tests fails.

Adding:
 - `ext-gd`
 - `ext-intl`
 - `ext-mysqli`

into `composer.json` (`require-dev` section) allow users to know that are required in order to run tests.