### PR TITLE
Add false as valid return value for sha1_file

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9837,7 +9837,7 @@ return [
 'setthreadtitle' => ['bool', 'title'=>'string'],
 'settype' => ['bool', '&rw_var'=>'mixed', 'type'=>'string'],
 'sha1' => ['string', 'str'=>'string', 'raw_output='=>'bool'],
-'sha1_file' => ['string', 'filename'=>'string', 'raw_output='=>'bool'],
+'sha1_file' => ['string|false', 'filename'=>'string', 'raw_output='=>'bool'],
 'sha256' => ['string', 'str'=>'string', 'raw_output='=>'bool'],
 'sha256_file' => ['string', 'filename'=>'string', 'raw_output='=>'bool'],
 'shapefileObj::__construct' => ['void', 'filename'=>'string', 'type'=>'int'],


### PR DESCRIPTION
False is a valid return type according to the php documentation http://php.net/manual/en/function.sha1-file.php