### PR TITLE
Clarify instructions for custom error formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,9 @@ interface ErrorFormatter
 Register the formatter in your `phpstan.neon`:
 
 ```
-errorFormatter.awesome:
-	class: App\PHPStan\AwesomeErrorFormatter
+services:
+	errorFormatter.awesome:
+		class: App\PHPStan\AwesomeErrorFormatter
 ```
 
 Use the name part after `errorFormatter.` as the CLI option value:


### PR DESCRIPTION
Hi,

Today i tried to create a custom error formatter but following the instructions lead to some errors thrown by Nette.

I figured it out so I thought it could help to clarify this on the readme.

It's not much I know but maybe I will contribute the error formatter itself later