### PR TITLE
Update to slevomat/cs v4.5 and consistence/cs to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,14 +29,14 @@
 		"ext-intl": "*",
 		"ext-gd": "*",
 		"ext-mysqli": "*",
-		"consistence/coding-standard": "2.2.1",
+		"consistence/coding-standard": "^3.0",
 		"jakub-onderka/php-parallel-lint": "^0.9.2",
 		"phing/phing": "^2.16.0",
 		"phpstan/phpstan-php-parser": "^0.10",
 		"phpstan/phpstan-phpunit": "^0.10",
 		"phpstan/phpstan-strict-rules": "^0.10",
 		"phpunit/phpunit": "^7.0",
-		"slevomat/coding-standard": "4.0.0"
+		"slevomat/coding-standard": "^4.5"
 	},
 	"autoload": {
 		"psr-4": {"PHPStan\\": ["src/", "build/PHPStan"]}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,7 +4,7 @@
 		<exclude name="Squiz.Functions.GlobalFunction.Found"/>
 		<exclude name="Consistence.Exceptions.ExceptionDeclaration"/>
 	</rule>
-	<rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
+	<rule ref="SlevomatCodingStandard">
 		<exclude name="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces"/>
@@ -16,6 +16,9 @@
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
 		<exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 		<exclude name="SlevomatCodingStandard.ControlStructures.RequireYodaComparison.RequiredYodaComparison"/>
+		<exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+		<exclude name="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>
+		<exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
 	</rule>
 	<rule ref="Squiz.PHP.InnerFunctions.NotAllowed">
 		<exclude-pattern>tests/TestCase.php</exclude-pattern>

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -10,54 +10,34 @@ use PHPStan\Rules\Registry;
 class Analyser
 {
 
-	/**
-	 * @var \PHPStan\Parser\Parser
-	 */
+	/** @var \PHPStan\Parser\Parser */
 	private $parser;
 
-	/**
-	 * @var \PHPStan\Rules\Registry
-	 */
+	/** @var \PHPStan\Rules\Registry */
 	private $registry;
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Analyser\NodeScopeResolver
-	 */
+	/** @var \PHPStan\Analyser\NodeScopeResolver */
 	private $nodeScopeResolver;
 
-	/**
-	 * @var \PhpParser\PrettyPrinter\Standard
-	 */
+	/** @var \PhpParser\PrettyPrinter\Standard */
 	private $printer;
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
-	/**
-	 * @var string[]
-	 */
+	/** @var string[] */
 	private $ignoreErrors;
 
-	/**
-	 * @var string|null
-	 */
+	/** @var string|null */
 	private $bootstrapFile;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $reportUnmatchedIgnoredErrors;
 
-	/**
-	 * @var int
-	 */
+	/** @var int */
 	private $internalErrorsCountLimit;
 
 	/**

--- a/src/Analyser/Error.php
+++ b/src/Analyser/Error.php
@@ -5,24 +5,16 @@ namespace PHPStan\Analyser;
 class Error
 {
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $message;
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $file;
 
-	/**
-	 * @var int|NULL
-	 */
+	/** @var int|NULL */
 	private $line;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $canBeIgnored;
 
 	public function __construct(string $message, string $file, int $line = null, bool $canBeIgnored = true)

--- a/src/Analyser/LookForAssignsSettings.php
+++ b/src/Analyser/LookForAssignsSettings.php
@@ -15,9 +15,7 @@ class LookForAssignsSettings
 		+ self::EARLY_TERMINATION_BREAK
 		+ self::EARLY_TERMINATION_STOP;
 
-	/**
-	 * @var int
-	 */
+	/** @var int */
 	private $respectEarlyTermination;
 
 	private function __construct(

--- a/src/Analyser/NameScope.php
+++ b/src/Analyser/NameScope.php
@@ -5,19 +5,13 @@ namespace PHPStan\Analyser;
 class NameScope
 {
 
-	/**
-	 * @var string|null
-	 */
+	/** @var string|null */
 	private $namespace;
 
-	/**
-	 * @var string[] alias(string) => fullName(string)
-	 */
+	/** @var string[] alias(string) => fullName(string) */
 	private $uses;
 
-	/**
-	 * @var string|null
-	 */
+	/** @var string|null */
 	private $className;
 
 	public function __construct(string $namespace = null, array $uses = [], string $className = null)

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1424,7 +1424,6 @@ class NodeScopeResolver
 					$certainty
 				);
 			}
-
 		} elseif ($var instanceof PropertyFetch && $subNodeType !== null) {
 			$scope = $scope->specifyExpressionType($var, $subNodeType);
 		} elseif ($var instanceof Expr\StaticPropertyFetch && $subNodeType !== null) {

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -62,84 +62,52 @@ use PHPStan\Type\VoidType;
 class Scope
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PhpParser\PrettyPrinter\Standard
-	 */
+	/** @var \PhpParser\PrettyPrinter\Standard */
 	private $printer;
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
-	/**
-	 * @var \PHPStan\Analyser\ScopeContext
-	 */
+	/** @var \PHPStan\Analyser\ScopeContext */
 	private $context;
 
-	/**
-	 * @var \PHPStan\Type\Type[]
-	 */
+	/** @var \PHPStan\Type\Type[] */
 	private $resolvedTypes = [];
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $declareStrictTypes;
 
-	/**
-	 * @var \PHPStan\Reflection\FunctionReflection|MethodReflection|null
-	 */
+	/** @var \PHPStan\Reflection\FunctionReflection|MethodReflection|null */
 	private $function;
 
-	/**
-	 * @var string|null
-	 */
+	/** @var string|null */
 	private $namespace;
 
-	/**
-	 * @var \PHPStan\Analyser\VariableTypeHolder[]
-	 */
+	/** @var \PHPStan\Analyser\VariableTypeHolder[] */
 	private $variableTypes;
 
-	/**
-	 * @var \PHPStan\Type\Type[]
-	 */
+	/** @var \PHPStan\Type\Type[] */
 	private $moreSpecificTypes;
 
-	/**
-	 * @var string|null
-	 */
+	/** @var string|null */
 	private $inClosureBindScopeClass;
 
-	/**
-	 * @var \PHPStan\Type\Type|null
-	 */
+	/** @var \PHPStan\Type\Type|null */
 	private $inAnonymousFunctionReturnType;
 
-	/**
-	 * @var \PhpParser\Node\Expr\FuncCall|\PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall|null
-	 */
+	/** @var \PhpParser\Node\Expr\FuncCall|\PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall|null */
 	private $inFunctionCall;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $negated;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $inFirstLevelStatement;
 
-	/**
-	 * @var string[]
-	 */
+	/** @var string[] */
 	private $currentlyAssignedExpressions = [];
 
 	/**

--- a/src/Analyser/SpecifiedTypes.php
+++ b/src/Analyser/SpecifiedTypes.php
@@ -7,14 +7,10 @@ use PHPStan\Type\TypeCombinator;
 class SpecifiedTypes
 {
 
-	/**
-	 * @var mixed[]
-	 */
+	/** @var mixed[] */
 	private $sureTypes;
 
-	/**
-	 * @var mixed[]
-	 */
+	/** @var mixed[] */
 	private $sureNotTypes;
 
 	/**

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -33,39 +33,25 @@ use PHPStan\Type\UnionType;
 class TypeSpecifier
 {
 
-	/**
-	 * @var \PhpParser\PrettyPrinter\Standard
-	 */
+	/** @var \PhpParser\PrettyPrinter\Standard */
 	private $printer;
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Type\FunctionTypeSpecifyingExtension[]
-	 */
+	/** @var \PHPStan\Type\FunctionTypeSpecifyingExtension[] */
 	private $functionTypeSpecifyingExtensions = [];
 
-	/**
-	 * @var \PHPStan\Type\MethodTypeSpecifyingExtension[]
-	 */
+	/** @var \PHPStan\Type\MethodTypeSpecifyingExtension[] */
 	private $methodTypeSpecifyingExtensions = [];
 
-	/**
-	 * @var \PHPStan\Type\StaticMethodTypeSpecifyingExtension[]
-	 */
+	/** @var \PHPStan\Type\StaticMethodTypeSpecifyingExtension[] */
 	private $staticMethodTypeSpecifyingExtensions = [];
 
-	/**
-	 * @var \PHPStan\Type\MethodTypeSpecifyingExtension[]
-	 */
+	/** @var \PHPStan\Type\MethodTypeSpecifyingExtension[] */
 	private $methodTypeSpecifyingExtensionsByClass;
 
-	/**
-	 * @var \PHPStan\Type\StaticMethodTypeSpecifyingExtension[]
-	 */
+	/** @var \PHPStan\Type\StaticMethodTypeSpecifyingExtension[] */
 	private $staticMethodTypeSpecifyingExtensionsByClass;
 
 	/**
@@ -166,7 +152,6 @@ class TypeSpecifier
 					return $leftTypes->unionWith($rightTypes);
 				}
 			}
-
 		} elseif ($expr instanceof Node\Expr\BinaryOp\NotIdentical) {
 			return $this->specifyTypesInCondition(
 				$scope,

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -12,14 +12,10 @@ class TypeSpecifierContext
 	public const CONTEXT_FALSEY_BUT_NOT_FALSE = 0b1000;
 	public const CONTEXT_FALSEY = self::CONTEXT_FALSE | self::CONTEXT_FALSEY_BUT_NOT_FALSE;
 
-	/**
-	 * @var int|null
-	 */
+	/** @var int|null */
 	private $value;
 
-	/**
-	 * @var self[]
-	 */
+	/** @var self[] */
 	private static $registry;
 
 	private function __construct(?int $value)

--- a/src/Analyser/TypeSpecifierFactory.php
+++ b/src/Analyser/TypeSpecifierFactory.php
@@ -13,9 +13,7 @@ class TypeSpecifierFactory
 	public const METHOD_TYPE_SPECIFYING_EXTENSION_TAG = 'phpstan.typeSpecifier.methodTypeSpecifyingExtension';
 	public const STATIC_METHOD_TYPE_SPECIFYING_EXTENSION_TAG = 'phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension';
 
-	/**
-	 * @var \Nette\DI\Container
-	 */
+	/** @var \Nette\DI\Container */
 	private $container;
 
 	public function __construct(Container $container)

--- a/src/Analyser/VariableTypeHolder.php
+++ b/src/Analyser/VariableTypeHolder.php
@@ -9,14 +9,10 @@ use PHPStan\Type\TypeCombinator;
 class VariableTypeHolder
 {
 
-	/**
-	 * @var \PHPStan\Type\Type
-	 */
+	/** @var \PHPStan\Type\Type */
 	private $type;
 
-	/**
-	 * @var \PHPStan\TrinaryLogic
-	 */
+	/** @var \PHPStan\TrinaryLogic */
 	private $certainty;
 
 	public function __construct(Type $type, TrinaryLogic $certainty)

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -13,19 +13,13 @@ use Symfony\Component\Finder\Finder;
 class AnalyseApplication
 {
 
-	/**
-	 * @var \PHPStan\Analyser\Analyser
-	 */
+	/** @var \PHPStan\Analyser\Analyser */
 	private $analyser;
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $memoryLimitFile;
 
-	/**
-	 * @var string[]
-	 */
+	/** @var string[] */
 	private $fileExtensions;
 
 	/** @var \PHPStan\File\FileHelper */

--- a/src/Command/AnalysisResult.php
+++ b/src/Command/AnalysisResult.php
@@ -7,24 +7,16 @@ use PHPStan\Analyser\Error;
 class AnalysisResult
 {
 
-	/**
-	 * @var \PHPStan\Analyser\Error[] sorted by their file name, line number and message
-	 */
+	/** @var \PHPStan\Analyser\Error[] sorted by their file name, line number and message */
 	private $fileSpecificErrors;
 
-	/**
-	 * @var string[]
-	 */
+	/** @var string[] */
 	private $notFileSpecificErrors;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $defaultLevelUsed;
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $currentDirectory;
 
 	/**

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -8,19 +8,13 @@ use PHPStan\File\FileHelper;
 class ContainerFactory
 {
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $currentWorkingDirectory;
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $rootDirectory;
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $configDirectory;
 
 	public function __construct(string $currentWorkingDirectory)

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -61,7 +61,6 @@ class FileHelper
 				if ($scheme === 'phar' && substr($removedPart, -5) === '.phar') {
 					$scheme = null;
 				}
-
 			} else {
 				$normalizedPathParts[] = $pathPart;
 			}

--- a/src/Parser/DirectParser.php
+++ b/src/Parser/DirectParser.php
@@ -7,14 +7,10 @@ use PhpParser\NodeTraverser;
 class DirectParser implements Parser
 {
 
-	/**
-	 * @var \PhpParser\Parser
-	 */
+	/** @var \PhpParser\Parser */
 	private $parser;
 
-	/**
-	 * @var \PhpParser\NodeTraverser
-	 */
+	/** @var \PhpParser\NodeTraverser */
 	private $traverser;
 
 	public function __construct(\PhpParser\Parser $parser, NodeTraverser $traverser)

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -7,29 +7,19 @@ use PHPStan\PhpDoc\Tag\ReturnTag;
 class ResolvedPhpDocBlock
 {
 
-	/**
-	 * @var \PHPStan\PhpDoc\Tag\VarTag[]
-	 */
+	/** @var \PHPStan\PhpDoc\Tag\VarTag[] */
 	private $varTags;
 
-	/**
-	 * @var \PHPStan\PhpDoc\Tag\MethodTag[]
-	 */
+	/** @var \PHPStan\PhpDoc\Tag\MethodTag[] */
 	private $methodTags;
 
-	/**
-	 * @var \PHPStan\PhpDoc\Tag\PropertyTag[]
-	 */
+	/** @var \PHPStan\PhpDoc\Tag\PropertyTag[] */
 	private $propertyTags;
 
-	/**
-	 * @var \PHPStan\PhpDoc\Tag\ParamTag[]
-	 */
+	/** @var \PHPStan\PhpDoc\Tag\ParamTag[] */
 	private $paramTags;
 
-	/**
-	 * @var \PHPStan\PhpDoc\Tag\ReturnTag|null
-	 */
+	/** @var \PHPStan\PhpDoc\Tag\ReturnTag|null */
 	private $returnTag;
 
 	/**

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -145,7 +145,6 @@ class TypeNodeResolver
 							return new ObjectType($classReflection->getParentClass()->getName());
 						}
 					}
-
 					return new NonexistentParentClassType();
 			}
 		}
@@ -252,7 +251,6 @@ class TypeNodeResolver
 			if (count($genericTypes) === 2) { // array<KeyType, ValueType>
 				return new ArrayType($genericTypes[0], $genericTypes[1]);
 			}
-
 		} elseif ($mainType === 'iterable') {
 			if (count($genericTypes) === 1) { // iterable<ValueType>
 				return new IterableType(new MixedType(true), $genericTypes[0]);

--- a/src/Reflection/Native/NativeFunctionReflection.php
+++ b/src/Reflection/Native/NativeFunctionReflection.php
@@ -7,24 +7,16 @@ use PHPStan\Type\Type;
 class NativeFunctionReflection implements \PHPStan\Reflection\FunctionReflection
 {
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $name;
 
-	/**
-	 * @var \PHPStan\Reflection\Native\NativeParameterReflection[]
-	 */
+	/** @var \PHPStan\Reflection\Native\NativeParameterReflection[] */
 	private $parameters;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $variadic;
 
-	/**
-	 * @var \PHPStan\Type\Type
-	 */
+	/** @var \PHPStan\Type\Type */
 	private $returnType;
 
 	/**

--- a/src/Reflection/Native/NativeParameterReflection.php
+++ b/src/Reflection/Native/NativeParameterReflection.php
@@ -9,29 +9,19 @@ use PHPStan\Type\Type;
 class NativeParameterReflection implements ParameterReflection
 {
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $name;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $optional;
 
-	/**
-	 * @var \PHPStan\Type\Type
-	 */
+	/** @var \PHPStan\Type\Type */
 	private $type;
 
-	/**
-	 * @var \PHPStan\Reflection\PassedByReference
-	 */
+	/** @var \PHPStan\Reflection\PassedByReference */
 	private $passedByReference;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $variadic;
 
 	public function __construct(

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -87,7 +87,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 					$parameter->name,
 					$isOptional,
 					$this->realParameterTypes[$parameter->name],
-					isset($this->phpDocParameterTypes[$parameter->name]) ? $this->phpDocParameterTypes[$parameter->name] : null,
+					array_key_exists($parameter->name, $this->phpDocParameterTypes) ? $this->phpDocParameterTypes[$parameter->name] : null,
 					$parameter->byRef
 						? PassedByReference::createCreatesNewVariable()
 						: PassedByReference::createNo(),

--- a/src/Reflection/Php/PhpFunctionReflection.php
+++ b/src/Reflection/Php/PhpFunctionReflection.php
@@ -79,7 +79,7 @@ class PhpFunctionReflection implements FunctionReflection, ParametersAcceptorWit
 			$this->parameters = array_map(function (\ReflectionParameter $reflection) {
 				return new PhpParameterReflection(
 					$reflection,
-					isset($this->phpDocParameterTypes[$reflection->getName()]) ? $this->phpDocParameterTypes[$reflection->getName()] : null
+					array_key_exists($reflection->getName(), $this->phpDocParameterTypes) ? $this->phpDocParameterTypes[$reflection->getName()] : null
 				);
 			}, $this->reflection->getParameters());
 			if (

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -161,7 +161,7 @@ class PhpMethodReflection implements MethodReflection, ParametersAcceptorWithPhp
 			$this->parameters = array_map(function (\ReflectionParameter $reflection) {
 				return new PhpParameterReflection(
 					$reflection,
-					isset($this->phpDocParameterTypes[$reflection->getName()]) ? $this->phpDocParameterTypes[$reflection->getName()] : null
+					array_key_exists($reflection->getName(), $this->phpDocParameterTypes) ? $this->phpDocParameterTypes[$reflection->getName()] : null
 				);
 			}, $this->reflection->getParameters());
 

--- a/src/Reflection/SignatureMap/FunctionSignature.php
+++ b/src/Reflection/SignatureMap/FunctionSignature.php
@@ -7,19 +7,13 @@ use PHPStan\Type\Type;
 class FunctionSignature
 {
 
-	/**
-	 * @var \PHPStan\Reflection\SignatureMap\ParameterSignature[]
-	 */
+	/** @var \PHPStan\Reflection\SignatureMap\ParameterSignature[] */
 	private $parameters;
 
-	/**
-	 * @var \PHPStan\Type\Type
-	 */
+	/** @var \PHPStan\Type\Type */
 	private $returnType;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $variadic;
 
 	/**

--- a/src/Reflection/SignatureMap/ParameterSignature.php
+++ b/src/Reflection/SignatureMap/ParameterSignature.php
@@ -8,29 +8,19 @@ use PHPStan\Type\Type;
 class ParameterSignature
 {
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $name;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $optional;
 
-	/**
-	 * @var \PHPStan\Type\Type
-	 */
+	/** @var \PHPStan\Type\Type */
 	private $type;
 
-	/**
-	 * @var \PHPStan\Reflection\PassedByReference
-	 */
+	/** @var \PHPStan\Reflection\PassedByReference */
 	private $passedByReference;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $variadic;
 
 	public function __construct(

--- a/src/Reflection/SignatureMap/SignatureMapParser.php
+++ b/src/Reflection/SignatureMap/SignatureMapParser.php
@@ -12,9 +12,7 @@ use PHPStan\Type\TypeCombinator;
 class SignatureMapParser
 {
 
-	/**
-	 * @var \PHPStan\PhpDoc\TypeStringResolver
-	 */
+	/** @var \PHPStan\PhpDoc\TypeStringResolver */
 	private $typeStringResolver;
 
 	public function __construct(

--- a/src/Rules/Arrays/IterableInForeachRule.php
+++ b/src/Rules/Arrays/IterableInForeachRule.php
@@ -9,9 +9,7 @@ use PHPStan\Type\UnionType;
 class IterableInForeachRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkUnionTypes;
 
 	public function __construct(bool $checkUnionTypes)

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -16,19 +16,13 @@ use PHPStan\Type\TypeCombinator;
 class ClassConstantRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\RuleLevelHelper
-	 */
+	/** @var \PHPStan\Rules\RuleLevelHelper */
 	private $ruleLevelHelper;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	public function __construct(

--- a/src/Rules/Classes/ExistingClassInClassExtendsRule.php
+++ b/src/Rules/Classes/ExistingClassInClassExtendsRule.php
@@ -9,9 +9,7 @@ use PHPStan\Rules\ClassCaseSensitivityCheck;
 class ExistingClassInClassExtendsRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	public function __construct(ClassCaseSensitivityCheck $classCaseSensitivityCheck)

--- a/src/Rules/Classes/ExistingClassInInstanceOfRule.php
+++ b/src/Rules/Classes/ExistingClassInInstanceOfRule.php
@@ -11,19 +11,13 @@ use PHPStan\Rules\ClassCaseSensitivityCheck;
 class ExistingClassInInstanceOfRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkClassCaseSensitivity;
 
 	public function __construct(

--- a/src/Rules/Classes/ExistingClassInTraitUseRule.php
+++ b/src/Rules/Classes/ExistingClassInTraitUseRule.php
@@ -9,9 +9,7 @@ use PHPStan\Rules\ClassCaseSensitivityCheck;
 class ExistingClassInTraitUseRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	public function __construct(ClassCaseSensitivityCheck $classCaseSensitivityCheck)

--- a/src/Rules/Classes/ExistingClassesInClassImplementsRule.php
+++ b/src/Rules/Classes/ExistingClassesInClassImplementsRule.php
@@ -9,9 +9,7 @@ use PHPStan\Rules\ClassCaseSensitivityCheck;
 class ExistingClassesInClassImplementsRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	public function __construct(ClassCaseSensitivityCheck $classCaseSensitivityCheck)

--- a/src/Rules/Classes/ExistingClassesInInterfaceExtendsRule.php
+++ b/src/Rules/Classes/ExistingClassesInInterfaceExtendsRule.php
@@ -9,9 +9,7 @@ use PHPStan\Rules\ClassCaseSensitivityCheck;
 class ExistingClassesInInterfaceExtendsRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	public function __construct(ClassCaseSensitivityCheck $classCaseSensitivityCheck)

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -12,19 +12,13 @@ use PHPStan\Rules\FunctionCallParametersCheck;
 class InstantiationRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\FunctionCallParametersCheck
-	 */
+	/** @var \PHPStan\Rules\FunctionCallParametersCheck */
 	private $check;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	public function __construct(

--- a/src/Rules/Constants/ConstantRule.php
+++ b/src/Rules/Constants/ConstantRule.php
@@ -9,9 +9,7 @@ use PHPStan\Broker\Broker;
 class ConstantRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
 	public function __construct(Broker $broker)

--- a/src/Rules/Exceptions/CaughtExceptionExistenceRule.php
+++ b/src/Rules/Exceptions/CaughtExceptionExistenceRule.php
@@ -11,9 +11,7 @@ use PHPStan\Rules\ClassCaseSensitivityCheck;
 class CaughtExceptionExistenceRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
 	/**

--- a/src/Rules/Exceptions/CaughtExceptionExistenceRule.php
+++ b/src/Rules/Exceptions/CaughtExceptionExistenceRule.php
@@ -14,14 +14,10 @@ class CaughtExceptionExistenceRule implements \PHPStan\Rules\Rule
 	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkClassCaseSensitivity;
 
 	public function __construct(

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -30,24 +30,16 @@ class FunctionDefinitionCheck
 		'parent',
 	];
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkClassCaseSensitivity;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkThisOnly;
 
 	public function __construct(

--- a/src/Rules/Functions/CallToCountOnlyWithArrayOrCountableRule.php
+++ b/src/Rules/Functions/CallToCountOnlyWithArrayOrCountableRule.php
@@ -14,9 +14,7 @@ use PHPStan\Type\UnionType;
 class CallToCountOnlyWithArrayOrCountableRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Rules\RuleLevelHelper
-	 */
+	/** @var \PHPStan\Rules\RuleLevelHelper */
 	private $ruleLevelHelper;
 
 	public function __construct(RuleLevelHelper $ruleLevelHelper)

--- a/src/Rules/Functions/CallToFunctionParametersRule.php
+++ b/src/Rules/Functions/CallToFunctionParametersRule.php
@@ -11,14 +11,10 @@ use PHPStan\Rules\FunctionCallParametersCheck;
 class CallToFunctionParametersRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\FunctionCallParametersCheck
-	 */
+	/** @var \PHPStan\Rules\FunctionCallParametersCheck */
 	private $check;
 
 	public function __construct(Broker $broker, FunctionCallParametersCheck $check)

--- a/src/Rules/Functions/CallToNonExistentFunctionRule.php
+++ b/src/Rules/Functions/CallToNonExistentFunctionRule.php
@@ -13,9 +13,7 @@ class CallToNonExistentFunctionRule implements \PHPStan\Rules\Rule
 	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkFunctionNameCase;
 
 	public function __construct(

--- a/src/Rules/Functions/CallToNonExistentFunctionRule.php
+++ b/src/Rules/Functions/CallToNonExistentFunctionRule.php
@@ -10,9 +10,7 @@ use PHPStan\Broker\Broker;
 class CallToNonExistentFunctionRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
 	/**

--- a/src/Rules/Methods/CallMethodsOnPossiblyNullRule.php
+++ b/src/Rules/Methods/CallMethodsOnPossiblyNullRule.php
@@ -11,14 +11,10 @@ use PHPStan\Type\UnionType;
 class CallMethodsOnPossiblyNullRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Rules\RuleLevelHelper
-	 */
+	/** @var \PHPStan\Rules\RuleLevelHelper */
 	private $ruleLevelHelper;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkThisOnly;
 
 	public function __construct(

--- a/src/Rules/Methods/CallMethodsRule.php
+++ b/src/Rules/Methods/CallMethodsRule.php
@@ -22,9 +22,7 @@ class CallMethodsRule implements \PHPStan\Rules\Rule
 	/** @var \PHPStan\Rules\RuleLevelHelper */
 	private $ruleLevelHelper;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkFunctionNameCase;
 
 	public function __construct(

--- a/src/Rules/Methods/CallMethodsRule.php
+++ b/src/Rules/Methods/CallMethodsRule.php
@@ -13,19 +13,13 @@ use PHPStan\Type\ErrorType;
 class CallMethodsRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\FunctionCallParametersCheck
-	 */
+	/** @var \PHPStan\Rules\FunctionCallParametersCheck */
 	private $check;
 
-	/**
-	 * @var \PHPStan\Rules\RuleLevelHelper
-	 */
+	/** @var \PHPStan\Rules\RuleLevelHelper */
 	private $ruleLevelHelper;
 
 	/**

--- a/src/Rules/Methods/CallStaticMethodsRule.php
+++ b/src/Rules/Methods/CallStaticMethodsRule.php
@@ -20,24 +20,16 @@ use PHPStan\Type\TypeWithClassName;
 class CallStaticMethodsRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\FunctionCallParametersCheck
-	 */
+	/** @var \PHPStan\Rules\FunctionCallParametersCheck */
 	private $check;
 
-	/**
-	 * @var \PHPStan\Rules\RuleLevelHelper
-	 */
+	/** @var \PHPStan\Rules\RuleLevelHelper */
 	private $ruleLevelHelper;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	/**

--- a/src/Rules/Methods/CallStaticMethodsRule.php
+++ b/src/Rules/Methods/CallStaticMethodsRule.php
@@ -32,9 +32,7 @@ class CallStaticMethodsRule implements \PHPStan\Rules\Rule
 	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkFunctionNameCase;
 
 	public function __construct(

--- a/src/Rules/Namespaces/ExistingNamesInGroupUseRule.php
+++ b/src/Rules/Namespaces/ExistingNamesInGroupUseRule.php
@@ -11,14 +11,10 @@ use PHPStan\Rules\ClassCaseSensitivityCheck;
 class ExistingNamesInGroupUseRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	/**

--- a/src/Rules/Namespaces/ExistingNamesInGroupUseRule.php
+++ b/src/Rules/Namespaces/ExistingNamesInGroupUseRule.php
@@ -17,9 +17,7 @@ class ExistingNamesInGroupUseRule implements \PHPStan\Rules\Rule
 	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkFunctionNameCase;
 
 	public function __construct(

--- a/src/Rules/Namespaces/ExistingNamesInUseRule.php
+++ b/src/Rules/Namespaces/ExistingNamesInUseRule.php
@@ -10,14 +10,10 @@ use PHPStan\Rules\ClassCaseSensitivityCheck;
 class ExistingNamesInUseRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	/**

--- a/src/Rules/Namespaces/ExistingNamesInUseRule.php
+++ b/src/Rules/Namespaces/ExistingNamesInUseRule.php
@@ -16,9 +16,7 @@ class ExistingNamesInUseRule implements \PHPStan\Rules\Rule
 	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkFunctionNameCase;
 
 	public function __construct(

--- a/src/Rules/Properties/AccessPropertiesOnPossiblyNullRule.php
+++ b/src/Rules/Properties/AccessPropertiesOnPossiblyNullRule.php
@@ -11,14 +11,10 @@ use PHPStan\Type\UnionType;
 class AccessPropertiesOnPossiblyNullRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Rules\RuleLevelHelper
-	 */
+	/** @var \PHPStan\Rules\RuleLevelHelper */
 	private $ruleLevelHelper;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkThisOnly;
 
 	public function __construct(

--- a/src/Rules/Properties/AccessPropertiesRule.php
+++ b/src/Rules/Properties/AccessPropertiesRule.php
@@ -11,14 +11,10 @@ use PHPStan\Type\ErrorType;
 class AccessPropertiesRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\RuleLevelHelper
-	 */
+	/** @var \PHPStan\Rules\RuleLevelHelper */
 	private $ruleLevelHelper;
 
 	public function __construct(

--- a/src/Rules/Properties/AccessStaticPropertiesRule.php
+++ b/src/Rules/Properties/AccessStaticPropertiesRule.php
@@ -17,19 +17,13 @@ use PHPStan\Type\TypeCombinator;
 class AccessStaticPropertiesRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\RuleLevelHelper
-	 */
+	/** @var \PHPStan\Rules\RuleLevelHelper */
 	private $ruleLevelHelper;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
 	public function __construct(

--- a/src/Rules/Properties/ExistingClassesInPropertiesRule.php
+++ b/src/Rules/Properties/ExistingClassesInPropertiesRule.php
@@ -11,19 +11,13 @@ use PHPStan\Rules\ClassCaseSensitivityCheck;
 class ExistingClassesInPropertiesRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var \PHPStan\Rules\ClassCaseSensitivityCheck
-	 */
+	/** @var \PHPStan\Rules\ClassCaseSensitivityCheck */
 	private $classCaseSensitivityCheck;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkClassCaseSensitivity;
 
 	public function __construct(

--- a/src/Rules/Registry.php
+++ b/src/Rules/Registry.php
@@ -5,14 +5,10 @@ namespace PHPStan\Rules;
 class Registry
 {
 
-	/**
-	 * @var \PHPStan\Rules\Rule[][]
-	 */
+	/** @var \PHPStan\Rules\Rule[][] */
 	private $rules = [];
 
-	/**
-	 * @var \PHPStan\Rules\Rule[][]
-	 */
+	/** @var \PHPStan\Rules\Rule[][] */
 	private $cache = [];
 
 	/**

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -18,24 +18,16 @@ use PHPStan\Type\UnionType;
 class RuleLevelHelper
 {
 
-	/**
-	 * @var \PHPStan\Broker\Broker
-	 */
+	/** @var \PHPStan\Broker\Broker */
 	private $broker;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkNullables;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkThisOnly;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkUnionTypes;
 
 	public function __construct(

--- a/src/Rules/Variables/DefinedVariableInAnonymousFunctionUseRule.php
+++ b/src/Rules/Variables/DefinedVariableInAnonymousFunctionUseRule.php
@@ -9,9 +9,7 @@ use PHPStan\Analyser\Scope;
 class DefinedVariableInAnonymousFunctionUseRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkMaybeUndefinedVariables;
 
 	public function __construct(

--- a/src/Rules/Variables/DefinedVariableRule.php
+++ b/src/Rules/Variables/DefinedVariableRule.php
@@ -9,14 +9,10 @@ use PHPStan\Analyser\Scope;
 class DefinedVariableRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $cliArgumentsVariablesRegistered;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkMaybeUndefinedVariables;
 
 	public function __construct(

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -32,9 +32,7 @@ use PHPStan\Type\Type;
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
 
-	/**
-	 * @var \Nette\DI\Container
-	 */
+	/** @var \Nette\DI\Container */
 	private static $container;
 
 	public function getContainer(): \Nette\DI\Container

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -24,7 +24,7 @@ class FileTypeMapper
 	/** @var \PHPStan\PhpDoc\ResolvedPhpDocBlock[][] */
 	private $memoryCache = [];
 
-	/** @var (false|callable|\PHPStan\PhpDoc\ResolvedPhpDocBlock)[][] */
+	/** @var \PHPStan\PhpDoc\ResolvedPhpDocBlock[][]|false[][]|callable[][] */
 	private $inProcess = [];
 
 	public function __construct(
@@ -115,7 +115,6 @@ class FileTypeMapper
 				$this->inProcess[$fileName][$phpDocKey] = $data = $resolveCallback();
 				$phpDocMap[$phpDocKey] = $data;
 			}
-
 		} finally {
 			unset($this->inProcess[$fileName]);
 		}

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -18,9 +18,7 @@ class MixedType implements CompoundType
 	use MaybeOffsetAccessibleTypeTrait;
 	use UndecidedBooleanTypeTrait;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $isExplicitMixed;
 
 	public function __construct(bool $isExplicitMixed = false)

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -40,7 +40,6 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements \PHPStan\Type\
 					$itemType = $scope->getVariableType($itemVariableName);
 				}
 			}
-
 		} else {
 			$keyType = new MixedType();
 			$itemType = new MixedType();

--- a/src/Type/Php/AssertFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/AssertFunctionTypeSpecifyingExtension.php
@@ -14,9 +14,7 @@ use PHPStan\Type\FunctionTypeSpecifyingExtension;
 class AssertFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
@@ -22,9 +22,7 @@ use PHPStan\Type\StringType;
 class IsAFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsArrayFunctionTypeSpecifyingExtension.php
@@ -16,9 +16,7 @@ use PHPStan\Type\MixedType;
 class IsArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsBoolFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsBoolFunctionTypeSpecifyingExtension.php
@@ -15,9 +15,7 @@ use PHPStan\Type\FunctionTypeSpecifyingExtension;
 class IsBoolFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsCallableFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsCallableFunctionTypeSpecifyingExtension.php
@@ -15,9 +15,7 @@ use PHPStan\Type\FunctionTypeSpecifyingExtension;
 class IsCallableFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsFloatFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsFloatFunctionTypeSpecifyingExtension.php
@@ -15,18 +15,12 @@ use PHPStan\Type\FunctionTypeSpecifyingExtension;
 class IsFloatFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
 	{
-		return in_array(strtolower($functionReflection->getName()), [
-				'is_float',
-				'is_double',
-				'is_real',
-			], true)
+		return in_array(strtolower($functionReflection->getName()), ['is_float', 'is_double', 'is_real'], true)
 			&& isset($node->args[0])
 			&& !$context->null();
 	}

--- a/src/Type/Php/IsIntFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsIntFunctionTypeSpecifyingExtension.php
@@ -15,18 +15,12 @@ use PHPStan\Type\IntegerType;
 class IsIntFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
 	{
-		return in_array(strtolower($functionReflection->getName()), [
-				'is_int',
-				'is_integer',
-				'is_long',
-			], true)
+		return in_array(strtolower($functionReflection->getName()), ['is_int', 'is_integer', 'is_long'], true)
 			&& isset($node->args[0])
 			&& !$context->null();
 	}

--- a/src/Type/Php/IsIterableFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsIterableFunctionTypeSpecifyingExtension.php
@@ -16,9 +16,7 @@ use PHPStan\Type\MixedType;
 class IsIterableFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsNullFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsNullFunctionTypeSpecifyingExtension.php
@@ -15,9 +15,7 @@ use PHPStan\Type\NullType;
 class IsNullFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsNumericFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsNumericFunctionTypeSpecifyingExtension.php
@@ -18,9 +18,7 @@ use PHPStan\Type\UnionType;
 class IsNumericFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsObjectFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsObjectFunctionTypeSpecifyingExtension.php
@@ -15,9 +15,7 @@ use PHPStan\Type\ObjectWithoutClassType;
 class IsObjectFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsResourceFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsResourceFunctionTypeSpecifyingExtension.php
@@ -15,9 +15,7 @@ use PHPStan\Type\ResourceType;
 class IsResourceFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/src/Type/Php/IsStringFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsStringFunctionTypeSpecifyingExtension.php
@@ -15,9 +15,7 @@ use PHPStan\Type\StringType;
 class IsStringFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/**
-	 * @var \PHPStan\Analyser\TypeSpecifier
-	 */
+	/** @var \PHPStan\Analyser\TypeSpecifier */
 	private $typeSpecifier;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool

--- a/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
@@ -7,9 +7,7 @@ use PHPStan\File\FileHelper;
 class AnalyserTraitsIntegrationTest extends \PHPStan\Testing\TestCase
 {
 
-	/**
-	 * @var \PHPStan\File\FileHelper
-	 */
+	/** @var \PHPStan\File\FileHelper */
 	private $fileHelper;
 
 	protected function setUp(): void

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -21,7 +21,7 @@ use PHPStan\Type\UnionType;
 class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 {
 
-	/** @var \PhpParser\PrettyPrinter\Standard() */
+	/** @var \PhpParser\PrettyPrinter\Standard */
 	private $printer;
 
 	/** @var \PHPStan\Analyser\TypeSpecifier */

--- a/tests/PHPStan/Analyser/data/iterable.php
+++ b/tests/PHPStan/Analyser/data/iterable.php
@@ -15,34 +15,22 @@ interface CollectionOfIntegers extends \Iterator
 class Foo
 {
 
-	/**
-	 * @var iterable
-	 */
+	/** @var iterable */
 	private $iterableProperty;
 
-	/**
-	 * @var string[]|iterable
-	 */
+	/** @var string[]|iterable */
 	private $stringIterableProperty;
 
-	/**
-	 * @var mixed[]|iterable
-	 */
+	/** @var mixed[]|iterable */
 	private $mixedIterableProperty;
 
-	/**
-	 * @var string[]|iterable|int
-	 */
+	/** @var string[]|iterable|int */
 	private $iterablePropertyAlsoWithSomethingElse;
 
-	/**
-	 * @var string[]|int[]|iterable|int
-	 */
+	/** @var string[]|int[]|iterable|int */
 	private $iterablePropertyWithTwoItemTypes;
 
-	/**
-	 * @var CollectionOfIntegers|string[]
-	 */
+	/** @var CollectionOfIntegers|string[] */
 	private $collectionOfIntegersOrArrayOfStrings;
 
 	/**

--- a/tests/PHPStan/Analyser/data/properties-defined.php
+++ b/tests/PHPStan/Analyser/data/properties-defined.php
@@ -7,14 +7,10 @@ use SomeNamespace\Sit as Dolor;
 class Bar
 {
 
-	/**
-	 * @var Dolor
-	 */
+	/** @var Dolor */
 	protected $inheritedProperty;
 
-	/**
-	 * @var self
-	 */
+	/** @var self */
 	protected $inheritDocProperty;
 
 	public function doBar(): Self

--- a/tests/PHPStan/Analyser/data/properties.php
+++ b/tests/PHPStan/Analyser/data/properties.php
@@ -20,9 +20,7 @@ abstract class Foo extends Bar
 	 */
 	private $anotherMixedProperty;
 
-	/**
-	 * @vaz int
-	 */
+	/** @vaz int */
 	private $yetAnotherMixedProperty;
 
 	/** @var int */
@@ -37,84 +35,52 @@ abstract class Foo extends Bar
 	/** @var mixed[] */
 	private $arrayPropertyOther;
 
-	/**
-	 * @var Lorem
-	 */
+	/** @var Lorem */
 	private $objectRelative;
 
-	/**
-	 * @var \SomeOtherNamespace\Ipsum
-	 */
+	/** @var \SomeOtherNamespace\Ipsum */
 	private $objectFullyQualified;
 
-	/**
-	 * @var Dolor
-	 */
+	/** @var Dolor */
 	private $objectUsed;
 
-	/**
-	 * @var null|int
-	 */
+	/** @var null|int */
 	private $nullableInteger;
 
-	/**
-	 * @var Dolor|null
-	 */
+	/** @var Dolor|null */
 	private $nullableObject;
 
-	/**
-	 * @var self
-	 */
+	/** @var self */
 	private $selfType;
 
-	/**
-	 * @var static
-	 */
+	/** @var static */
 	private $staticType;
 
-	/**
-	 * @var null
-	 */
+	/** @var null */
 	private $nullType;
 
-	/**
-	 * @var Bar
-	 */
+	/** @var Bar */
 	private $barObject;
 
-	/**
-	 * @var [$invalidType]
-	 */
+	/** @var [$invalidType] */
 	private $invalidTypeProperty;
 
-	/**
-	 * @var resource
-	 */
+	/** @var resource */
 	private $resource;
 
-	/**
-	 * @var array[array]
-	 */
+	/** @var array[array] */
 	private $yetAnotherAnotherMixedParameter;
 
-	/**
-	 * @var \\Test\Bar
-	 */
+	/** @var \\Test\Bar */
 	private $yetAnotherAnotherAnotherMixedParameter;
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private static $staticStringProperty;
 
-	/**
-	 * @var One
-	 */
+	/** @var One */
 	private $groupUseProperty;
 
-	/**
-	 * @var Too
-	 */
+	/** @var Too */
 	private $anotherGroupUseProperty;
 
 	/**
@@ -122,24 +88,16 @@ abstract class Foo extends Bar
 	 */
 	protected $inheritDocProperty;
 
-	/**
-	 * @var \PHPUnit_Framework_MockObject_MockObject|Foo
-	 */
+	/** @var \PHPUnit_Framework_MockObject_MockObject|Foo */
 	private $phpunitProperty;
 
-	/**
-	 * @var Foo|\PHPUnit_Framework_MockObject_MockObject
-	 */
+	/** @var Foo|\PHPUnit_Framework_MockObject_MockObject */
 	private $anotherPhpunitProperty;
 
-	/**
-	 * @var Foo|\PHPUnit\Framework\MockObject\MockObject
-	 */
+	/** @var Foo|\PHPUnit\Framework\MockObject\MockObject */
 	private $yetAnotherPhpunitProperty;
 
-	/**
-	 * @var Foo|MockObject
-	 */
+	/** @var Foo|MockObject */
 	private $yetYetAnotherPhpunitProperty;
 
 	public function doFoo()

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -11,9 +11,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 class CheckstyleErrorFormatterTest extends \PHPStan\Testing\TestCase
 {
 
-	/**
-	 * @var CheckstyleErrorFormatter
-	 */
+	/** @var CheckstyleErrorFormatter */
 	protected $formatter;
 
 	/**

--- a/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
@@ -11,9 +11,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 class JsonErrorFormatterTest extends \PHPStan\Testing\TestCase
 {
 
-	/**
-	 * @var \PHPStan\Command\ErrorFormatter\JsonErrorFormatter
-	 */
+	/** @var \PHPStan\Command\ErrorFormatter\JsonErrorFormatter */
 	private $formatter;
 
 	protected function setUp(): void

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -9,9 +9,7 @@ use PHPStan\Rules\RuleLevelHelper;
 class CallStaticMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 {
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkThisOnly;
 
 	protected function getRule(): \PHPStan\Rules\Rule

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -10,9 +10,7 @@ class AccessPropertiesRuleTest extends \PHPStan\Testing\RuleTestCase
 	/** @var bool */
 	private $checkThisOnly;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkUnionTypes;
 
 	protected function getRule(): \PHPStan\Rules\Rule

--- a/tests/PHPStan/Rules/Variables/DefinedVariableInAnonymousFunctionUseRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableInAnonymousFunctionUseRuleTest.php
@@ -5,9 +5,7 @@ namespace PHPStan\Rules\Variables;
 class DefinedVariableInAnonymousFunctionUseRuleTest extends \PHPStan\Testing\RuleTestCase
 {
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkMaybeUndefinedVariables;
 
 	protected function getRule(): \PHPStan\Rules\Rule

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -5,24 +5,16 @@ namespace PHPStan\Rules\Variables;
 class DefinedVariableRuleTest extends \PHPStan\Testing\RuleTestCase
 {
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $cliArgumentsVariablesRegistered;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $checkMaybeUndefinedVariables;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $polluteScopeWithLoopInitialAssignments;
 
-	/**
-	 * @var bool
-	 */
+	/** @var bool */
 	private $polluteCatchScopeWithTryAssignments;
 
 	protected function getRule(): \PHPStan\Rules\Rule


### PR DESCRIPTION
I've updated our `slevomat/codings-standard` to v4.4. Didn't update to v4.5 as some conflicts of min-version of PHPCS and `consistence/coding-standard` :(

/cc @kukulich there are some [internals errors happening](https://travis-ci.org/phpstan/phpstan/builds/353854612), are there related to `slevomat`?