### PR TITLE
Improve error message for command not found

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -2,6 +2,7 @@
 <?php declare(strict_types=1);
 
 use PHPStan\Command\AnalyseCommand;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
 
 gc_disable(); // performance boost
 
@@ -32,4 +33,8 @@ $application = new \Symfony\Component\Console\Application(
 );
 $application->setCatchExceptions(false);
 $application->add(new AnalyseCommand());
-$application->run();
+try {
+    $application->run();
+} catch (CommandNotFoundException $exception) {
+    echo $exception->getMessage()."\n";
+}


### PR DESCRIPTION
With this branch the error message become:
```
./bin/phpstan asd
Command "asd" is not defined.
```

Before was something like:
```
./bin/phpstan asd
PHP Fatal error:  Uncaught Symfony\Component\Console\Exception\CommandNotFoundException: Command "asd" is not defined. in /Users/fain182/Documents/OpenSource/phpstan/vendor/symfony/console/Application.php:611
Stack trace:
#0 /Users/fain182/Documents/OpenSource/phpstan/vendor/symfony/console/Application.php(224): Symfony\Component\Console\Application->find('asd')
#1 /Users/fain182/Documents/OpenSource/phpstan/vendor/symfony/console/Application.php(143): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /Users/fain182/Documents/OpenSource/phpstan/bin/phpstan(35): Symfony\Component\Console\Application->run()
#3 {main}
  thrown in /Users/fain182/Documents/OpenSource/phpstan/vendor/symfony/console/Application.php on line 611

Fatal error: Uncaught Symfony\Component\Console\Exception\CommandNotFoundException: Command "asd" is not defined. in /Users/fain182/Documents/OpenSource/phpstan/vendor/symfony/console/Application.php:611
Stack trace:
#0 /Users/fain182/Documents/OpenSource/phpstan/vendor/symfony/console/Application.php(224): Symfony\Component\Console\Application->find('asd')
#1 /Users/fain182/Documents/OpenSource/phpstan/vendor/symfony/console/Application.php(143): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /Users/fain182/Documents/OpenSource/phpstan/bin/phpstan(35): Symfony\Component\Console\Application->run()
#3 {main}
  thrown in /Users/fain182/Documents/OpenSource/phpstan/vendor/symfony/console/Application.php on line 611
```