### PR TITLE
Enhancement: Reference phpunit.xsd as installed with composer

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,6 +7,7 @@
 		composer-normalize-check,
 		lint,
 		cs,
+		test-configuration-validate,
 		tests,
 		phpstan
 	"/>
@@ -111,6 +112,10 @@
 			<arg path="src"/>
 			<arg path="tests"/>
 		</exec>
+	</target>
+
+	<target name="test-configuration-validate" depends="composer-install">
+		<xmllint schema="vendor/phpunit/phpunit/phpunit.xsd" file="tests/phpunit.xml"/>
 	</target>
 
 	<target name="tests">

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.2/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
 	bootstrap="bootstrap.php"
 	colors="true"
 	failOnRisky="true"


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` as installed with `composer`
* [x] validates `tests/phpunit.xml` against `phpunit.xsd` using an `XmlLintTask`

💁‍♂️ This way the reference will always be up-to-date. Also see current `composer.json`: https://github.com/phpstan/phpstan/blob/bfd31f1bb31b855f47c271f61d7e67cb5f054870/composer.json#L35.

For reference, see https://www.phing.info/phing/guide/en/output/chunkhtml/XmlLintTask.html.