### PR TITLE
WIP: File Caching

### DIFF
--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -96,7 +96,7 @@ class AnalyseApplication
 			} elseif (is_file($path)) {
 				$files[] = $this->fileHelper->normalizePath($path);
 			} else {
-				$files = $files + $this->loadFiles($path, $onlyFiles, $enableCache, $clearCache);
+				$files = $files + $this->loadFiles($path, $onlyFiles, $enableCache, $clearCache, $style, $debug);
 			}
 		}
 
@@ -163,9 +163,12 @@ class AnalyseApplication
 		);
 	}
 
-	private function loadFiles(string $path, &$onlyFiles, bool $enableCache, bool $clearCache): array
+	private function loadFiles(string $path, &$onlyFiles, bool $enableCache, bool $clearCache, OutputStyle $style, bool $debug): array
 	{
 		if ($enableCache && !$clearCache && ($files = $this->cache->load('analyse-files-' . $path)) !== null) {
+			if ($debug) {
+				$style->writeln(sprintf('Loaded %d files from cache', count($files)));
+			}
 			return $files;
 		}
 

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -192,9 +192,12 @@ class AnalyseApplication
 					sprintf('Loaded %d files from cache', count($files)),
 					true
 				);
+
+				return $files;
 			}
 
-			return $files;
+			$this->logMessage('No files loaded from cache');
+			$this->logMessage('Note: When using docker, you must mount a folder to the "tmpDir" folder for caching to work correctly.', true);
 		}
 
 		$this->logMessage('Scanning File System');

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -36,6 +36,8 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 				new InputOption('autoload-file', 'a', InputOption::VALUE_REQUIRED, 'Project\'s additional autoload file path'),
 				new InputOption('errorFormat', null, InputOption::VALUE_REQUIRED, 'Format in which to print the result of the analysis', 'table'),
 				new InputOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Memory limit for analysis'),
+				new InputOption('cache', null, InputOption::VALUE_NONE, 'Enable Path Level Caching'),
+				new InputOption('cache-clear', null, InputOption::VALUE_NONE, 'Force reloading of files.')
 			]);
 	}
 
@@ -219,7 +221,9 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 				$consoleStyle,
 				$errorFormatter,
 				$defaultLevelUsed,
-				$input->getOption('debug')
+				$input->getOption('debug'),
+				$input->getOption('cache'),
+				$input->getOption('cache-clear')
 			),
 			$memoryLimitFile
 		);


### PR DESCRIPTION
Still working on this, but looking for any preliminary comments and or discussions. I've a project with over 5000 files in it. It usually takes a minute or two for PHPStan just to scan the files. This PR is too add a caching mechanism to the system such that it doesn't have to rescan every time, by specifying the --cache option. Specifying --cache-clear in combination with --cache will force the cache to refresh itself (In the event of new files, etc).