### PR TITLE
Add support for non-truthy values filtering with array_filter

### DIFF
--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -20,6 +20,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 
 class ArrayFilterFunctionReturnTypeReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
@@ -42,7 +43,9 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements \PHPStan\Type\
 			$itemType = $arrayArgType->getIterableValueType();
 
 			if ($callbackArg === null) {
-				return $this->removeFalsey($arrayArgType);
+				return TypeCombinator::union(
+					...array_map([$this, 'removeFalsey'], TypeUtils::getArrays($arrayArgType))
+				);
 			}
 
 			if ($flagArg === null && $callbackArg instanceof Closure && count($callbackArg->stmts) === 1) {
@@ -66,7 +69,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements \PHPStan\Type\
 		return new ArrayType($keyType, $itemType);
 	}
 
-	private function removeFalsey(Type $type): Type
+	public function removeFalsey(Type $type): Type
 	{
 		$falseyTypes = new UnionType([
 			new NullType(),

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4116,6 +4116,30 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'null',
 				'array_shift([])',
 			],
+			[
+				'array(null, \'\', 1)',
+				'$constantArrayWithFalseyValues',
+			],
+			[
+				'array(2 => 1)',
+				'$constantTruthyValues',
+			],
+			[
+				'array<int, false|null>',
+				'$falsey',
+			],
+			[
+				'array()',
+				'array_filter($falsey)',
+			],
+			[
+				'array<int, bool|null>',
+				'$withFalsey',
+			],
+			[
+				'array<int, true>',
+				'array_filter($withFalsey)',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4140,6 +4140,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array<int, true>',
 				'array_filter($withFalsey)',
 			],
+			[
+				'array(\'a\' => 1)',
+				'array_filter($union)',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4144,6 +4144,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array(\'a\' => 1)',
 				'array_filter($union)',
 			],
+			[
+				'array<int, int|true>',
+				'array_filter($withPossiblyFalsey)',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/array-functions.php
+++ b/tests/PHPStan/Analyser/data/array-functions.php
@@ -41,6 +41,16 @@ $stringOrIntegerKeys = [
 	1 => new \stdClass(),
 ];
 
+$constantArrayWithFalseyValues = [null, '', 1];
+
+$constantTruthyValues = array_filter($constantArrayWithFalseyValues);
+
+/** @var array<int, false|null> $falsey */
+$falsey = doFoo();
+
+/** @var array<int, bool|null> $withFalsey */
+$withFalsey = doFoo();
+
 /** @var array<string, int> $generalStringKeys */
 $generalStringKeys = doFoo();
 

--- a/tests/PHPStan/Analyser/data/array-functions.php
+++ b/tests/PHPStan/Analyser/data/array-functions.php
@@ -51,6 +51,11 @@ $falsey = doFoo();
 /** @var array<int, bool|null> $withFalsey */
 $withFalsey = doFoo();
 
+$union = ['a' => 1];
+if (rand(0, 1) === 1) {
+	$union['b'] = false;
+}
+
 /** @var array<string, int> $generalStringKeys */
 $generalStringKeys = doFoo();
 

--- a/tests/PHPStan/Analyser/data/array-functions.php
+++ b/tests/PHPStan/Analyser/data/array-functions.php
@@ -56,6 +56,13 @@ if (rand(0, 1) === 1) {
 	$union['b'] = false;
 }
 
+/** @var bool $bool */
+$bool = doFoo();
+/** @var int $integer */
+$integer = doFoo();
+
+$withPossiblyFalsey = [$bool, $integer, '', 'a' => 0];
+
 /** @var array<string, int> $generalStringKeys */
 $generalStringKeys = doFoo();
 


### PR DESCRIPTION
Hi,
When `array_filter` is called without second argument, all non-truthy values are filtered. This patch adds support for this for both constant and other types (`NullType`)

