### PR TITLE
Run dynamic return extensions for all compound types

### DIFF
--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -45,6 +45,7 @@ use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
@@ -1108,12 +1109,19 @@ class Scope
 		if ($node instanceof MethodCall && is_string($node->name)) {
 			$methodCalledOnType = $this->getType($node->var);
 			$referencedClasses = $methodCalledOnType->getReferencedClasses();
-			if (
-				count($referencedClasses) === 1
-				&& $this->broker->hasClass($referencedClasses[0])
-			) {
-				$methodClassReflection = $this->broker->getClass($referencedClasses[0]);
+
+			$resolvedTypes = [];
+			foreach ($referencedClasses as $referencedClass) {
+				if (!$this->broker->hasClass($referencedClass)) {
+					continue;
+				}
+
+				$methodClassReflection = $this->broker->getClass($referencedClass);
 				if (!$methodClassReflection->hasMethod($node->name)) {
+					if ($methodCalledOnType instanceof IntersectionType) {
+						continue;
+					}
+
 					return new ErrorType();
 				}
 
@@ -1123,8 +1131,11 @@ class Scope
 						continue;
 					}
 
-					return $dynamicMethodReturnTypeExtension->getTypeFromMethodCall($methodReflection, $node, $this);
+					$resolvedTypes[] = $dynamicMethodReturnTypeExtension->getTypeFromMethodCall($methodReflection, $node, $this);
 				}
+			}
+			if (count($resolvedTypes) > 0) {
+				return TypeCombinator::union(...$resolvedTypes);
 			}
 
 			if (!$methodCalledOnType->hasMethod($node->name)) {
@@ -1159,19 +1170,26 @@ class Scope
 			}
 			$staticMethodReflection = $calleeType->getMethod($node->name, $this);
 			$referencedClasses = $calleeType->getReferencedClasses();
-			if (
-				count($calleeType->getReferencedClasses()) === 1
-				&& $this->broker->hasClass($referencedClasses[0])
-			) {
-				$staticMethodClassReflection = $this->broker->getClass($referencedClasses[0]);
+
+			$resolvedTypes = [];
+			foreach ($referencedClasses as $referencedClass) {
+				if (!$this->broker->hasClass($referencedClass)) {
+					continue;
+				}
+
+				$staticMethodClassReflection = $this->broker->getClass($referencedClass);
 				foreach ($this->broker->getDynamicStaticMethodReturnTypeExtensionsForClass($staticMethodClassReflection->getName()) as $dynamicStaticMethodReturnTypeExtension) {
 					if (!$dynamicStaticMethodReturnTypeExtension->isStaticMethodSupported($staticMethodReflection)) {
 						continue;
 					}
 
-					return $dynamicStaticMethodReturnTypeExtension->getTypeFromStaticMethodCall($staticMethodReflection, $node, $this);
+					$resolvedTypes[] = $dynamicStaticMethodReturnTypeExtension->getTypeFromStaticMethodCall($staticMethodReflection, $node, $this);
 				}
 			}
+			if (count($resolvedTypes) > 0) {
+				return TypeCombinator::union(...$resolvedTypes);
+			}
+
 			if ($staticMethodReflection->getReturnType() instanceof StaticResolvableType) {
 				if ($node->class instanceof Name) {
 					$nodeClassString = strtolower((string) $node->class);


### PR DESCRIPTION
Hi,
now dynamic return type extensions are run only for first type of compoud types. This PR makes change that dynamic return type extensions are run on all compound types and then unioned.
If calle type is intersection then method must exist in at least one type.
This PR changes behaviour of instance call `$var->method()` as well static call `$var::method()`.