### PR TITLE
PHPUnit 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"phpstan/phpstan-php-parser": "^0.10",
 		"phpstan/phpstan-phpunit": "^0.10",
 		"phpstan/phpstan-strict-rules": "^0.10",
-		"phpunit/phpunit": "^6.5.4",
+		"phpunit/phpunit": "^7.0",
 		"slevomat/coding-standard": "4.0.0"
 	},
 	"autoload": {


### PR DESCRIPTION
PHPUnit 7[ has just released](https://phpunit.de/announcements/phpunit-7.html), fully optimized for PHP 7, requiring minimum PHP 7.1