### PR TITLE
Conditioned calling non-existing function should not throw error

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
@@ -31,6 +31,11 @@ class CallToNonExistentFunctionRuleTest extends \PHPStan\Testing\RuleTestCase
 		]);
 	}
 
+	public function testCallToNonexistentFunctionConditioned(): void
+	{
+		$this->analyse([__DIR__ . '/data/nonexistent-function-conditioned.php'], []);
+	}
+
 	public function testCallToNonexistentNestedFunction(): void
 	{
 		$this->analyse([__DIR__ . '/data/nonexistent-nested-function.php'], [

--- a/tests/PHPStan/Rules/Functions/data/nonexistent-function-conditioned.php
+++ b/tests/PHPStan/Rules/Functions/data/nonexistent-function-conditioned.php
@@ -1,0 +1,7 @@
+<?php
+
+if (function_exists('foobarNonExistentFunction')) {
+	foobarNonExistentFunction();
+}
+
+function_exists('foobarNonExistentFunction') && foobarNonExistentFunction();


### PR DESCRIPTION
When calling non-existing function in condition testing existence these function no error should be thrown.

