### PR TITLE
Recfactor checkstyle error formatter

### DIFF
--- a/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
+++ b/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
@@ -20,33 +20,28 @@ class CheckstyleErrorFormatter implements ErrorFormatter
 		OutputStyle $style
 	): int
 	{
-		$returnCode = 1;
-		if (!$analysisResult->hasErrors()) {
-			$returnCode = 0;
-		}
-
-		$out = '';
+		$style->writeln('<?xml version="1.0" encoding="UTF-8"?>');
+		$style->writeln('<checkstyle>');
 
 		foreach ($this->groupByFile($analysisResult) as $relativeFilePath => $errors) {
-			$out .= '<file name="' . $this->escape($relativeFilePath) . '">' . "\n";
+			$style->writeln(sprintf(
+				'<file name="%s">',
+				$this->escape($relativeFilePath)
+			));
+
 			foreach ($errors as $error) {
-				$out .= sprintf(
-					'  <error line="%d" column="1" severity="error" message="%s" />' . "\n",
+				$style->writeln(sprintf(
+					'  <error line="%d" column="1" severity="error" message="%s" />',
 					$this->escape((string) $error->getLine()),
 					$this->escape((string) $error->getMessage())
-				);
+				));
 			}
-			$out .= '</file>' . "\n";
+			$style->writeln('</file>');
 		}
 
-		$style->write('<?xml version="1.0" encoding="UTF-8"?>' . "\n");
-		$style->write('<checkstyle>' . "\n");
-		if ($out !== '') {
-			$style->write($out);
-		}
-		$style->write('</checkstyle>' . "\n");
+		$style->writeln('</checkstyle>');
 
-		return $returnCode;
+		return $analysisResult->hasErrors() ? 1 : 0;
 	}
 
 	/**

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -2,54 +2,55 @@
 
 namespace PHPStan\Command\ErrorFormatter;
 
-use PHPStan\Analyser\Error;
-use PHPStan\Command\AnalysisResult;
-use PHPStan\Command\ErrorsConsoleStyle;
-use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Output\StreamOutput;
-
-class CheckstyleErrorFormatterTest extends \PHPStan\Testing\TestCase
+class CheckstyleErrorFormatterTest extends TestBaseFormatter
 {
 
-	private const DIRECTORY_PATH = '/data/folder/with space/and unicode 😃/project';
-
-	/** @var CheckstyleErrorFormatter */
-	protected $formatter;
-
-	protected function setUp(): void
+	public function checkstyleOutputProvider(): iterable
 	{
-		$this->formatter = new CheckstyleErrorFormatter();
-	}
-
-	public function testFormatErrors(): void
-	{
-		$analysisResult = new AnalysisResult(
-			[
-				new Error('Foo', self::DIRECTORY_PATH . '/foo.php', 1),
-				new Error('Bar', self::DIRECTORY_PATH . '/foo.php', 5),
-				new Error('Bar', self::DIRECTORY_PATH . '/file name with "spaces" and unicode 😃.php', 2),
-				new Error('Foo', self::DIRECTORY_PATH . '/file name with "spaces" and unicode 😃.php', 4),
-			],
-			[],
-			false,
-			self::DIRECTORY_PATH
-		);
-		$resource = fopen('php://memory', 'w', false);
-		if ($resource === false) {
-			throw new \PHPStan\ShouldNotHappenException();
-		}
-
-		$outputStream = new StreamOutput($resource);
-
-		$style = new ErrorsConsoleStyle(new StringInput(''), $outputStream);
-		$this->assertSame(1, $this->formatter->formatErrors($analysisResult, $style));
-
-		rewind($outputStream->getStream());
-		$output = stream_get_contents($outputStream->getStream());
-
-		$expected = '<?xml version="1.0" encoding="UTF-8"?>
+		yield [
+			'No errors',
+			0,
+			0,
+			0,
+			'<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
-<file name="file name with &quot;spaces&quot; and unicode 😃.php">
+</checkstyle>
+',
+		];
+
+		yield [
+			'One file error',
+			1,
+			1,
+			0,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+<file name="folder with unicode 😃/file name with &quot;spaces&quot; and unicode 😃.php">
+ <error line="4" column="1" severity="error" message="Foo"/>
+</file>
+</checkstyle>
+',
+		];
+
+		yield [
+			'One generic error',
+			1,
+			0,
+			1,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+</checkstyle>
+',
+		];
+
+		yield [
+			'Multiple file errors',
+			1,
+			4,
+			0,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+<file name="folder with unicode 😃/file name with &quot;spaces&quot; and unicode 😃.php">
  <error line="2" column="1" severity="error" message="Bar"/>
  <error line="4" column="1" severity="error" message="Foo"/>
 </file>
@@ -58,31 +59,65 @@ class CheckstyleErrorFormatterTest extends \PHPStan\Testing\TestCase
  <error line="5" column="1" severity="error" message="Bar"/>
 </file>
 </checkstyle>
-';
-		$this->assertXmlStringEqualsXmlString($expected, $output);
-	}
+',
+		];
 
