### PR TITLE
substr_replace return type extension

### DIFF
--- a/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
@@ -22,6 +22,7 @@ class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctionRetur
 		'preg_replace_callback' => 2,
 		'preg_replace_callback_array' => 1,
 		'str_replace' => 2,
+		'substr_replace' => 0,
 	];
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool


### PR DESCRIPTION
We can recognize return type of `substr_replace` function, based on #1 parameter `string`.
http://php.net/manual/en/function.substr-replace.php