### PR TITLE
Fixing signature of function readdir

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -8875,7 +8875,7 @@ return [
 'rawurldecode' => ['string', 'str'=>'string'],
 'rawurlencode' => ['string', 'str'=>'string'],
 'read_exif_data' => ['array', 'filename'=>'string', 'sections_needed='=>'string', 'sub_arrays='=>'bool', 'read_thumbnail='=>'bool'],
-'readdir' => ['string', 'dir_handle='=>'resource'],
+'readdir' => ['string|false', 'dir_handle='=>'resource'],
 'readfile' => ['int', 'filename'=>'string', 'use_include_path='=>'bool', 'context='=>'resource'],
 'readgzfile' => ['int|false', 'filename'=>'string', 'use_include_path='=>'int'],
 'readline' => ['string', 'prompt='=>'?string'],


### PR DESCRIPTION
Adding false return value as of http://php.net/manual/de/function.readdir.php, which is returned on failure (when no next entry exists)

This also fixes an issue when running with phpstan-strict-rules: phpstan/phpstan-strict-rules#32