### PR TITLE
Fix: Update composer itself once only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
 
 before_script:
   - phpenv config-rm xdebug.ini
-  - composer self-update
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --no-interaction; fi;
   - if [ "$dependencies" = "highest" ]; then composer update --no-interaction; fi;
 


### PR DESCRIPTION
This PR

* [x] updates `composer` itself once only

💁‍♂️ Note that Travis updates `composer` already, see

* https://travis-ci.org/phpstan/phpstan/jobs/406684332#L438
* https://travis-ci.org/phpstan/phpstan/jobs/406684332#L468