-	public function testFormatErrorsEmpty(): void
-	{
-		$analysisResult = new AnalysisResult([], [], false, self::DIRECTORY_PATH);
-		$resource = fopen('php://memory', 'w', false);
-		if ($resource === false) {
-			throw new \PHPStan\ShouldNotHappenException();
-		}
-
-		$outputStream = new StreamOutput($resource);
-		$style = new ErrorsConsoleStyle(new StringInput(''), $outputStream);
-
-		$this->assertSame(0, $this->formatter->formatErrors($analysisResult, $style));
-
-		rewind($outputStream->getStream());
-		$output = stream_get_contents($outputStream->getStream());
-
-		$expected = '<?xml version="1.0" encoding="UTF-8"?>
+		yield [
+			'Multiple generic errors',
+			1,
+			0,
+			2,
+			'<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
 </checkstyle>
-';
-		$this->assertXmlStringEqualsXmlString($expected, $output);
+',
+		];
+
+		yield [
+			'Multiple file, multiple generic errors',
+			1,
+			4,
+			2,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+<file name="folder with unicode 😃/file name with &quot;spaces&quot; and unicode 😃.php">
+ <error line="2" column="1" severity="error" message="Bar"/>
+ <error line="4" column="1" severity="error" message="Foo"/>
+</file>
+<file name="foo.php">
+ <error line="1" column="1" severity="error" message="Foo"/>
+ <error line="5" column="1" severity="error" message="Bar"/>
+</file>
+</checkstyle>
+',
+		];
+	}
+
+	/**
+	 * @param string $message          Test message
+	 * @param int    $exitCode         Expected exit code from the application
+	 * @param int    $numFileErrors    Number of errors for file
+	 * @param int    $numGenericErrors Number of generic errors
+	 * @param string $expected         Expected output
+	 *
+	 * @dataProvider checkstyleOutputProvider
+	 */
+	public function testFormatErrors(
+		string $message,
+		int $exitCode,
+		int $numFileErrors,
+		int $numGenericErrors,
+		string $expected
+	): void
+	{
+		$formatter = new CheckstyleErrorFormatter();
+
+		$this->assertSame($exitCode, $formatter->formatErrors(
+			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
+			$this->getErrorConsoleStyle()
+		), sprintf('%s: response code do not match', $message));
+
+		$this->assertXmlStringEqualsXmlString($expected, $this->getOutputContent(), sprintf('%s: XML do not match', $message));
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -26,7 +26,7 @@ class CheckstyleErrorFormatterTest extends TestBaseFormatter
 			'<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
 <file name="folder with unicode 😃/file name with &quot;spaces&quot; and unicode 😃.php">
- <error line="4" column="1" severity="error" message="Foo"/>
+  <error line="4" column="1" severity="error" message="Foo"/>
 </file>
 </checkstyle>
 ',
@@ -51,12 +51,12 @@ class CheckstyleErrorFormatterTest extends TestBaseFormatter
 			'<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
 <file name="folder with unicode 😃/file name with &quot;spaces&quot; and unicode 😃.php">
- <error line="2" column="1" severity="error" message="Bar"/>
- <error line="4" column="1" severity="error" message="Foo"/>
+  <error line="2" column="1" severity="error" message="Bar"/>
+  <error line="4" column="1" severity="error" message="Foo"/>
 </file>
 <file name="foo.php">
- <error line="1" column="1" severity="error" message="Foo"/>
- <error line="5" column="1" severity="error" message="Bar"/>
+  <error line="1" column="1" severity="error" message="Foo"/>
+  <error line="5" column="1" severity="error" message="Bar"/>
 </file>
 </checkstyle>
 ',
@@ -81,12 +81,12 @@ class CheckstyleErrorFormatterTest extends TestBaseFormatter
 			'<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
 <file name="folder with unicode 😃/file name with &quot;spaces&quot; and unicode 😃.php">
- <error line="2" column="1" severity="error" message="Bar"/>
- <error line="4" column="1" severity="error" message="Foo"/>
+  <error line="2" column="1" severity="error" message="Bar"/>
+  <error line="4" column="1" severity="error" message="Foo"/>
 </file>
 <file name="foo.php">
- <error line="1" column="1" severity="error" message="Foo"/>
- <error line="5" column="1" severity="error" message="Bar"/>
+  <error line="1" column="1" severity="error" message="Foo"/>
+  <error line="5" column="1" severity="error" message="Bar"/>
 </file>
 </checkstyle>
 ',

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Command\ErrorFormatter;
 class CheckstyleErrorFormatterTest extends TestBaseFormatter
 {
 
-	public function checkstyleOutputProvider(): iterable
+	public function dataFormatterOutputProvider(): iterable
 	{
 		yield [
 			'No errors',
@@ -94,13 +94,13 @@ class CheckstyleErrorFormatterTest extends TestBaseFormatter
 	}
 
 	/**
-	 * @param string $message          Test message
-	 * @param int    $exitCode         Expected exit code from the application
-	 * @param int    $numFileErrors    Number of errors for file
-	 * @param int    $numGenericErrors Number of generic errors
-	 * @param string $expected         Expected output
+	 * @dataProvider dataFormatterOutputProvider
 	 *
-	 * @dataProvider checkstyleOutputProvider
+	 * @param string $message
+	 * @param int    $exitCode
+	 * @param int    $numFileErrors
+	 * @param int    $numGenericErrors
+	 * @param string $expected
 	 */
 	public function testFormatErrors(
 		string $message,

--- a/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Command\ErrorFormatter;
 class JsonErrorFormatterTest extends TestBaseFormatter
 {
 
-	public function jsonOutputProvider(): iterable
+	public function dataFormatterOutputProvider(): iterable
 	{
 		yield [
 			'No errors',
@@ -186,13 +186,13 @@ class JsonErrorFormatterTest extends TestBaseFormatter
 	}
 
 	/**
-	 * @param string $message          Test message
-	 * @param int    $exitCode         Expected exit code from the application
-	 * @param int    $numFileErrors    Number of errors for file
-	 * @param int    $numGenericErrors Number of generic errors
-	 * @param string $expected         Expected output
+	 * @dataProvider dataFormatterOutputProvider
 	 *
-	 * @dataProvider jsonOutputProvider
+	 * @param string $message
+	 * @param int    $exitCode
+	 * @param int    $numFileErrors
+	 * @param int    $numGenericErrors
+	 * @param string $expected
 	 */
 	public function testPrettyFormatErrors(
 		string $message,
@@ -213,13 +213,14 @@ class JsonErrorFormatterTest extends TestBaseFormatter
 	}
 
 	/**
-	 * @param string $message          Test message
-	 * @param int    $exitCode         Expected exit code from the application
-	 * @param int    $numFileErrors    Number of errors for file
-	 * @param int    $numGenericErrors Number of generic errors
-	 * @param string $expected         Expected output
+	 * @dataProvider dataFormatterOutputProvider
 	 *
-	 * @dataProvider jsonOutputProvider
+	 * @param string $message
+	 * @param int    $exitCode
+	 * @param int    $numFileErrors
+	 * @param int    $numGenericErrors
+	 * @param string $expected
+	 *
 	 */
 	public function testFormatErrors(
 		string $message,

--- a/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Command\ErrorFormatter;
 class RawErrorFormatterTest extends TestBaseFormatter
 {
 
-	public function rawOutputProvider(): iterable
+	public function dataFormatterOutputProvider(): iterable
 	{
 		yield [
 			'No errors',
@@ -71,13 +71,13 @@ class RawErrorFormatterTest extends TestBaseFormatter
 	}
 
 	/**
-	 * @param string $message          Test message
-	 * @param int    $exitCode         Expected exit code from the application
-	 * @param int    $numFileErrors    Number of errors for file
-	 * @param int    $numGenericErrors Number of generic errors
-	 * @param string $expected         Expected output
+	 * @dataProvider dataFormatterOutputProvider
 	 *
-	 * @dataProvider rawOutputProvider
+	 * @param string $message
+	 * @param int    $exitCode
+	 * @param int    $numFileErrors
+	 * @param int    $numGenericErrors
+	 * @param string $expected
 	 */
 	public function testFormatErrors(
 		string $message,

--- a/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
@@ -2,94 +2,99 @@
 
 namespace PHPStan\Command\ErrorFormatter;
 
-use PHPStan\Analyser\Error;
-use PHPStan\Command\AnalysisResult;
-use PHPStan\Command\ErrorsConsoleStyle;
-use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\StreamOutput;
-
-class RawErrorFormatterTest extends \PHPStan\Testing\TestCase
+class RawErrorFormatterTest extends TestBaseFormatter
 {
 
-	private const DIRECTORY_PATH = '/data/folder/with space/and unicode 😃/project';
-
-	/** @var RawErrorFormatter */
-	protected $formatter;
-
-	protected function setUp(): void
+	public function rawOutputProvider(): iterable
 	{
-		$this->formatter = new RawErrorFormatter();
-	}
+		yield [
+			'No errors',
+			0,
+			0,
+			0,
+			'',
+		];
 
-	public function testFormatErrors(): void
-	{
-		$analysisResult = new AnalysisResult(
-			[
-				new Error('Foo', self::DIRECTORY_PATH . '/foo.php', 1),
-				new Error('Bar', self::DIRECTORY_PATH . '/file name with "spaces" and unicode 😃.php', 2),
-			],
-			[
-				'first generic error',
-				'second generic error',
-			],
-			false,
-			self::DIRECTORY_PATH
-		);
-		$resource = fopen('php://memory', 'w', false);
-		if ($resource === false) {
-			throw new \PHPStan\ShouldNotHappenException();
-		}
+		yield [
+			'One file error',
+			1,
+			1,
+			0,
+			'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:4:Foo
+',
+		];
 
-		$outputStream = new StreamOutput($resource, OutputInterface::VERBOSITY_NORMAL, false);
-		$style = new ErrorsConsoleStyle(new StringInput(''), $outputStream);
+		yield [
+			'One generic error',
+			1,
+			0,
+			1,
+			'?:?:first generic error
+',
+		];
 
-		$this->assertEquals(1, $this->formatter->formatErrors($analysisResult, $style));
-
-		rewind($outputStream->getStream());
-		$output = stream_get_contents($outputStream->getStream());
-
-		$expected = '?:?:first generic error
-?:?:second generic error
-/data/folder/with space/and unicode 😃/project/file name with "spaces" and unicode 😃.php:2:Bar
+		yield [
+			'Multiple file errors',
+			1,
+			4,
+			0,
+			'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:2:Bar
+/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:4:Foo
 /data/folder/with space/and unicode 😃/project/foo.php:1:Foo
-';
+/data/folder/with space/and unicode 😃/project/foo.php:5:Bar
+',
+		];
 
-		$this->assertEquals($expected, $this->rtrimMultiline($output));
+		yield [
+			'Multiple generic errors',
+			1,
+			0,
+			2,
+			'?:?:first generic error
+?:?:second generic error
+',
+		];
+
+		yield [
+			'Multiple file, multiple generic errors',
+			1,
+			4,
+			2,
+			'?:?:first generic error
+?:?:second generic error
+/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:2:Bar
+/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:4:Foo
+/data/folder/with space/and unicode 😃/project/foo.php:1:Foo
+/data/folder/with space/and unicode 😃/project/foo.php:5:Bar
+',
+		];
 	}
 
-	public function testFormatErrorsEmpty(): void
+	/**
+	 * @param string $message          Test message
+	 * @param int    $exitCode         Expected exit code from the application
+	 * @param int    $numFileErrors    Number of errors for file
+	 * @param int    $numGenericErrors Number of generic errors
+	 * @param string $expected         Expected output
+	 *
+	 * @dataProvider rawOutputProvider
+	 */
+	public function testFormatErrors(
+		string $message,
+		int $exitCode,
+		int $numFileErrors,
+		int $numGenericErrors,
+		string $expected
+	): void
 	{
-		$analysisResult = new AnalysisResult(
-			[],
-			[],
-			false,
-			self::DIRECTORY_PATH
-		);
-		$resource = fopen('php://memory', 'w', false);
-		if ($resource === false) {
-			throw new \PHPStan\ShouldNotHappenException();
-		}
+		$formatter = new RawErrorFormatter();
 
-		$outputStream = new StreamOutput($resource, OutputInterface::VERBOSITY_NORMAL, false);
-		$style = new ErrorsConsoleStyle(new StringInput(''), $outputStream);
+		$this->assertSame($exitCode, $formatter->formatErrors(
+			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
+			$this->getErrorConsoleStyle()
+		), sprintf('%s: response code do not match', $message));
 
-		$this->assertEquals(0, $this->formatter->formatErrors($analysisResult, $style));
-
-		rewind($outputStream->getStream());
-		$output = stream_get_contents($outputStream->getStream());
-
-		$expected = '';
-		$this->assertEquals($expected, $this->rtrimMultiline($output));
-	}
-
-	private function rtrimMultiline(string $output): string
-	{
-		$result = array_map(function (string $line): string {
-			return rtrim($line, " \r\n");
-		}, explode("\n", $output));
-
-		return implode("\n", $result);
+		$this->assertEquals($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Command\ErrorFormatter;
 class TableErrorFormatterTest extends TestBaseFormatter
 {
 
-	public function tableOutputProvider(): iterable
+	public function dataFormatterOutputProvider(): iterable
 	{
 		yield [
 			'No errors',
@@ -124,13 +124,13 @@ class TableErrorFormatterTest extends TestBaseFormatter
 	}
 
 	/**
-	 * @param string $message          Test message
-	 * @param int    $exitCode         Expected exit code from the application
-	 * @param int    $numFileErrors    Number of errors for file
-	 * @param int    $numGenericErrors Number of generic errors
-	 * @param string $expected         Expected output
+	 * @dataProvider dataFormatterOutputProvider
 	 *
-	 * @dataProvider tableOutputProvider
+	 * @param string $message
+	 * @param int    $exitCode
+	 * @param int    $numFileErrors
+	 * @param int    $numGenericErrors
+	 * @param string $expected
 	 */
 	public function testFormatErrors(
 		string $message,

--- a/tests/PHPStan/Command/ErrorFormatter/TestBaseFormatter.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TestBaseFormatter.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use PHPStan\Analyser\Error;
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\ErrorsConsoleStyle;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\StreamOutput;
+
+abstract class TestBaseFormatter extends \PHPStan\Testing\TestCase
+{
+
+	private const DIRECTORY_PATH = '/data/folder/with space/and unicode 😃/project';
+
+	/** @var StreamOutput */
+	private $outputStream;
+
+	/** @var ErrorsConsoleStyle */
+	private $errorConsoleStyle;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$resource = fopen('php://memory', 'w', false);
+		if ($resource === false) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
+		$this->outputStream = new StreamOutput($resource);
+
+		$this->errorConsoleStyle = new ErrorsConsoleStyle(new StringInput(''), $this->outputStream);
+	}
+
+	protected function getOutputContent(): string
+	{
+		rewind($this->outputStream->getStream());
+
+		return $this->rtrimMultiline(stream_get_contents($this->outputStream->getStream()));
+	}
+
+	protected function getErrorConsoleStyle(): ErrorsConsoleStyle
+	{
+		return $this->errorConsoleStyle;
+	}
+
+	protected function getAnalysisResult(int $numFileErrors, int $numGenericErrors): AnalysisResult
+	{
+		if ($numFileErrors > 4 || $numFileErrors < 0 || $numGenericErrors > 2 || $numGenericErrors < 0) {
+			throw new \Exception();
+		}
+
+		$fileErrors = array_slice([
+			new Error('Foo', self::DIRECTORY_PATH . '/folder with unicode 😃/file name with "spaces" and unicode 😃.php', 4),
+			new Error('Foo', self::DIRECTORY_PATH . '/foo.php', 1),
+			new Error('Bar', self::DIRECTORY_PATH . '/foo.php', 5),
+			new Error('Bar', self::DIRECTORY_PATH . '/folder with unicode 😃/file name with "spaces" and unicode 😃.php', 2),
+		], 0, $numFileErrors);
+
+		$genericErrors = array_slice([
+			'first generic error',
+			'second generic error',
+		], 0, $numGenericErrors);
+
+		return new AnalysisResult(
+			$fileErrors,
+			$genericErrors,
+			false,
+			self::DIRECTORY_PATH
+		);
+	}
+
+	private function rtrimMultiline(string $output): string
+	{
+		$result = array_map(function (string $line): string {
+			return rtrim($line, " \r\n");
+		}, explode("\n", $output));
+
+		return implode("\n", $result);
+	}
+
+}


### PR DESCRIPTION
A bit of refactoring on checkstyle error formatter.
Relevant commit is https://github.com/phpstan/phpstan/commit/c7b4a43e4a2e26cdff0f0ace796ba95ab3f3ae5d, this should be merged after https://github.com/phpstan/phpstan/pull/1034