### PR TITLE
Tests compatibility with ext/interbase

### DIFF
--- a/tests/PHPStan/Reflection/data/function-definitions.php
+++ b/tests/PHPStan/Reflection/data/function-definitions.php
@@ -1,6 +1,8 @@
 <?php
 
-function ibase_wait_event()
-{
+if (!function_exists('ibase_wait_event')) {
+	function ibase_wait_event()
+	{
 
+	}
 }


### PR DESCRIPTION
closes #1360

This definition isn't compatible with [the function itself](http://php.net/ibase_wait_event), but apparently it was never a problem. :smiley: 