### PR TITLE
Adding str_ireplace to Dynamic Return Type Extension

### DIFF
--- a/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
@@ -22,6 +22,7 @@ class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctionRetur
 		'preg_replace_callback' => 2,
 		'preg_replace_callback_array' => 1,
 		'str_replace' => 2,
+		'str_ireplace' => 2,
 		'substr_replace' => 0,
 	];
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -6123,6 +6123,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'string',
 				'str_replace(\'.\', \':\', $intOrStringKey)',
 			],
+			[
+				'string',
+				'str_ireplace(\'.\', \':\', $intOrStringKey)',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/replaceFunctions.php
+++ b/tests/PHPStan/Analyser/data/replaceFunctions.php
@@ -28,6 +28,11 @@ function ($mixed) {
 	$expectedArray2 = preg_replace_callback('aaa', function () {}, $array);
 	$expectedArrayOrString2 = preg_replace_callback('aaa', function () {}, $arrayOrString);
 
+	$expectedString3 = str_ireplace('aaa', 'bbb', $string);
+	$expectedArray3 = str_ireplace('aaa', 'bbb', $array);
+	$expectedArrayOrString3 = str_ireplace('aaa', 'bbb', $arrayOrString);
+	$expectedBenevolentArrayOrString3 = str_ireplace('aaa', 'bbb', $mixed);
+
 	/** @var Foo[] $arr */
 	$arr = doFoo();
 


### PR DESCRIPTION
Fixes #1217 

I copied the `str_replace` related tests for `str_ireplace` then confirmed that a test failed:

```
1) PHPStan\Analyser\NodeScopeResolverTest::testReplaceFunctions with data set #13 ('string', 'str_ireplace('.', ':', $intOr...ngKey)')
str_ireplace('.', ':', $intOrStringKey) at die
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'string'
+'array<string>|string'
```

Then added `str_ireplace` to `src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php` and confirmed that the failing test passed.