### PR TITLE
Enhancement: Use --ansi option when running Symfony console commands

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,6 +19,7 @@
 				checkreturn="true"
 		>
 			<arg value="validate"/>
+			<arg value="--ansi"/>
 		</exec>
 	</target>
 
@@ -30,6 +31,7 @@
 				checkreturn="true"
 		>
 			<arg value="install"/>
+			<arg value="--ansi"/>
 		</exec>
 	</target>
 


### PR DESCRIPTION
This PR

* [x] consistently uses the `--ansi` option when running Symfony console commands

Follows https://github.com/phpstan/phpstan/pull/1258#discussion_r204221133.