### PR TITLE
Better application exceptions

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -3,7 +3,6 @@
 
 use Composer\XdebugHandler\XdebugHandler;
 use PHPStan\Command\AnalyseCommand;
-use Symfony\Component\Console\Exception\CommandNotFoundException;
 
 gc_disable(); // performance boost
 
@@ -36,10 +35,5 @@ $application = new \Symfony\Component\Console\Application(
 	'PHPStan - PHP Static Analysis Tool',
 	$version
 );
-$application->setCatchExceptions(false);
 $application->add(new AnalyseCommand());
-try {
-    $application->run();
-} catch (CommandNotFoundException $exception) {
-    echo $exception->getMessage()."\n";
-}
+$application->run();

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -47,6 +47,13 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 		return ['analyze'];
 	}
 
+	protected function initialize(InputInterface $input, OutputInterface $output): void
+	{
+		if ((bool) $input->getOption('debug')) {
+			$this->getApplication()->setCatchExceptions(false);
+		}
+	}
+
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
 		$errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;


### PR DESCRIPTION
This should make for some nicer looking fatal errors and uncatched exceptions. The `--debug` option still remains.