### PR TITLE
Micro-optimisation to prevent excessive memory allocation

### DIFF
--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -104,7 +104,7 @@ class TrinaryLogic
 
 	public function describe(): string
 	{
-		$labels = [
+		static $labels = [
 			self::NO => 'No',
 			self::MAYBE => 'Maybe',
 			self::YES => 'Yes',


### PR DESCRIPTION
I've tried to run PHPStan on Drupal 8 codebase and my laptop dies.
I am suspecting it ran out of memory and I know the code base has never been tested with the tool, so there are likly many errors.

I saw that the tool was running without a garbage collection.
So this is a small step to improve my particular memory usage problems.

**Offtopics:** 
Why the GC is disabled?
Is there a runtime option to enable it?