### PR TITLE
WIP: type: added getPropertyRead & getPropertyWrite as support for magic properties

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1411,6 +1411,16 @@ class NodeScopeResolver
 						$var = $var->var;
 					} else {
 						$type = $scope->getType($node->expr);
+						if ($node->var instanceof PropertyFetch) {
+							$propertyHolderType = $scope->getType($node->var->var);
+							$propertyName = (string) $node->var->name;
+							if ($propertyHolderType->hasProperty($propertyName)) {
+								$propertyReflection = $propertyHolderType->getPropertyForWrite($propertyName, $scope);
+								if (!$propertyReflection->canChangeTypeAfterAssignment()) {
+									continue;
+								}
+							}
+						}
 					}
 				} elseif ($node instanceof Expr\AssignOp) {
 					$type = $scope->getType($node);

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -1283,7 +1283,7 @@ class Scope
 				return new ErrorType();
 			}
 
-			return $propertyFetchedOnType->getProperty($node->name->name, $this)->getType();
+			return $propertyFetchedOnType->getPropertyForRead($node->name->name, $this)->getType();
 		}
 
 		if ($node instanceof Expr\StaticPropertyFetch && $node->name instanceof Node\VarLikeIdentifier && $node->class instanceof Name) {
@@ -1296,7 +1296,7 @@ class Scope
 					return new ErrorType();
 				}
 
-				return $staticPropertyClassReflection->getProperty($node->name->name, $this)->getType();
+				return $staticPropertyClassReflection->getPropertyForRead($node->name->name, $this)->getType();
 			}
 		}
 

--- a/src/Reflection/Annotations/AnnotationPropertyReflection.php
+++ b/src/Reflection/Annotations/AnnotationPropertyReflection.php
@@ -69,4 +69,9 @@ class AnnotationPropertyReflection implements PropertyReflection
 		return $this->writable;
 	}
 
+	public function canChangeTypeAfterAssignment(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
@@ -30,9 +30,14 @@ class AnnotationsPropertiesClassReflectionExtension implements PropertiesClassRe
 		return isset($this->properties[$classReflection->getName()][$propertyName]);
 	}
 
