### PR TITLE
Adding Base64DecodeDynamicFunctionReturnTypeExtension

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -311,6 +311,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\Base64DecodeDynamicFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\CountFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -404,7 +404,7 @@ return [
 'BadMethodCallException::getPrevious' => ['?Throwable|?BadMethodCallException'],
 'BadMethodCallException::getTrace' => ['array'],
 'BadMethodCallException::getTraceAsString' => ['string'],
-'base64_decode' => ['string|false', 'str'=>'string', 'strict='=>'bool|false'],
+'base64_decode' => ['string|false', 'str'=>'string', 'strict='=>'bool'],
 'base64_encode' => ['string', 'str'=>'string'],
 'base_convert' => ['string', 'number'=>'string', 'frombase'=>'int', 'tobase'=>'int'],
 'basename' => ['string', 'path'=>'string', 'suffix='=>'string'],

--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -404,7 +404,7 @@ return [
 'BadMethodCallException::getPrevious' => ['?Throwable|?BadMethodCallException'],
 'BadMethodCallException::getTrace' => ['array'],
 'BadMethodCallException::getTraceAsString' => ['string'],
-'base64_decode' => ['string|false', 'str'=>'string', 'strict='=>'bool'],
+'base64_decode' => ['string|false', 'str'=>'string', 'strict='=>'bool|false'],
 'base64_encode' => ['string', 'str'=>'string'],
 'base_convert' => ['string', 'number'=>'string', 'frombase'=>'int', 'tobase'=>'int'],
 'basename' => ['string', 'path'=>'string', 'suffix='=>'string'],

--- a/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
@@ -47,7 +47,11 @@ class Base64DecodeDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
 		}
 
 		// second argument could be interpreted as true
-		return new UnionType([new StringType(), new ConstantBooleanType(false)]);
+		if (!$isTrueType->no()) {
+			return new UnionType([new StringType(), new ConstantBooleanType(false)]);
+		}
+
+		return new StringType();
 	}
 
 }

--- a/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\BenevolentUnionType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+class Base64DecodeDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'base64_decode';
+	}
+
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $functionCall,
+		Scope $scope
+	): Type
+	{
+		if (!isset($functionCall->args[1])) {
+			return new StringType();
+		}
+
+		$argType = $scope->getType($functionCall->args[1]->value);
+
+		if ($argType instanceof MixedType) {
+			return new BenevolentUnionType([new StringType(), new ConstantBooleanType(false)]);
+		}
+
+		$isTrueType = (new ConstantBooleanType(true))->isSuperTypeOf($argType);
+		$isFalseType = (new ConstantBooleanType(false))->isSuperTypeOf($argType);
+		$compareTypes = $isTrueType->compareTo($isFalseType);
+		if ($compareTypes === $isTrueType) {
+			return new UnionType([new StringType(), new ConstantBooleanType(false)]);
+		}
+		if ($compareTypes === $isFalseType) {
+			return new StringType();
+		}
+
+		// second argument could be interpreted as true
+		return new UnionType([new StringType(), new ConstantBooleanType(false)]);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4634,7 +4634,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$base64DecodeWithStrictEnabled',
 			],
 			[
-				'string|false',
+				'string',
 				'$base64DecodeDefault',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4621,6 +4621,26 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array(0 => int, 1 => int, 2 => int, 3 => int, 4 => int, 5 => int, 6 => int, 7 => int, ...)|false',
 				'$fstat',
 			],
+			[
+				'string',
+				'$base64DecodeWithoutStrict',
+			],
+			[
+				'string',
+				'$base64DecodeWithStrictDisabled',
+			],
+			[
+				'string|false',
+				'$base64DecodeWithStrictEnabled',
+			],
+			[
+				'string|false',
+				'$base64DecodeDefault',
+			],
+			[
+				'(string|false)',
+				'$base64DecodeBenevolent',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/functions.php
+++ b/tests/PHPStan/Analyser/data/functions.php
@@ -52,4 +52,10 @@ $stat = stat(__FILE__);
 $lstat = lstat(__FILE__);
 $fstat = fstat($resource);
 
+$base64DecodeWithoutStrict = base64_decode('');
+$base64DecodeWithStrictDisabled = base64_decode('', false);
+$base64DecodeWithStrictEnabled = base64_decode('', true);
+$base64DecodeDefault = base64_decode('', null);
+$base64DecodeBenevolent = base64_decode('', $undefined);
+
 die;


### PR DESCRIPTION
Closes #1365 

* Note that I didn't change the return type in the signature of `base64_decode` in the `functionMap.php` because its a safer default. Is that right?