### PR TITLE
Fixed openssl_pkcs12_export - fifth parameter is optional

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -168,6 +168,10 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Function openssl_x509_parse invoked with 3 parameters, 1-2 required.',
 				41,
 			],
+			[
+				'Function openssl_pkcs12_export invoked with 6 parameters, 4-5 required.',
+				47,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/data/call-to-weird-functions.php
+++ b/tests/PHPStan/Rules/Functions/data/call-to-weird-functions.php
@@ -41,3 +41,7 @@ openssl_x509_parse('foo', true); // OK
 openssl_x509_parse('foo', true, 'bar'); // should report 3 parameters given, 1-2 required
 
 get_defined_functions(); // OK for PHP <7.1.10
+
+openssl_pkcs12_export('signed-csr', $output, 'private-key', 'password'); // OK
+openssl_pkcs12_export('signed-csr', $output, 'private-key', 'password', ['friendlyname' => 'name']); // OK
+openssl_pkcs12_export('signed-csr', $output, 'private-key', 'password', ['friendlyname' => 'name'], 'bar');  // should report 6 parameters given, 4-5 required


### PR DESCRIPTION
This PR

 * [x] fix `openssl_pkcs12_export` - fifth parameter is optional

For reference: http://php.net/manual/en/function.openssl-pkcs12-export.php