### PR TITLE
Fix issues found by Psalm

### DIFF
--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -915,13 +915,11 @@ class Scope
 							return new ObjectType($this->getClassReflection()->getName());
 						}
 
-						if ($lowercasedClassName === 'parent') {
-							if ($this->getClassReflection()->getParentClass() !== false) {
-								return new ObjectType($this->getClassReflection()->getParentClass()->getName());
-							}
-
-							return new NonexistentParentClassType();
+						if ($this->getClassReflection()->getParentClass() !== false) {
+							return new ObjectType($this->getClassReflection()->getParentClass()->getName());
 						}
+
+						return new NonexistentParentClassType();
 					}
 				}
 
@@ -976,12 +974,6 @@ class Scope
 			}
 
 			return new ConstantStringType($parts[0]);
-		} elseif ($node instanceof Node\Scalar\MagicConst\Class_) {
-			if (!$this->isInClass()) {
-				return new ConstantStringType('');
-			}
-
-			return new ConstantStringType($this->getClassReflection()->getName());
 		} elseif ($node instanceof Node\Scalar\MagicConst\Method) {
 			if ($this->isInAnonymousFunction()) {
 				return new ConstantStringType('{closure}');
@@ -1763,7 +1755,7 @@ class Scope
 	 * @param bool $isVariadic
 	 * @return Type
 	 */
-	public function getFunctionType($type = null, bool $isNullable, bool $isVariadic): Type
+	public function getFunctionType($type, bool $isNullable, bool $isVariadic): Type
 	{
 		if ($isNullable) {
 			return TypeCombinator::addNull(

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -53,10 +53,10 @@ class TypeSpecifier
 	/** @var \PHPStan\Type\StaticMethodTypeSpecifyingExtension[] */
 	private $staticMethodTypeSpecifyingExtensions = [];
 
-	/** @var \PHPStan\Type\MethodTypeSpecifyingExtension[][] */
+	/** @var \PHPStan\Type\MethodTypeSpecifyingExtension[][]|null */
 	private $methodTypeSpecifyingExtensionsByClass;
 
-	/** @var \PHPStan\Type\StaticMethodTypeSpecifyingExtension[][] */
+	/** @var \PHPStan\Type\StaticMethodTypeSpecifyingExtension[][]|null */
 	private $staticMethodTypeSpecifyingExtensionsByClass;
 
 	/**

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -25,7 +25,7 @@ class TypeSpecifierContext
 
 	private static function create(?int $value): self
 	{
-		self::$registry[$value ?: ''] = self::$registry[$value ?: ''] ?? new self($value);
+		self::$registry[$value] = self::$registry[$value] ?? new self($value);
 		return self::$registry[$value];
 	}
 

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -25,7 +25,7 @@ class TypeSpecifierContext
 
 	private static function create(?int $value): self
 	{
-		self::$registry[$value] = self::$registry[$value] ?? new self($value);
+		self::$registry[$value ?: ''] = self::$registry[$value ?: ''] ?? new self($value);
 		return self::$registry[$value];
 	}
 

--- a/src/Broker/Broker.php
+++ b/src/Broker/Broker.php
@@ -40,10 +40,10 @@ class Broker
 	/** @var \PHPStan\Type\DynamicStaticMethodReturnTypeExtension[] */
 	private $dynamicStaticMethodReturnTypeExtensions = [];
 
-	/** @var \PHPStan\Type\DynamicMethodReturnTypeExtension[][] */
+	/** @var \PHPStan\Type\DynamicMethodReturnTypeExtension[][]|null */
 	private $dynamicMethodReturnTypeExtensionsByClass;
 
-	/** @var \PHPStan\Type\DynamicStaticMethodReturnTypeExtension[][] */
+	/** @var \PHPStan\Type\DynamicStaticMethodReturnTypeExtension[][]|null */
 	private $dynamicStaticMethodReturnTypeExtensionsByClass;
 
 	/** @var \PHPStan\Type\DynamicFunctionReturnTypeExtension[] */

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -62,13 +62,13 @@ class PhpMethodReflection implements MethodReflection, DeprecatableReflection, I
 	/** @var \PHPStan\Type\Type|null */
 	private $phpDocThrowType;
 
-	/** @var \PHPStan\Reflection\ParameterReflection[] */
+	/** @var \PHPStan\Reflection\ParameterReflection[]|null */
 	private $parameters;
 
-	/** @var \PHPStan\Type\Type */
+	/** @var \PHPStan\Type\Type|null */
 	private $returnType;
 
-	/** @var \PHPStan\Type\Type */
+	/** @var \PHPStan\Type\Type|null */
 	private $nativeReturnType;
 
 	/** @var bool */

--- a/src/Reflection/Php/PhpParameterFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpParameterFromParserNodeReflection.php
@@ -32,7 +32,7 @@ class PhpParameterFromParserNodeReflection implements \PHPStan\Reflection\Parame
 	/** @var bool */
 	private $variadic;
 
-	/** @var \PHPStan\Type\Type */
+	/** @var \PHPStan\Type\Type|null */
 	private $type;
 
 	public function __construct(

--- a/src/Reflection/Php/PhpParameterReflection.php
+++ b/src/Reflection/Php/PhpParameterReflection.php
@@ -17,10 +17,10 @@ class PhpParameterReflection implements ParameterReflection
 	/** @var \PHPStan\Type\Type|null */
 	private $phpDocType = null;
 
-	/** @var \PHPStan\Type\Type */
+	/** @var \PHPStan\Type\Type|null */
 	private $type;
 
-	/** @var \PHPStan\Type\Type */
+	/** @var \PHPStan\Type\Type|null */
 	private $nativeType;
 
 	public function __construct(\ReflectionParameter $reflection, ?Type $phpDocType)

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -17,7 +17,7 @@ use PHPStan\Type\FileTypeMapper;
 abstract class RuleTestCase extends \PHPStan\Testing\TestCase
 {
 
-	/** @var \PHPStan\Analyser\Analyser */
+	/** @var \PHPStan\Analyser\Analyser|null */
 	private $analyser;
 
 	abstract protected function getRule(): Rule;

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -37,7 +37,7 @@ use PHPStan\Type\Type;
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
 
-	/** @var \Nette\DI\Container */
+	/** @var \Nette\DI\Container|null */
 	private static $container;
 
 	public static function getContainer(): \Nette\DI\Container


### PR DESCRIPTION
Removes an always-true predicate and an always-false one, and adds `null` to a few property types that weren't listed as nullable.