### PR TITLE
 Extract testing helper

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -2,42 +2,25 @@
 
 namespace PHPStan\Testing;
 
+use Nette\DI\Container;
 use PHPStan\Broker\Broker;
-use PHPStan\Broker\BrokerFactory;
-use PHPStan\Cache\Cache;
-use PHPStan\Cache\MemoryCacheStorage;
 use PHPStan\DependencyInjection\ContainerFactory;
 use PHPStan\File\FileHelper;
-use PHPStan\Parser\FunctionCallStatementFinder;
 use PHPStan\Parser\Parser;
-use PHPStan\PhpDoc\PhpDocStringResolver;
-use PHPStan\PhpDoc\TypeStringResolver;
-use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
-use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
-use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\FunctionReflectionFactory;
-use PHPStan\Reflection\Php\PhpClassReflectionExtension;
-use PHPStan\Reflection\Php\PhpFunctionReflection;
-use PHPStan\Reflection\Php\PhpMethodReflection;
-use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
-use PHPStan\Reflection\Php\UniversalObjectCratesClassReflectionExtension;
-use PHPStan\Reflection\PhpDefect\PhpDefectClassReflectionExtension;
-use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
-use PHPStan\Type\FileTypeMapper;
-use PHPStan\Type\Type;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
 
-	/**
-	 * @var \Nette\DI\Container
-	 */
+	/** @var Container */
 	private static $container;
 
