### PR TITLE
TypeNodeResolver: implement basic CallableTypeNode resolution

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1162,6 +1162,14 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$callable',
 			],
 			[
+				'callable',
+				'$callableWithTypes',
+			],
+			[
+				'Closure<void>',
+				'$closureWithTypes',
+			],
+			[
 				'VarAnnotations\Foo',
 				'$self',
 			],

--- a/tests/PHPStan/Analyser/data/var-annotations.php
+++ b/tests/PHPStan/Analyser/data/var-annotations.php
@@ -37,6 +37,12 @@ class Foo
 		/** @var callable $callable */
 		$callable = getFoo();
 
+		/** @var callable(int $x, string ...$y): void $callableWithTypes */
+		$callableWithTypes = getFoo();
+
+		/** @var \Closure(int $x, string ...$y): void $closureWithTypes */
+		$closureWithTypes = getFoo();
+
 		/** @var self $self */
 		$self = getFoo();
 
@@ -80,6 +86,12 @@ class Foo
 
 		/** @var callable */
 		$callable = getFoo();
+
+		/** @var callable(int $x, string &...$y): void */
+		$callableWithTypes = getFoo();
+
+		/** @var \Closure(int $x, string &...$y): void */
+		$closureWithTypes = getFoo();
 
 		/** @var self */
 		$self = getFoo();


### PR DESCRIPTION
Add initial support for stuff like

~~~php
/**
 * @param callable(int $x, string ...$y): void $a
 * @param Closure(int $x, string ...$y): void $b
 */
~~~

parameter and return types are currently ignored for `CallableType` which does not support them