### PR TITLE
Fix: Update composer itself to latest snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ matrix:
 
 before_script:
   - if php --ri xdebug >/dev/null; then phpenv config-rm xdebug.ini; fi
+
+before_install:
+  - composer self-update --snapshot
+
+install:
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --no-interaction; fi
   - if [ "$dependencies" = "highest" ]; then composer update --no-interaction; fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ install:
   - ps: If ((Test-Path $Env:composer_installer) -eq $False) { appveyor-retry appveyor DownloadFile https://getcomposer.org/installer -FileName $Env:composer_installer }
   - ps: If ((Test-Path $Env:composer_executable) -eq $False) { php $Env:composer_installer --install-dir=$Env:composer_directory }
   - ps: Set-Content -Path ($Env:composer_directory + '\composer.bat') -Value ('@php ' + $Env:composer_executable + ' %*')
-  - composer self-update
+  - composer self-update --snapshot
 
   # Install dependencies
   - ps: cd $Env:project_directory


### PR DESCRIPTION
This PR

* [x] updates `composer` itself to latest snapshot

Related to https://github.com/localheinz/composer-normalize/issues/68#issuecomment-410437851.
Follows https://github.com/composer/composer/issues/7516#issuecomment-410459001.

💁‍♂️ This is a temporary patch until `1.7.1` is released. 