### PR TITLE
fix issues in phpstan level 7 generated from php-parser 4.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"nette/di": "^2.4.7 || ^3.0",
 		"nette/robot-loader": "^3.0.1",
 		"nette/utils": "^2.4.5 || ^3.0",
-		"nikic/php-parser": "^4.0",
+		"nikic/php-parser": "^4.0.2",
 		"symfony/console": "~3.2 || ~4.0",
 		"symfony/finder": "~3.2 || ~4.0",
 		"jean85/pretty-package-versions": "^1.0.3",

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -872,7 +872,7 @@ class Scope
 				if ($param->variadic) {
 					$isVariadic = true;
 				}
-				if (!is_string($param->var->name)) {
+				if (!$param->var instanceof Variable || !is_string($param->var->name)) {
 					throw new \PHPStan\ShouldNotHappenException();
 				}
 				$parameters[] = new NativeParameterReflection(
@@ -1504,7 +1504,7 @@ class Scope
 	{
 		$realParameterTypes = [];
 		foreach ($functionLike->getParams() as $parameter) {
-			if (!is_string($parameter->var->name)) {
+			if (!$parameter->var instanceof Variable || !is_string($parameter->var->name)) {
 				throw new \PHPStan\ShouldNotHappenException();
 			}
 			$realParameterTypes[$parameter->var->name] = $this->getFunctionType(
@@ -1633,7 +1633,7 @@ class Scope
 		foreach ($closure->params as $parameter) {
 			$isNullable = $this->isParameterValueNullable($parameter);
 
-			if (!is_string($parameter->var->name)) {
+			if (!$parameter->var instanceof Variable || !is_string($parameter->var->name)) {
 				throw new \PHPStan\ShouldNotHappenException();
 			}
 			$variableTypes[$parameter->var->name] = VariableTypeHolder::createYes(

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Reflection\Php;
 
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\FunctionVariant;
@@ -119,7 +120,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 					$isOptional = false;
 				}
 
-				if (!is_string($parameter->var->name)) {
+				if (!$parameter->var instanceof Variable || !is_string($parameter->var->name)) {
 					throw new \PHPStan\ShouldNotHappenException();
 				}
 				$parameters[] = new PhpParameterFromParserNodeReflection(

--- a/src/Rules/Classes/UnusedConstructorParametersRule.php
+++ b/src/Rules/Classes/UnusedConstructorParametersRule.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Classes;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
@@ -51,7 +52,7 @@ class UnusedConstructorParametersRule implements \PHPStan\Rules\Rule
 		return $this->check->getUnusedParameters(
 			$scope,
 			array_map(function (Param $parameter): string {
-				if (!is_string($parameter->var->name)) {
+				if (!$parameter->var instanceof Variable || !is_string($parameter->var->name)) {
 					throw new \PHPStan\ShouldNotHappenException();
 				}
 				return $parameter->var->name;

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules;
 
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
@@ -122,7 +123,7 @@ class FunctionDefinitionCheck
 			}
 
 			if (!$this->broker->hasClass($class)) {
-				if (!is_string($param->var->name)) {
+				if (!$param->var instanceof Variable || !is_string($param->var->name)) {
 					throw new \PHPStan\ShouldNotHappenException();
 				}
 				$errors[] = sprintf($parameterMessage, $param->var->name, $class);

--- a/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\PhpDoc;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\ErrorType;
@@ -132,7 +133,7 @@ class IncompatiblePhpDocTypeRule implements \PHPStan\Rules\Rule
 		$nativeParameterTypes = [];
 		foreach ($node->getParams() as $parameter) {
 			$isNullable = $scope->isParameterValueNullable($parameter);
-			if (!is_string($parameter->var->name)) {
+			if (!$parameter->var instanceof Variable || !is_string($parameter->var->name)) {
 				throw new \PHPStan\ShouldNotHappenException();
 			}
 			$nativeParameterTypes[$parameter->var->name] = $scope->getFunctionType(

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
@@ -34,7 +35,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements \PHPStan\Type\
 			if ($flagArg === null && $callbackArg instanceof Closure && count($callbackArg->stmts) === 1) {
 				$statement = $callbackArg->stmts[0];
 				if ($statement instanceof Return_ && $statement->expr !== null && count($callbackArg->params) > 0) {
-					if (!is_string($callbackArg->params[0]->var->name)) {
+					if (!$callbackArg->params[0]->var instanceof Variable || !is_string($callbackArg->params[0]->var->name)) {
 						throw new \PHPStan\ShouldNotHappenException();
 					}
 					$itemVariableName = $callbackArg->params[0]->var->name;


### PR DESCRIPTION
After `nikic/php-parser` release 4.0.2 we have issue on code that is not correctly checked, this should fix it.
The issue is generated from https://github.com/nikic/PHP-Parser/compare/v4.0.1...v4.0.2#diff-4abbd24bd532741591878bd14be6dd5dR15 where `$var` can be also an error.