-	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	public function getPropertyForRead(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
 		return $this->properties[$classReflection->getName()][$propertyName];
+	}
+
+	public function getPropertyForWrite(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	{
+		return $this->getPropertyForRead($classReflection, $propertyName);
 	}
 
 	/**

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -245,9 +245,19 @@ class ClassReflection implements DeprecatableReflection
 		return $extension;
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
 	{
-		$key = $propertyName;
+		return $this->getProperty($propertyName, $scope, true);
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
+	{
+		return $this->getProperty($propertyName, $scope, false);
+	}
+
+	private function getProperty(string $propertyName, Scope $scope, bool $isRead): PropertyReflection
+	{
+		$key = sprintf("%d-%s", $isRead, $propertyName);
 		if ($scope->isInClass()) {
 			$key = sprintf('%s-%s', $key, $scope->getClassReflection()->getName());
 		}
@@ -257,7 +267,11 @@ class ClassReflection implements DeprecatableReflection
 					continue;
 				}
 
-				$property = $extension->getProperty($this, $propertyName);
+				if ($isRead) {
+					$property = $extension->getPropertyForRead($this, $propertyName);
+				} else {
+					$property = $extension->getPropertyForWrite($this, $propertyName);
+				}
 				if ($scope->canAccessProperty($property)) {
 					return $this->properties[$key] = $property;
 				}

--- a/src/Reflection/Dummy/DummyPropertyReflection.php
+++ b/src/Reflection/Dummy/DummyPropertyReflection.php
@@ -48,4 +48,9 @@ class DummyPropertyReflection implements PropertyReflection
 		return true;
 	}
 
+	public function canChangeTypeAfterAssignment(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -81,13 +81,18 @@ class PhpClassReflectionExtension
 		return $classReflection->getNativeReflection()->hasProperty($propertyName);
 	}
 
-	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	public function getPropertyForRead(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
 		if (!isset($this->propertiesIncludingAnnotations[$classReflection->getName()][$propertyName])) {
 			$this->propertiesIncludingAnnotations[$classReflection->getName()][$propertyName] = $this->createProperty($classReflection, $propertyName, true);
 		}
 
 		return $this->propertiesIncludingAnnotations[$classReflection->getName()][$propertyName];
+	}
+
+	public function getPropertyForWrite(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	{
+		return $this->getPropertyForRead($classReflection, $propertyName);
 	}
 
 	public function getNativeProperty(ClassReflection $classReflection, string $propertyName): PhpPropertyReflection
@@ -114,7 +119,7 @@ class PhpClassReflectionExtension
 
 		if ($includingAnnotations && $this->annotationsPropertiesClassReflectionExtension->hasProperty($classReflection, $propertyName)) {
 			$hierarchyDistances = $classReflection->getClassHierarchyDistances();
-			$annotationProperty = $this->annotationsPropertiesClassReflectionExtension->getProperty($classReflection, $propertyName);
+			$annotationProperty = $this->annotationsPropertiesClassReflectionExtension->getPropertyForRead($classReflection, $propertyName);
 			if (!isset($hierarchyDistances[$annotationProperty->getDeclaringClass()->getName()])) {
 				throw new \PHPStan\ShouldNotHappenException();
 			}

--- a/src/Reflection/Php/PhpPropertyReflection.php
+++ b/src/Reflection/Php/PhpPropertyReflection.php
@@ -83,4 +83,9 @@ class PhpPropertyReflection implements PropertyReflection, DeprecatableReflectio
 		return $this->isDeprecated;
 	}
 
+	public function canChangeTypeAfterAssignment(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Reflection/Php/UniversalObjectCrateProperty.php
+++ b/src/Reflection/Php/UniversalObjectCrateProperty.php
@@ -52,4 +52,9 @@ class UniversalObjectCrateProperty implements \PHPStan\Reflection\PropertyReflec
 		return true;
 	}
 
+	public function canChangeTypeAfterAssignment(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Reflection/Php/UniversalObjectCratesClassReflectionExtension.php
+++ b/src/Reflection/Php/UniversalObjectCratesClassReflectionExtension.php
@@ -66,9 +66,14 @@ class UniversalObjectCratesClassReflectionExtension
 		return false;
 	}
 
-	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	public function getPropertyForRead(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
 		return new UniversalObjectCrateProperty($classReflection);
+	}
+
+	public function getPropertyForWrite(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	{
+		return $this->getPropertyForRead($classReflection, $propertyName);
 	}
 
 }

--- a/src/Reflection/PhpDefect/PhpDefectClassReflectionExtension.php
+++ b/src/Reflection/PhpDefect/PhpDefectClassReflectionExtension.php
@@ -164,7 +164,7 @@ class PhpDefectClassReflectionExtension implements PropertiesClassReflectionExte
 		return $classWithProperties !== null;
 	}
 
-	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	public function getPropertyForRead(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
 		/** @var \PHPStan\Reflection\ClassReflection $classWithProperties */
 		$classWithProperties = $this->getClassWithProperties($classReflection, $propertyName);
@@ -173,6 +173,11 @@ class PhpDefectClassReflectionExtension implements PropertiesClassReflectionExte
 			$classWithProperties,
 			$this->typeStringResolver->resolve($typeString)
 		);
+	}
+
+	public function getPropertyForWrite(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	{
+		return $this->getPropertyForRead($classReflection, $propertyName);
 	}
 
 	private function getClassWithProperties(ClassReflection $classReflection, string $propertyName): ?\PHPStan\Reflection\ClassReflection

--- a/src/Reflection/PhpDefect/PhpDefectPropertyReflection.php
+++ b/src/Reflection/PhpDefect/PhpDefectPropertyReflection.php
@@ -59,4 +59,9 @@ class PhpDefectPropertyReflection implements PropertyReflection
 		return true;
 	}
 
+	public function canChangeTypeAfterAssignment(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Reflection/PropertiesClassReflectionExtension.php
+++ b/src/Reflection/PropertiesClassReflectionExtension.php
@@ -7,6 +7,8 @@ interface PropertiesClassReflectionExtension
 
 	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool;
 
-	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection;
+	public function getPropertyForRead(ClassReflection $classReflection, string $propertyName): PropertyReflection;
+
+	public function getPropertyForWrite(ClassReflection $classReflection, string $propertyName): PropertyReflection;
 
 }