-	public function getContainer(): \Nette\DI\Container
+	/** @var TestingKit */
+	protected $testingKit;
+
+	public function getContainer(): Container
 	{
 		if (self::$container === null) {
-			$rootDir = __DIR__ . '/../..';
+			$rootDir = $this->getRootDir();
 			$containerFactory = new ContainerFactory($rootDir);
 			self::$container = $containerFactory->create($rootDir . '/tmp', [
 				$containerFactory->getConfigDirectory() . '/config.level7.neon',
@@ -47,141 +30,35 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 		return self::$container;
 	}
 
-	public function getParser(): \PHPStan\Parser\Parser
+	protected function getRootDir(): string
 	{
-		/** @var \PHPStan\Parser\Parser $parser */
-		$parser = $this->getContainer()->getService('directParser');
-		return $parser;
+		return __DIR__ . '/../..';
 	}
 
-	/**
-	 * @param \PHPStan\Type\DynamicMethodReturnTypeExtension[] $dynamicMethodReturnTypeExtensions
-	 * @param \PHPStan\Type\DynamicStaticMethodReturnTypeExtension[] $dynamicStaticMethodReturnTypeExtensions
-	 * @return \PHPStan\Broker\Broker
-	 */
+	protected function setUp(): void
+	{
+		$this->testingKit = new TestingKit($this->getContainer());
+	}
+
 	public function createBroker(
 		array $dynamicMethodReturnTypeExtensions = [],
 		array $dynamicStaticMethodReturnTypeExtensions = []
 	): Broker
 	{
-		$functionCallStatementFinder = new FunctionCallStatementFinder();
-		$parser = $this->getParser();
-		$cache = new Cache(new MemoryCacheStorage());
-		$methodReflectionFactory = new class($parser, $functionCallStatementFinder, $cache) implements PhpMethodReflectionFactory {
-			/** @var \PHPStan\Parser\Parser */
-			private $parser;
-
-			/** @var \PHPStan\Parser\FunctionCallStatementFinder */
-			private $functionCallStatementFinder;
-
-			/** @var \PHPStan\Cache\Cache */
-			private $cache;
-
-			/** @var \PHPStan\Broker\Broker */
-			public $broker;
-
-			public function __construct(
-				Parser $parser,
-				FunctionCallStatementFinder $functionCallStatementFinder,
-				Cache $cache
-			)
-			{
-				$this->parser = $parser;
-				$this->functionCallStatementFinder = $functionCallStatementFinder;
-				$this->cache = $cache;
-			}
-
-			public function create(
-				ClassReflection $declaringClass,
-				\ReflectionMethod $reflection,
-				array $phpDocParameterTypes,
-				Type $phpDocReturnType = null
-			): PhpMethodReflection
-			{
-				return new PhpMethodReflection(
-					$declaringClass,
-					$reflection,
-					$this->broker,
-					$this->parser,
-					$this->functionCallStatementFinder,
-					$this->cache,
-					$phpDocParameterTypes,
-					$phpDocReturnType
-				);
-			}
-		};
-		$phpDocStringResolver = $this->getContainer()->getByType(PhpDocStringResolver::class);
-		$fileTypeMapper = new FileTypeMapper($parser, $phpDocStringResolver, $cache);
-		$annotationsPropertiesClassReflectionExtension = new AnnotationsPropertiesClassReflectionExtension($fileTypeMapper);
-		$signatureMapProvider = $this->getContainer()->getByType(SignatureMapProvider::class);
-		$phpExtension = new PhpClassReflectionExtension($methodReflectionFactory, $fileTypeMapper, new AnnotationsMethodsClassReflectionExtension($fileTypeMapper), $annotationsPropertiesClassReflectionExtension, $signatureMapProvider);
-		$functionReflectionFactory = new class($this->getParser(), $functionCallStatementFinder, $cache) implements FunctionReflectionFactory {
-			/** @var \PHPStan\Parser\Parser */
-			private $parser;
-
-			/** @var \PHPStan\Parser\FunctionCallStatementFinder */
-			private $functionCallStatementFinder;
-
-			/** @var \PHPStan\Cache\Cache */
-			private $cache;
-
-			public function __construct(
-				Parser $parser,
-				FunctionCallStatementFinder $functionCallStatementFinder,
-				Cache $cache
-			)
-			{
-				$this->parser = $parser;
-				$this->functionCallStatementFinder = $functionCallStatementFinder;
-				$this->cache = $cache;
-			}
-
-			public function create(
-				\ReflectionFunction $function,
-				array $phpDocParameterTypes,
-				Type $phpDocReturnType = null
-			): PhpFunctionReflection
-			{
-				return new PhpFunctionReflection(
-					$function,
-					$this->parser,
-					$this->functionCallStatementFinder,
-					$this->cache,
-					$phpDocParameterTypes,
-					$phpDocReturnType
-				);
-			}
-		};
-
-		$tagToService = function (array $tags) {
-			return array_map(function (string $serviceName) {
-				return $this->getContainer()->getService($serviceName);
-			}, array_keys($tags));
-		};
-
-		$broker = new Broker(
-			[
-				$phpExtension,
-				$annotationsPropertiesClassReflectionExtension,
-				new UniversalObjectCratesClassReflectionExtension([\stdClass::class]),
-				new PhpDefectClassReflectionExtension($this->getContainer()->getByType(TypeStringResolver::class)),
-			],
-			[$phpExtension],
+		return $this->testingKit->createBroker(
 			$dynamicMethodReturnTypeExtensions,
-			$dynamicStaticMethodReturnTypeExtensions,
-			$tagToService($this->getContainer()->findByTag(BrokerFactory::DYNAMIC_FUNCTION_RETURN_TYPE_EXTENSION_TAG)),
-			$functionReflectionFactory,
-			new FileTypeMapper($this->getParser(), $phpDocStringResolver, $cache),
-			$signatureMapProvider
+			$dynamicStaticMethodReturnTypeExtensions
 		);
-		$methodReflectionFactory->broker = $broker;
+	}
 
-		return $broker;
+	public function getParser(): Parser
+	{
+		return $this->testingKit->getParser();
 	}
 
 	public function getFileHelper(): FileHelper
 	{
-		return $this->getContainer()->getByType(FileHelper::class);
+		return $this->testingKit->getFileHelper();
 	}
 
 }

--- a/src/Testing/TestingKit.php
+++ b/src/Testing/TestingKit.php
@@ -1,0 +1,254 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Testing;
+
+use Nette\DI\Container;
+use PhpParser\PrettyPrinter\Standard;
+use PHPStan\Analyser\Analyser;
+use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Broker\Broker;
+use PHPStan\Broker\BrokerFactory;
+use PHPStan\Cache\Cache;
+use PHPStan\Cache\MemoryCacheStorage;
+use PHPStan\File\FileHelper;
+use PHPStan\Parser\FunctionCallStatementFinder;
+use PHPStan\Parser\Parser;
+use PHPStan\PhpDoc\PhpDocStringResolver;
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
+use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionReflectionFactory;
+use PHPStan\Reflection\Php\PhpClassReflectionExtension;
+use PHPStan\Reflection\Php\PhpFunctionReflection;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
+use PHPStan\Reflection\Php\UniversalObjectCratesClassReflectionExtension;
+use PHPStan\Reflection\PhpDefect\PhpDefectClassReflectionExtension;
+use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
+use PHPStan\Rules\Registry;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\FileTypeMapper;
+use PHPStan\Type\Type;
+
+final class TestingKit
+{
+
+	/** @var Container  */
+	private $container;
+
+	public function __construct(Container $container)
+	{
+		$this->container = $container;
+	}
+
+	public function getAnalyser(
+		Rule $rule,
+		Cache $cache,
+		bool $shouldPolluteScopeWithLoopInitialAssignments = false,
+		bool $shouldPolluteCatchScopeWithTryAssignments = false
+	): Analyser
+	{
+		$registry = new Registry([$rule]);
+		$broker = $this->createBroker();
+		$printer = new Standard();
+		$fileHelper = $this->getFileHelper();
+		$typeSpecifier = new TypeSpecifier($printer);
+
+		return new Analyser(
+			$broker,
+			$this->getParser(),
+			$registry,
+			new NodeScopeResolver(
+				$broker,
+				$this->getParser(),
+				$printer,
+				new FileTypeMapper(
+					$this->getParser(),
+					$this->getPhpDocStringResolver(),
+					$cache
+				),
+				$fileHelper,
+				$shouldPolluteScopeWithLoopInitialAssignments,
+				$shouldPolluteCatchScopeWithTryAssignments,
+				[]
+			),
+			$printer,
+			$typeSpecifier,
+			$fileHelper,
+			[],
+			null,
+			true,
+			50
+		);
+	}
+
+	/**
+	 * @param \PHPStan\Type\DynamicMethodReturnTypeExtension[] $dynamicMethodReturnTypeExtensions
+	 * @param \PHPStan\Type\DynamicStaticMethodReturnTypeExtension[] $dynamicStaticMethodReturnTypeExtensions
+	 * @return \PHPStan\Broker\Broker
+	 */
+	public function createBroker(
+		array $dynamicMethodReturnTypeExtensions = [],
+		array $dynamicStaticMethodReturnTypeExtensions = []
+	): Broker
+	{
+		$functionCallStatementFinder = new FunctionCallStatementFinder();
+		$parser = $this->getParser();
+		$cache = new Cache(new MemoryCacheStorage());
+		$methodReflectionFactory = new class($parser, $functionCallStatementFinder, $cache) implements PhpMethodReflectionFactory {
+			/** @var \PHPStan\Parser\Parser */
+			private $parser;
+
+			/** @var \PHPStan\Parser\FunctionCallStatementFinder */
+			private $functionCallStatementFinder;
+
+			/** @var \PHPStan\Cache\Cache */
+			private $cache;
+
+			/** @var \PHPStan\Broker\Broker */
+			public $broker;
+
+			public function __construct(
+				Parser $parser,
+				FunctionCallStatementFinder $functionCallStatementFinder,
+				Cache $cache
+			)
+			{
+				$this->parser = $parser;
+				$this->functionCallStatementFinder = $functionCallStatementFinder;
+				$this->cache = $cache;
+			}
+
+			public function create(
+				ClassReflection $declaringClass,
+				\ReflectionMethod $reflection,
+				array $phpDocParameterTypes,
+				Type $phpDocReturnType = null
+			): PhpMethodReflection
+			{
+				return new PhpMethodReflection(
+					$declaringClass,
+					$reflection,
+					$this->broker,
+					$this->parser,
+					$this->functionCallStatementFinder,
+					$this->cache,
+					$phpDocParameterTypes,
+					$phpDocReturnType
+				);
+			}
+		};
+
+		$phpDocStringResolver = $this->getPhpDocStringResolver();
+		$fileTypeMapper = new FileTypeMapper($parser, $phpDocStringResolver, $cache);
+		$annotationsPropertiesClassReflectionExtension = new AnnotationsPropertiesClassReflectionExtension($fileTypeMapper);
+		$phpExtension = new PhpClassReflectionExtension(
+			$methodReflectionFactory,
+			$fileTypeMapper,
+			new AnnotationsMethodsClassReflectionExtension($fileTypeMapper),
+			$annotationsPropertiesClassReflectionExtension,
+			$this->getSignatureMapProvider()
+		);
+
+		$functionReflectionFactory = new class($this->getParser(), $functionCallStatementFinder, $cache) implements FunctionReflectionFactory {
+			/** @var \PHPStan\Parser\Parser */
+			private $parser;
+
+			/** @var \PHPStan\Parser\FunctionCallStatementFinder */
+			private $functionCallStatementFinder;
+
+			/** @var \PHPStan\Cache\Cache */
+			private $cache;
+
+			public function __construct(
+				Parser $parser,
+				FunctionCallStatementFinder $functionCallStatementFinder,
+				Cache $cache
+			)
+			{
+				$this->parser = $parser;
+				$this->functionCallStatementFinder = $functionCallStatementFinder;
+				$this->cache = $cache;
+			}
+
+			public function create(
+				\ReflectionFunction $function,
+				array $phpDocParameterTypes,
+				Type $phpDocReturnType = null
+			): PhpFunctionReflection
+			{
+				return new PhpFunctionReflection(
+					$function,
+					$this->parser,
+					$this->functionCallStatementFinder,
+					$this->cache,
+					$phpDocParameterTypes,
+					$phpDocReturnType
+				);
+			}
+		};
+
+		$tagToService = function (array $tags) {
+			return array_map(function (string $serviceName) {
+				return $this->container->getService($serviceName);
+			}, array_keys($tags));
+		};
+
+		$broker = new Broker(
+			[
+				$phpExtension,
+				$annotationsPropertiesClassReflectionExtension,
+				new UniversalObjectCratesClassReflectionExtension([\stdClass::class]),
+				new PhpDefectClassReflectionExtension($this->getTypeStringResolver()),
+			],
+			[$phpExtension],
+			$dynamicMethodReturnTypeExtensions,
+			$dynamicStaticMethodReturnTypeExtensions,
+			$tagToService($this->container->findByTag(BrokerFactory::DYNAMIC_FUNCTION_RETURN_TYPE_EXTENSION_TAG)),
+			$functionReflectionFactory,
+			new FileTypeMapper($this->getParser(), $phpDocStringResolver, $cache),
+			$this->getSignatureMapProvider()
+		);
+		$methodReflectionFactory->broker = $broker;
+
+		return $broker;
+	}
+
+	private function getPhpDocStringResolver(): PhpDocStringResolver
+	{
+		/** @var PhpDocStringResolver $resolver */
+		$resolver = $this->container->getByType(PhpDocStringResolver::class);
+		return $resolver;
+	}
+
+	public function getFileHelper(): FileHelper
+	{
+		/** @var FileHelper $fileHelper */
+		$fileHelper = $this->container->getByType(FileHelper::class);
+		return $fileHelper;
+	}
+
+	public function getParser(): Parser
+	{
+		/** @var Parser $parser */
+		$parser = $this->container->getService('directParser');
+		return $parser;
+	}
+
+	private function getTypeStringResolver(): TypeStringResolver
+	{
+		/** @var TypeStringResolver $resolver */
+		$resolver = $this->container->getByType(TypeStringResolver::class);
+		return $resolver;
+	}
+
+	private function getSignatureMapProvider(): SignatureMapProvider
+	{
+		/** @var SignatureMapProvider $provider */
+		$provider = $this->container->getByType(SignatureMapProvider::class);
+		return $provider;
+	}
+
+}

--- a/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
@@ -2,9 +2,9 @@
 
 namespace PHPStan\Analyser;
 
-use PHPStan\File\FileHelper;
+use PHPStan\Testing\TestCase;
 
-class AnalyserTraitsIntegrationTest extends \PHPStan\Testing\TestCase
+class AnalyserTraitsIntegrationTest extends TestCase
 {
 
 	/**
@@ -14,7 +14,9 @@ class AnalyserTraitsIntegrationTest extends \PHPStan\Testing\TestCase
 
 	protected function setUp(): void
 	{
-		$this->fileHelper = $this->getContainer()->getByType(FileHelper::class);
+		parent::setUp();
+
+		$this->fileHelper = $this->getFileHelper();
 	}
 
 	public function testMethodIsInClassUsingTrait(): void

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
+use PHPStan\Testing\TestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\NullType;
@@ -18,7 +19,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 
-class TypeSpecifierTest extends \PHPStan\Testing\TestCase
+class TypeSpecifierTest extends TestCase
 {
 
 	/** @var \PhpParser\PrettyPrinter\Standard() */
@@ -32,6 +33,8 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 
 	protected function setUp(): void
 	{
+		parent::setUp();
+
 		$broker = $this->createBroker();
 		$this->printer = new \PhpParser\PrettyPrinter\Standard();
 		$this->typeSpecifier = new TypeSpecifier($this->printer);

--- a/tests/PHPStan/Broker/BrokerTest.php
+++ b/tests/PHPStan/Broker/BrokerTest.php
@@ -18,6 +18,8 @@ class BrokerTest extends \PHPStan\Testing\TestCase
 
 	protected function setUp(): void
 	{
+		parent::setUp();
+
 		$phpDocStringResolver = $this->getContainer()->getByType(PhpDocStringResolver::class);
 
 		$this->broker = new Broker(

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -5,10 +5,11 @@ namespace PHPStan\Command\ErrorFormatter;
 use PHPStan\Analyser\Error;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\ErrorsConsoleStyle;
+use PHPStan\Testing\TestCase;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\StreamOutput;
 
-class CheckstyleErrorFormatterTest extends \PHPStan\Testing\TestCase
+class CheckstyleErrorFormatterTest extends TestCase
 {
 
 	/**
@@ -23,6 +24,8 @@ class CheckstyleErrorFormatterTest extends \PHPStan\Testing\TestCase
 	 */
 	protected function setUp(): void
 	{
+		parent::setUp();
+
 		$this->formatter = new CheckstyleErrorFormatter();
 	}
 

--- a/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
@@ -5,10 +5,11 @@ namespace PHPStan\Command\ErrorFormatter;
 use PHPStan\Analyser\Error;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\ErrorsConsoleStyle;
+use PHPStan\Testing\TestCase;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\StreamOutput;
 
-class JsonErrorFormatterTest extends \PHPStan\Testing\TestCase
+class JsonErrorFormatterTest extends TestCase
 {
 
 	/**
@@ -18,6 +19,8 @@ class JsonErrorFormatterTest extends \PHPStan\Testing\TestCase
 
 	protected function setUp(): void
 	{
+		parent::setUp();
+
 		$this->formatter = new JsonErrorFormatter();
 	}
 

--- a/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Reflection\SignatureMap;
 
+use PHPStan\Testing\TestCase;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CallableType;
@@ -13,12 +14,13 @@ use PHPStan\Type\ResourceType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 
-class SignatureMapParserTest extends \PHPStan\Testing\TestCase
+class SignatureMapParserTest extends TestCase
 {
 
 	protected function setUp(): void
 	{
 		parent::setUp();
+
 		$this->createBroker();
 	}
 

--- a/tests/PHPStan/Type/IntersectionTypeTest.php
+++ b/tests/PHPStan/Type/IntersectionTypeTest.php
@@ -2,18 +2,17 @@
 
 namespace PHPStan\Type;
 
+use PHPStan\Testing\TestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 
-class IntersectionTypeTest extends \PHPStan\Testing\TestCase
+class IntersectionTypeTest extends TestCase
 {
 
 	public function dataAccepts(): \Iterator
 	{
-		$this->createBroker();
-
 		$intersectionType = new IntersectionType([
 			new ObjectType('Collection'),
 			new IterableType(new MixedType(), new ObjectType('Item')),
@@ -105,8 +104,6 @@ class IntersectionTypeTest extends \PHPStan\Testing\TestCase
 
 	public function dataIsSuperTypeOf(): \Iterator
 	{
-		$this->createBroker();
-
 		$intersectionTypeA = new IntersectionType([
 			new ObjectType('ArrayObject'),
 			new IterableType(new MixedType(), new ObjectType('Item')),
@@ -167,8 +164,6 @@ class IntersectionTypeTest extends \PHPStan\Testing\TestCase
 
 	public function dataIsSubTypeOf(): \Iterator
 	{
-		$this->createBroker();
-
 		$intersectionTypeA = new IntersectionType([
 			new ObjectType('ArrayObject'),
 			new IterableType(new MixedType(), new ObjectType('Item')),

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -67,8 +67,6 @@ class UnionTypeTest extends \PHPStan\Testing\TestCase
 
 	public function dataIsSuperTypeOf(): \Iterator
 	{
-		$this->createBroker();
-
 		$unionTypeA = new UnionType([
 			new IntegerType(),
 			new StringType(),
@@ -265,8 +263,6 @@ class UnionTypeTest extends \PHPStan\Testing\TestCase
 
 	public function dataIsSubTypeOf(): \Iterator
 	{
-		$this->createBroker();
-
 		$unionTypeA = new UnionType([
 			new IntegerType(),
 			new StringType(),


### PR DESCRIPTION
Thank you for the great tool.

1. There are abstract test case classes provided, but they are impossible to use with [Codeception](https://codeception.com/docs/05-UnitTests). I have extracted methods to traits so they can be used in both PHPUnit and Codeception. Abstract test case classes were left for backwards compatibility.

2. The root directory was hardcoded, so it was hard to test custom rule, that uses user configurations, that resides in the root, for example. So root resolution was extracted to the method, that can be overridden in the test case class.

Thank you in advance.