### PR TITLE
Don't use array_push

### DIFF
--- a/src/Command/ErrorFormatter/JsonErrorFormatter.php
+++ b/src/Command/ErrorFormatter/JsonErrorFormatter.php
@@ -29,15 +29,15 @@ class JsonErrorFormatter implements ErrorFormatter
 			}
 			$errorsArray['files'][$fileSpecificError->getFile()]['errors']++;
 
-			array_push($errorsArray['files'][$fileSpecificError->getFile()]['messages'], [
+			$errorsArray['files'][$fileSpecificError->getFile()]['messages'][] = [
 				'message' => $fileSpecificError->getMessage(),
 				'line' => $fileSpecificError->getLine(),
 				'ignorable' => $fileSpecificError->canBeIgnored(),
-			]);
+			];
 		}
 
 		foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
-			array_push($errorsArray['errors'], $notFileSpecificError);
+			$errorsArray['errors'][] = $notFileSpecificError;
 		}
 
 		$json = Json::encode($errorsArray);


### PR DESCRIPTION
https://secure.php.net/manual/en/function.array-push.php

> Note: If you use array_push() to add one element to the array it's better to use $array[] = because in that way there is no overhead of calling a function.