### PR TITLE
nikic/php-parser for PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"nette/di": "^2.4.7 || ^3.0",
 		"nette/robot-loader": "^3.0.1",
 		"nette/utils": "^2.4.5 || ^3.0",
-		"nikic/php-parser": "^3.1",
+		"nikic/php-parser": "^4.0",
 		"symfony/console": "~3.2 || ~4.0",
 		"symfony/finder": "~3.2 || ~4.0",
 		"jean85/pretty-package-versions": "^1.0.3",


### PR DESCRIPTION
> Documentation for version 4.x (stable; for running on PHP >= 7.0; for parsing PHP 5.2 to PHP 7.2)

https://github.com/nikic/PHP-Parser/blob/master/README.md