### PR TITLE
Fix: Use latest version of composer again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
 before_script:
   - if php --ri xdebug >/dev/null; then phpenv config-rm xdebug.ini; fi
 
-before_install:
-  - composer self-update --snapshot
-
 install:
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --no-interaction; fi
   - if [ "$dependencies" = "highest" ]; then composer update --no-interaction; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,6 @@ install:
   - ps: If ((Test-Path $Env:composer_installer) -eq $False) { appveyor-retry appveyor DownloadFile https://getcomposer.org/installer -FileName $Env:composer_installer }
   - ps: If ((Test-Path $Env:composer_executable) -eq $False) { php $Env:composer_installer --install-dir=$Env:composer_directory }
   - ps: Set-Content -Path ($Env:composer_directory + '\composer.bat') -Value ('@php ' + $Env:composer_executable + ' %*')
-  - composer self-update --snapshot
 
   # Install dependencies
   - ps: cd $Env:project_directory


### PR DESCRIPTION
This PR

* [x] uses the latest version of `composer` again

Follows #1331.

💁‍♂️ For reference, see https://github.com/composer/composer/compare/1.7.0...1.7.1.