### PR TITLE
Changed: Negated boolean <expression> is always false.

### DIFF
--- a/src/Rules/Comparison/BooleanNotConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanNotConstantConditionRule.php
@@ -36,7 +36,7 @@ class BooleanNotConstantConditionRule implements \PHPStan\Rules\Rule
 		if ($exprType instanceof ConstantBooleanType) {
 			return [
 				sprintf(
-					'Negated boolean is always %s.',
+					'Negated boolean expression is always %s.',
 					$exprType->getValue() ? 'false' : 'true'
 				),
 			];

--- a/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
@@ -20,19 +20,19 @@ class BooleanNotConstantConditionRuleTest extends \PHPStan\Testing\RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/boolean-not.php'], [
 			[
-				'Negated boolean is always false.',
+				'Negated boolean expression is always false.',
 				13,
 			],
 			[
-				'Negated boolean is always true.',
+				'Negated boolean expression is always true.',
 				18,
 			],
 			[
-				'Negated boolean is always false.',
+				'Negated boolean expression is always false.',
 				33,
 			],
 			[
-				'Negated boolean is always false.',
+				'Negated boolean expression is always false.',
 				40,
 			],
 		]);


### PR DESCRIPTION
"Negated boolean is always false" makes no sense because it isn't a boolean that's negated, but a boolean expression. Fixed this.