### PR TITLE
str_split return type extension

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -447,6 +447,11 @@ services:
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
+	-
+		class: PHPStan\Type\Php\StrSplitFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
 	typeSpecifier:
 		class: PHPStan\Analyser\TypeSpecifier
 		factory: @typeSpecifierFactory::create

--- a/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'str_split';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+
+		if (count($functionCall->args) < 1) {
+			return $defaultReturnType;
+		}
+
+		$splitLength = 1;
+		if (count($functionCall->args) >= 2) {
+			$splitLengthType = $scope->getType($functionCall->args[1]->value);
+			$splitLengthIntegerType = $splitLengthType->toInteger();
+			if (!$splitLengthIntegerType instanceof ConstantIntegerType) {
+				return $splitLengthIntegerType instanceof ErrorType ? $splitLengthIntegerType : $defaultReturnType;
+			}
+			$splitLength = $splitLengthIntegerType->getValue();
+
+			if ($splitLength < 1) {
+				return new ConstantBooleanType(false);
+			}
+		}
+
+		$stringType = $scope->getType($functionCall->args[0]->value);
+		if (!$stringType instanceof ConstantStringType) {
+			return new ArrayType(new IntegerType(), new StringType());
+		}
+		$stringValue = $stringType->getValue();
+
+		$items = str_split($stringValue, $splitLength);
+		if (!is_array($items)) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
+		return self::createConstantArrayFrom($items, $scope);
+	}
+
+	private static function createConstantArrayFrom(array $constantArray, Scope $scope): ConstantArrayType
+	{
+		$keyTypes = [];
+		$valueTypes = [];
+		$isList = true;
+		$i = 0;
+
+		foreach ($constantArray as $key => $value) {
+			$keyType = $scope->getTypeFromValue($key);
+			if (!$keyType instanceof ConstantIntegerType) {
+				throw new \PHPStan\ShouldNotHappenException();
+			}
+			$keyTypes[] = $keyType;
+
+			$valueTypes[] = $scope->getTypeFromValue($value);
+
+			$isList = $isList && $key === $i;
+			$i++;
+		}
+
+		return new ConstantArrayType($keyTypes, $valueTypes, $isList ? $i : 0);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4274,6 +4274,43 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'bool',
 				'$versionCompare8',
 			],
+			// str_split
+			[
+				'array<int, string>|false',
+				'$strSplitConstantStringWithoutDefinedParameters',
+			],
+			[
+				"array('a', 'b', 'c', 'd', 'e', 'f')",
+				'$strSplitConstantStringWithoutDefinedSplitLength',
+			],
+			[
+				"array('a', 'b', 'c', 'd', 'e', 'f')",
+				'$strSplitConstantStringWithSplitLengthStringType',
+			],
+			[
+				"array('a', 'b', 'c', 'd', 'e', 'f')",
+				'$strSplitConstantStringWithOneSplitLength',
+			],
+			[
+				"array('abcdef')",
+				'$strSplitConstantStringWithGreaterSplitLengthThanStringLength',
+			],
+			[
+				'false',
+				'$strSplitConstantStringWithFailureSplitLength',
+			],
+			[
+				'*ERROR*',
+				'$strSplitConstantStringWithInvalidSplitLengthType',
+			],
+			[
+				'array<int, string>',
+				'$strSplitConstantStringWithVariableStringAndConstantSplitLength',
+			],
+			[
+				'array<int, string>|false',
+				'$strSplitConstantStringWithVariableStringAndVariableSplitLength',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/functions.php
+++ b/tests/PHPStan/Analyser/data/functions.php
@@ -21,4 +21,15 @@ $versionCompare6 = version_compare('7.0.0', doFoo() ? '7.0.1' : '6.0.0', '<');
 $versionCompare7 = version_compare(doFoo() ? '7.0.0' : '6.0.5', doBar() ? '7.0.1' : '6.0.0', '<');
 $versionCompare8 = version_compare('7.0.0', doFoo(), '<');
 
+
+// str_split
+$strSplitConstantStringWithoutDefinedParameters = str_split();
+$strSplitConstantStringWithoutDefinedSplitLength = str_split('abcdef');
+$strSplitConstantStringWithSplitLengthStringType = str_split('abcdef', '1');
+$strSplitConstantStringWithOneSplitLength = str_split('abcdef', 1);
+$strSplitConstantStringWithGreaterSplitLengthThanStringLength = str_split('abcdef', 999);
+$strSplitConstantStringWithFailureSplitLength = str_split('abcdef', 0);
+$strSplitConstantStringWithInvalidSplitLengthType = str_split('abcdef', []);
+$strSplitConstantStringWithVariableStringAndConstantSplitLength = str_split(doFoo() ? 'abcdef' : 'ghijkl', 1);
+$strSplitConstantStringWithVariableStringAndVariableSplitLength = str_split(doFoo() ? 'abcdef' : 'ghijkl', doFoo() ? 1 : 2);
 die;


### PR DESCRIPTION
Hi,
I have little weird problem that I cannot solve. At the end of resolving function there is real call to `str_split` function and phpstan tells me that type of the result is integer. This is nearly impossible because in functionMap there is return type `array<int, string>|false`.