### PR TITLE
Configuration of dynamic constants

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -29,6 +29,36 @@ parameters:
 		- SimpleXMLElement
 	earlyTerminatingMethodCalls: []
 	memoryLimitFile: %tmpDir%/.memory_limit
+	dynamicConstantNames:
+		- ICONV_IMPL
+		- PHP_VERSION
+		- PHP_EXTRA_VERSION
+		- PHP_OS
+		- PHP_OS_FAMILY
+		- PHP_SAPI
+		- DEFAULT_INCLUDE_PATH
+		- PEAR_INSTALL_DIR
+		- PEAR_EXTENSION_DIR
+		- PHP_EXTENSION_DIR
+		- PHP_PREFIX
+		- PHP_BINDIR
+		- PHP_BINARY
+		- PHP_MANDIR
+		- PHP_LIBDIR
+		- PHP_DATADIR
+		- PHP_SYSCONFDIR
+		- PHP_LOCALSTATEDIR
+		- PHP_CONFIG_FILE_PATH
+		- PHP_CONFIG_FILE_SCAN_DIR
+		- PHP_SHLIB_SUFFIX
+		- PHP_FD_SETSIZE
+		- PHP_MAJOR_VERSION
+		- PHP_MINOR_VERSION
+		- PHP_RELEASE_VERSION
+		- PHP_VERSION_ID
+		- PHP_ZTS
+		- PHP_DEBUG
+		- PHP_MAXPATHLEN
 
 extensions:
 	rules: PHPStan\DependencyInjection\RulesExtension
@@ -91,6 +121,8 @@ services:
 
 	-
 		implement: PHPStan\Analyser\ScopeFactory
+		arguments:
+			dynamicConstantNames: %dynamicConstantNames%
 
 	-
 		class: PHPStan\Analyser\NodeScopeResolver

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -226,9 +226,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 		return $broker;
 	}
 
-	public function createScopeFactory(Broker $broker, TypeSpecifier $typeSpecifier): ScopeFactory
+	/**
+	 * @param Broker $broker
+	 * @param TypeSpecifier $typeSpecifier
+	 * @param string[] $dynamicConstantNames
+	 *
+	 * @return ScopeFactory
+	 */
+	public function createScopeFactory(Broker $broker, TypeSpecifier $typeSpecifier, array $dynamicConstantNames = []): ScopeFactory
 	{
-		return new class($broker, $typeSpecifier) implements ScopeFactory {
+		return new class($broker, $typeSpecifier, $dynamicConstantNames) implements ScopeFactory {
 
 			/** @var \PHPStan\Broker\Broker */
 			private $broker;
@@ -239,11 +246,20 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 			/** @var \PHPStan\Analyser\TypeSpecifier */
 			private $typeSpecifier;
 
-			public function __construct(Broker $broker, TypeSpecifier $typeSpecifier)
+			/** @var string[] */
+			private $dynamicConstantNames;
+
+			/**
+			 * @param Broker $broker
+			 * @param TypeSpecifier $typeSpecifier
+			 * @param string[] $dynamicConstantNames
+			 */
+			public function __construct(Broker $broker, TypeSpecifier $typeSpecifier, array $dynamicConstantNames)
 			{
 				$this->broker = $broker;
 				$this->printer = new \PhpParser\PrettyPrinter\Standard();
 				$this->typeSpecifier = $typeSpecifier;
+				$this->dynamicConstantNames = $dynamicConstantNames;
 			}
 
 			/**
@@ -293,7 +309,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 					$inFunctionCall,
 					$negated,
 					$inFirstLevelStatement,
-					$currentlyAssignedExpressions
+					$currentlyAssignedExpressions,
+					$this->dynamicConstantNames
 				);
 			}
 

--- a/tests/PHPStan/Analyser/data/dynamic-constant.php
+++ b/tests/PHPStan/Analyser/data/dynamic-constant.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DynamicConstants;
+
+define('GLOBAL_PURE_CONSTANT', 123);
+define('GLOBAL_DYNAMIC_CONSTANT', false);
+
+class DynamicConstantClass
+{
+	const DYNAMIC_CONSTANT_IN_CLASS = 'abcdef';
+	const PURE_CONSTANT_IN_CLASS = 'abc123def';
+}
+
+class NoDynamicConstantClass
+{
+	// constant name is same as in DynamicConstantClass, just to test
+	const DYNAMIC_CONSTANT_IN_CLASS = 'xyz';
+
+	private function rip()
+	{
+		die;
+	}
+}


### PR DESCRIPTION
Hi.
I added feature called "dynamic constants".
It is good when you use constants for configuration like for example WordPress [https://github.com/WordPress/WordPress/blob/6fd8080e7ee7599b36d4528f72a8ced612130b8c/wp-config-sample.php] does.
You only need to configure which constants are dynamic, type of constant is resolved from their definition.

Limitation: This feature is not designed to cover union types.

Possible BC break: Some constants where hardcoded with its type in phpstan's core (see Scope.php diff from line 843). They were moved to dynamic constants configuration and the type is now resolved from value which may differ from previous type.

Example configuration in your phpstan.neon
```yaml
parameters:
    dynamicConstantNames:
        - MyNamespace\MyClass::MY_DYNAMIC_CONSTANT
        - MY_GLOBAL_CONSTANT
```