### PR TITLE
Correct the 4th argument to socket_set_option()

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -10026,7 +10026,7 @@ return [
 'socket_sendto' => ['int', 'socket'=>'resource', 'buf'=>'string', 'len'=>'int', 'flags'=>'int', 'addr'=>'string', 'port='=>'int'],
 'socket_set_block' => ['bool', 'socket'=>'resource'],
 'socket_set_nonblock' => ['bool', 'socket'=>'resource'],
-'socket_set_option' => ['bool', 'socket'=>'resource', 'level'=>'int', 'optname'=>'int', 'optval'=>'int|array'],
+'socket_set_option' => ['bool', 'socket'=>'resource', 'level'=>'int', 'optname'=>'int', 'optval'=>'int|string|array'],
 'socket_shutdown' => ['bool', 'socket'=>'resource', 'how='=>'int'],
 'socket_strerror' => ['string', 'errno'=>'int'],
 'socket_write' => ['int|false', 'socket'=>'resource', 'buf'=>'string', 'length='=>'int'],


### PR DESCRIPTION
Some options (such as [IP_MULTICAST_IF](http://php.net/manual/en/function.socket-get-option.php)) accept a string argument, so this PR extends the 4th argument of `socket_set_option()` to allow that