### PR TITLE
Set analyse as default command

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -36,4 +36,5 @@ $application = new \Symfony\Component\Console\Application(
 	$version
 );
 $application->add(new AnalyseCommand());
+$application->setDefaultCommand('analyse');
 $application->run();


### PR DESCRIPTION
Symfony's console component has a feature which sets the default command if no command can't be guessed. So you only need to call `bin/phpstan src/` instead of `bin/phpstan analyse src/` . 

I think this is more DX thing, but it would make my life a little bit easier and i hope others too :)