### PR TITLE
Add `exclude_analyse` support for RobotLoader

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -213,6 +213,10 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 				$robotLoader->addDirectory($fileHelper->normalizePath($directory));
 			}
 
+			foreach ($container->parameters['excludes_analyse'] as $directory) {
+				$robotLoader->excludeDirectory($fileHelper->normalizePath($directory));
+			}
+
 			$robotLoader->register();
 		}
 


### PR DESCRIPTION
Currently `exclude_analyse` works only on analyse step in phpstan, but error can occurs on robot-loader's parse step, when you have same classes in tests.