### PR TITLE
array_search return type is always array key|false

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -251,6 +251,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\ArraySearchFunctionDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\ArrayValuesFunctionDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\ConstantScalarType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
+use PHPStan\Type\UnionType;
+
+final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'array_search';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		if (count($functionCall->args) < 3) {
+			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		}
+
+		$strictArgType = $scope->getType($functionCall->args[2]->value);
+		$haystackArgType = $scope->getType($functionCall->args[1]->value);
+		if (!($strictArgType instanceof ConstantBooleanType) || $strictArgType->getValue() === false) {
+			return new UnionType([$haystackArgType->getIterableKeyType(), new ConstantBooleanType(false), new NullType()]);
+		}
+
+		$needleArgType = $scope->getType($functionCall->args[0]->value);
+
+		if (count(TypeUtils::getArrays($haystackArgType)) === 0) {
+			return new NullType();
+		}
+
+		if ($haystackArgType->getIterableValueType()->isSuperTypeOf($needleArgType)->no()) {
+			return new ConstantBooleanType(false);
+		}
+
+		if ($haystackArgType instanceof ConstantArrayType) {
+			return $this->resolveTypeFromConstantHaystackAndNeedle($needleArgType, $haystackArgType);
+		}
+
+		return TypeCombinator::union($haystackArgType->getIterableKeyType(), new ConstantBooleanType(false));
+	}
+
+	private function resolveTypeFromConstantHaystackAndNeedle(Type $needle, ConstantArrayType $haystack): Type
+	{
+		$matchesByType = [];
+
+		foreach ($haystack->getValueTypes() as $index => $valueType) {
+			if ($needle->isSuperTypeOf($valueType)->no()) {
+				$matchesByType[] = new ConstantBooleanType(false);
+				continue;
+			}
+
+			if ($needle instanceof ConstantScalarType && $valueType instanceof ConstantScalarType
+				&& $needle->getValue() === $valueType->getValue()
+			) {
+				return $haystack->getKeyTypes()[$index];
+			}
+
+			$matchesByType[] = $haystack->getKeyTypes()[$index];
+		}
+
+		if (count($matchesByType) > 0) {
+			if (
+				$haystack->getIterableValueType()->accepts($needle, true)->yes()
+				&& $needle->isSuperTypeOf(new ObjectWithoutClassType())->no()
+			) {
+				return TypeCombinator::union(...$matchesByType);
+			}
+
+			return TypeCombinator::union(new ConstantBooleanType(false), ...$matchesByType);
+		}
+
+		return new ConstantBooleanType(false);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4148,6 +4148,42 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array<int, int|true>',
 				'array_filter($withPossiblyFalsey)',
 			],
+			[
+				'1|\'foo\'|false',
+				'array_search(new stdClass, $stringOrIntegerKeys, true)',
+			],
+			[
+				'\'foo\'',
+				'array_search(\'foo\', $stringKeys, true)',
+			],
+			[
+				'int|false',
+				'array_search(new DateTimeImmutable(), $generalDateTimeValues, true)',
+			],
+			[
+				'string|false',
+				'array_search(9, $generalStringKeys, true)',
+			],
+			[
+				'null',
+				'array_search(999, $integer, true)',
+			],
+			[
+				'false',
+				'array_search(new stdClass, $generalStringKeys, true)',
+			],
+			[
+				'\'foo\'|false',
+				'array_search($generalIntegerOrString, $stringKeys, true)',
+			],
+			[
+				'int|false',
+				'array_search($generalIntegerOrString, $generalArrayOfIntegersOrStrings, true)',
+			],
+			[
+				'int|false',
+				'array_search($generalIntegerOrString, $clonedConditionalArray, true)',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/array-functions.php
+++ b/tests/PHPStan/Analyser/data/array-functions.php
@@ -97,4 +97,13 @@ if (doFoo()) {
 	$conditionalKeysArray['lorem'] = 1;
 }
 
+/** @var int|string $generalIntegerOrString */
+$generalIntegerOrString = doFoo();
+
+/** @var array<int, int|string> $generalArrayOfIntegersOrStrings */
+$generalArrayOfIntegersOrStrings = doFoo();
+
+$clonedConditionalArray = $conditionalArray;
+$clonedConditionalArray[(int)$generalIntegerOrString] = $generalIntegerOrString;
+
 die;


### PR DESCRIPTION
Hi,
I want to specify return type of array_search function.
Consider following code:
```php
class A
{
    /**
      * @var array<string, MyType>
      */
    private $table = [];
   
    public function getTypeByValue(MyType $value): string
    {
        $key = array_search($value, $this->table, true);
        if ($key === false) {
            throw new \Exception;
        }
        return $key;
    }
}
class MyType{}
```

We definitely know that returned value should be string (exception is thrown if value not found).