--- a/src/Reflection/PropertyReflection.php
+++ b/src/Reflection/PropertyReflection.php
@@ -13,4 +13,6 @@ interface PropertyReflection extends ClassMemberReflection
 
 	public function isWritable(): bool;
 
+	public function canChangeTypeAfterAssignment(): bool;
+
 }

--- a/src/Rules/Properties/AccessPropertiesRule.php
+++ b/src/Rules/Properties/AccessPropertiesRule.php
@@ -119,7 +119,7 @@ class AccessPropertiesRule implements \PHPStan\Rules\Rule
 			];
 		}
 
-		$propertyReflection = $type->getProperty($name, $scope);
+		$propertyReflection = $type->getPropertyForRead($name, $scope);
 		if (!$scope->canAccessProperty($propertyReflection)) {
 			return [
 				sprintf(

--- a/src/Rules/Properties/AccessStaticPropertiesRule.php
+++ b/src/Rules/Properties/AccessStaticPropertiesRule.php
@@ -162,7 +162,7 @@ class AccessStaticPropertiesRule implements \PHPStan\Rules\Rule
 			]);
 		}
 
-		$property = $classType->getProperty($name, $scope);
+		$property = $classType->getPropertyForRead($name, $scope);
 		if (!$property->isStatic()) {
 			return array_merge($messages, [
 				sprintf(

--- a/src/Rules/Properties/PropertyReflectionFinder.php
+++ b/src/Rules/Properties/PropertyReflectionFinder.php
@@ -43,7 +43,7 @@ class PropertyReflectionFinder
 			return null;
 		}
 
-		return $propertyHolderType->getProperty($propertyName, $scope);
+		return $propertyHolderType->getPropertyForWrite($propertyName, $scope);
 	}
 
 }

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -118,9 +118,14 @@ class ClosureType implements CompoundType, ParametersAcceptor
 		return $this->objectType->hasProperty($propertyName);
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
 	{
-		return $this->objectType->getProperty($propertyName, $scope);
+		return $this->objectType->getPropertyForRead($propertyName, $scope);
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
+	{
+		return $this->objectType->getPropertyForWrite($propertyName, $scope);
 	}
 
 	public function canCallMethods(): TrinaryLogic

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -133,15 +133,26 @@ class IntersectionType implements CompoundType, StaticResolvableType
 		return false;
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
 	{
 		foreach ($this->types as $type) {
 			if ($type->hasProperty($propertyName)) {
-				return $type->getProperty($propertyName, $scope);
+				return $type->getPropertyForRead($propertyName, $scope);
 			}
 		}
 
 		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
+	{
+		foreach ($this->types as $type) {
+			if ($type->hasProperty($propertyName)) {
+				return $type->getPropertyForWrite($propertyName, $scope);
+			}
+		}
+
+		throw new \PhpStan\ShouldNotHappenException();
 	}
 
 	public function canCallMethods(): TrinaryLogic

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -73,7 +73,12 @@ class MixedType implements CompoundType
 		return true;
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
+	{
+		return new DummyPropertyReflection();
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
 	{
 		return new DummyPropertyReflection();
 	}

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -62,7 +62,12 @@ class NeverType implements CompoundType
 		return false;
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
+	{
+		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
 	{
 		throw new \PHPStan\ShouldNotHappenException();
 	}

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -36,7 +36,12 @@ class NonexistentParentClassType implements Type
 		return false;
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
+	{
+		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
 	{
 		throw new \PHPStan\ShouldNotHappenException();
 	}

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -48,10 +48,16 @@ class ObjectType implements TypeWithClassName
 		return $broker->getClass($this->className)->hasProperty($propertyName);
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
 	{
 		$broker = Broker::getInstance();
-		return $broker->getClass($this->className)->getProperty($propertyName, $scope);
+		return $broker->getClass($this->className)->getPropertyForRead($propertyName, $scope);
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
+	{
+		$broker = Broker::getInstance();
+		return $broker->getClass($this->className)->getPropertyForWrite($propertyName, $scope);
 	}
 
 	/**

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -25,7 +25,12 @@ class ObjectWithoutClassType implements Type
 		return false;
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
+	{
+		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
 	{
 		throw new \PHPStan\ShouldNotHappenException();
 	}

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -91,9 +91,14 @@ class StaticType implements StaticResolvableType, TypeWithClassName
 		return $this->staticObjectType->hasProperty($propertyName);
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
 	{
-		return $this->staticObjectType->getProperty($propertyName, $scope);
+		return $this->staticObjectType->getPropertyForRead($propertyName, $scope);
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
+	{
+		return $this->staticObjectType->getPropertyForWrite($propertyName, $scope);
 	}
 
 	public function canCallMethods(): TrinaryLogic

--- a/src/Type/Traits/NonObjectTypeTrait.php
+++ b/src/Type/Traits/NonObjectTypeTrait.php
@@ -21,7 +21,12 @@ trait NonObjectTypeTrait
 		return false;
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
+	{
+		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
 	{
 		throw new \PHPStan\ShouldNotHappenException();
 	}

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -28,7 +28,9 @@ interface Type
 
 	public function hasProperty(string $propertyName): bool;
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection;
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection;
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection;
 
 	public function canCallMethods(): TrinaryLogic;
 

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -263,13 +263,25 @@ class UnionType implements CompoundType, StaticResolvableType
 		);
 	}
 
-	public function getProperty(string $propertyName, Scope $scope): PropertyReflection
+	public function getPropertyForRead(string $propertyName, Scope $scope): PropertyReflection
 	{
 		foreach ($this->types as $type) {
 			if ($type->canAccessProperties()->no()) {
 				continue;
 			}
-			return $type->getProperty($propertyName, $scope);
+			return $type->getPropertyForRead($propertyName, $scope);
+		}
+
+		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	public function getPropertyForWrite(string $propertyName, Scope $scope): PropertyReflection
+	{
+		foreach ($this->types as $type) {
+			if ($type instanceof NullType) {
+				continue;
+			}
+			return $type->getPropertyForWrite($propertyName, $scope);
 		}
 
 		throw new \PHPStan\ShouldNotHappenException();

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -229,7 +229,7 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\Testing
 				sprintf('Class %s does not define property %s.', $className, $propertyName)
 			);
 
-			$property = $class->getProperty($propertyName, $scope);
+			$property = $class->getPropertyForRead($propertyName, $scope);
 			$this->assertSame(
 				$expectedPropertyData['class'],
 				$property->getDeclaringClass()->getName(),

--- a/tests/PHPStan/Reflection/PhpDefect/PhpDefectClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/PhpDefect/PhpDefectClassReflectionExtensionTest.php
@@ -42,7 +42,7 @@ class PhpDefectClassReflectionExtensionTest extends \PHPStan\Testing\TestCase
 			$broker = self::getContainer()->getByType(Broker::class);
 			$classReflection = $broker->getClass($className);
 			$this->assertTrue($classReflection->hasProperty($propertyName), sprintf('%s::$%s', $className, $propertyName));
-			$propertyReflection = $classReflection->getProperty($propertyName, $scope);
+			$propertyReflection = $classReflection->getPropertyForRead($propertyName, $scope);
 			$this->assertInstanceOf(PhpDefectPropertyReflection::class, $propertyReflection);
 			$this->assertSame($declaringClassName, $propertyReflection->getDeclaringClass()->getName());
 			$this->assertSame($typeDescription, $propertyReflection->getType()->describe(VerbosityLevel::value()), sprintf('%s::$%s', $className, $propertyName));


### PR DESCRIPTION
Hi, I've tried implement #570. The PhpStan code is pretty complicated and sadly almost all the time I had no idea if I'm lost only partially or totally. I would appreciate much more comments in code why is something done (mainly in NodeScopeResolver, also, some shortcuts are not clear to me, such as dim, difference in Assign and AssignOp, etc, this mainly originates in PhpParser, but still ... :) )

So, I have successfully [modified nextras orm extension](https://github.com/nextras/orm-phpstan/commit/163f9a234fbe04d6b69fec013f8effda562d4db2) to support this and [tested](https://github.com/nextras/orm-phpstan/blob/163f9a234fbe04d6b69fec013f8effda562d4db2/tests/testbox/Reflection/Test.php) [it](https://github.com/nextras/orm-phpstan/blob/163f9a234fbe04d6b69fec013f8effda562d4db2/tests/testbox/Reflection/fixtures/Entity.php), but this PR misses tests, I will add them after some first review if this is hopefully the right approach.