### PR TITLE
Allow early terminating static calls

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1306,12 +1306,19 @@ class NodeScopeResolver
 			|| $statement instanceof Exit_
 		) {
 			return $statement;
-		} elseif ($statement instanceof MethodCall && count($this->earlyTerminatingMethodCalls) > 0) {
+		} elseif (($statement instanceof MethodCall || $statement instanceof Expr\StaticCall) && count($this->earlyTerminatingMethodCalls) > 0) {
 			if (!is_string($statement->name)) {
 				return null;
 			}
 
-			$methodCalledOnType = $scope->getType($statement->var);
+			if ($statement instanceof MethodCall) {
+				$methodCalledOnType = $scope->getType($statement->var);
+			} elseif ($statement instanceof Expr\StaticCall) {
+				$methodCalledOnType = $scope->getFunctionType($statement->class, false, false);
+			} else {
+				return null;
+			}
+
 			foreach ($methodCalledOnType->getReferencedClasses() as $referencedClass) {
 				if (!$this->broker->hasClass($referencedClass)) {
 					continue;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1314,7 +1314,13 @@ class NodeScopeResolver
 			if ($statement instanceof MethodCall) {
 				$methodCalledOnType = $scope->getType($statement->var);
 			} elseif ($statement instanceof Expr\StaticCall) {
-				$methodCalledOnType = $scope->getFunctionType($statement->class, false, false);
+				if ($statement->class instanceof Name) {
+					$methodCalledOnType = $scope->getFunctionType($statement->class, false, false);
+				} elseif ($statement->class instanceof Expr) {
+					$methodCalledOnType = $scope->getType($statement->class);
+				} else {
+					return null;
+				}
 			} else {
 				return null;
 			}

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -1098,7 +1098,7 @@ class Scope
 			return new ArrayType(new MixedType(), new MixedType());
 		} elseif ($type instanceof Name) {
 			$className = (string) $type;
-			if ($className === 'self') {
+			if ($className === 'self' || $className === 'static') {
 				$className = $this->getClassReflection()->getName();
 			} elseif (
 				$className === 'parent'

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4208,6 +4208,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 			[
 				\EarlyTermination\Foo::class => [
 					'doFoo',
+					'doBar',
 				],
 			]
 		);

--- a/tests/PHPStan/Analyser/data/early-termination-defined.php
+++ b/tests/PHPStan/Analyser/data/early-termination-defined.php
@@ -4,6 +4,10 @@ namespace EarlyTermination;
 
 class Foo
 {
+	public static function doBar()
+	{
+		throw new \Exception();
+	}
 
 	public function doFoo()
 	{

--- a/tests/PHPStan/Analyser/data/early-termination.php
+++ b/tests/PHPStan/Analyser/data/early-termination.php
@@ -7,7 +7,12 @@ if ($something % 2 === 0) {
 	$var = true;
 } else {
 	$foo = new Bar();
-	$foo->doFoo();
+
+	if ($something <= 5) {
+		Bar::doBar();
+	} else {
+		$foo->doFoo();
+	}
 }
 
 die;


### PR DESCRIPTION
While trying to get phpstan to register a static call to `PHPUnit\Framework\TestCase::fail` as an early terminating method, I realised that it just ignores all static methods for early termination. By the time I understood the source enough to realise I could have just called the static method dynamically, I'd already spent a while on it and figured I might as well update the source to support static methods.

I've updated the tests to include a check for a static early terminating function, and also tested it in my own project and everything seems to be working well.