### PR TITLE
Fix missing version check on unpack test

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -176,6 +176,9 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 	 */
 	public function testUnpackOnAfter711(): void
 	{
+		if (PHP_VERSION_ID < 70101) {
+			$this->markTestSkipped('This test requires PHP >= 7.1.1');
+		}
 		$this->analyse([__DIR__ . '/data/unpack.php'], [
 			[
 				'Function unpack invoked with 0 parameters, 2-3 required.',


### PR DESCRIPTION
With commit https://github.com/phpstan/phpstan/commit/24894eb the check for `unpack` response error is splitted on two different test for PHP < 7.1.1 and PHP >= 7.1.1 but the version check condition is missing in one test.

We have failure on master and all branches that we generate from it, see: 
 - https://ci.appveyor.com/project/ondrejmirtes/phpstan/build/1225/job/baub4tyma3rqwisn#L244
 - https://ci.appveyor.com/project/ondrejmirtes/phpstan/build/1224/job/uw5oi1u34m8oped8#L244
 - ...