### PR TITLE
Enhancement: Run composer normalize during build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,7 @@
 	<target name="check" depends="
 		composer-validate,
 		composer-install,
+		composer-normalize-check,
 		lint,
 		cs,
 		tests,
@@ -29,6 +30,31 @@
 				checkreturn="true"
 		>
 			<arg value="install"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-check">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
+			<arg value="--dry-run"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-fix">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
 		</exec>
 	</target>
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"consistence/coding-standard": "^3.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
 		"jakub-onderka/php-parallel-lint": "^1.0",
+		"localheinz/composer-normalize": "~0.8.0",
 		"phing/phing": "^2.16.0",
 		"phpstan/phpstan-deprecation-rules": "^0.10.2",
 		"phpstan/phpstan-php-parser": "^0.10",


### PR DESCRIPTION
This PR

* [x] requires `localheinz/composer-normalize` as development dependency
* [x] adds `composer-normalize-{check,fix}` targets to `build.xml`

Follows https://github.com/phpstan/phpstan/pull/1256#issuecomment-406736436.