### PR TITLE
Console output as a service

### DIFF
--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -15,6 +15,7 @@ parameters:
 		- '#Strict comparison using === between PhpParser\\Node\\Expr\\ArrayItem and null will always evaluate to false#'
 		- '#Dynamic call to static method PHPUnit\\Framework\\#'
 		- '#(pre|post)-(de|in)crement, bool\|float\|int\|string\|null given#'
+		- '#Call to an undefined method Nette\\DI\\Container::initialize\(\)#'
 	tmpDir: %rootDir%/tmp
 services:
 	-

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -418,6 +418,10 @@ services:
 		class: PHPStan\Rules\Registry
 		factory: @PHPStan\Rules\RegistryFactory::create
 
+	output:
+		class: Symfony\Component\Console\Output\OutputInterface
+		dynamic: true
+
 	errorFormatter.raw:
 		class: PHPStan\Command\ErrorFormatter\RawErrorFormatter
 

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -151,7 +151,7 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 			}
 		}
 
-		$container = $containerFactory->create($tmpDir, $additionalConfigFiles);
+		$container = $containerFactory->create($tmpDir, $additionalConfigFiles, $output);
 		$memoryLimitFile = $container->parameters['memoryLimitFile'];
 		if (file_exists($memoryLimitFile)) {
 			$memoryLimitFileContents = file_get_contents($memoryLimitFile);

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -5,6 +5,8 @@ namespace PHPStan\DependencyInjection;
 use Nette\DI\Extensions\PhpExtension;
 use PHPStan\Broker\Broker;
 use PHPStan\File\FileHelper;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class ContainerFactory
 {
@@ -29,11 +31,13 @@ class ContainerFactory
 	/**
 	 * @param string $tempDirectory
 	 * @param string[] $additionalConfigFiles
+	 * @param \Symfony\Component\Console\Output\OutputInterface|null $output
 	 * @return \Nette\DI\Container
 	 */
 	public function create(
 		string $tempDirectory,
-		array $additionalConfigFiles
+		array $additionalConfigFiles,
+		?OutputInterface $output = null
 	): \Nette\DI\Container
 	{
 		$configurator = new Configurator(new LoaderFactory());
@@ -54,7 +58,9 @@ class ContainerFactory
 			$configurator->addConfig($additionalConfigFile);
 		}
 
+		$configurator->addServices(['output' => $output ?? new NullOutput()]);
 		$container = $configurator->createContainer();
+		$container->initialize();
 
 		/** @var Broker $broker */
 		$broker = $container->getService('broker');


### PR DESCRIPTION
The `$container->initialize();` line is there so that extensions can use their own `CompilerExtension`s with `afterCompile` method.

Notice the line `Using Symfony container...`.

![cool-thing](https://user-images.githubusercontent.com/3863468/41937689-4aa4ac92-7991-11e8-82ea-f8e0b031b53a.jpg)
