### PR TITLE
Feature/illegal string offset

### DIFF
--- a/conf/config.level7.neon
+++ b/conf/config.level7.neon
@@ -1,5 +1,8 @@
 includes:
 	- config.level6.neon
 
+rules:
+	- PHPStan\Rules\Arrays\AppendedArrayItemToStringRule
+
 parameters:
 	checkNullables: true

--- a/src/Rules/Arrays/AppendedArrayItemToStringRule.php
+++ b/src/Rules/Arrays/AppendedArrayItemToStringRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Arrays;
 
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\VerbosityLevel;
 
@@ -36,7 +37,19 @@ class AppendedArrayItemToStringRule implements \PHPStan\Rules\Rule
         }
 
         $nodeType = $scope->getType($node->var);
+	    $dimType = $scope->getType($node->dim);
+
         if ($nodeType instanceof ConstantStringType) {
+            if ($dimType instanceof ConstantIntegerType) {
+                return [];
+            }
+
+            if ($dimType instanceof ConstantStringType) {
+                if (ctype_digit($dimType->getValue())) {
+                    return [];
+                }
+            }
+
             return [
                 sprintf(
                     'Append array to variable of invalid type %s',

--- a/src/Rules/Arrays/AppendedArrayItemToStringRule.php
+++ b/src/Rules/Arrays/AppendedArrayItemToStringRule.php
@@ -10,34 +10,34 @@ use PHPStan\Type\VerbosityLevel;
 
 class AppendedArrayItemToStringRule implements \PHPStan\Rules\Rule
 {
-	/** @var \PHPStan\Rules\RuleLevelHelper */
-	private $ruleLevelHelper;
+    /** @var \PHPStan\Rules\RuleLevelHelper */
+    private $ruleLevelHelper;
 
-	public function __construct(
-		RuleLevelHelper $ruleLevelHelper
-	)
-	{
-		$this->ruleLevelHelper = $ruleLevelHelper;
-	}
+    public function __construct(
+        RuleLevelHelper $ruleLevelHelper
+    )
+    {
+        $this->ruleLevelHelper = $ruleLevelHelper;
+    }
 
-	public function getNodeType(): string
-	{
-		return \PhpParser\Node\Expr\ArrayDimFetch::class;
-	}
+    public function getNodeType(): string
+    {
+        return \PhpParser\Node\Expr\ArrayDimFetch::class;
+    }
 
-	/**
-	 * @param \PhpParser\Node $node
-	 * @param \PHPStan\Analyser\Scope $scope
-	 * @return string[]
-	 */
-	public function processNode(\PhpParser\Node $node, Scope $scope): array
-	{
-	    if (version_compare(PHP_VERSION, '5.4') < 0) {
-	        return [];
+    /**
+     * @param \PhpParser\Node $node
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return string[]
+     */
+    public function processNode(\PhpParser\Node $node, Scope $scope): array
+    {
+        if (version_compare(PHP_VERSION, '5.4') < 0) {
+            return [];
         }
 
         $nodeType = $scope->getType($node->var);
-	    $dimType = $scope->getType($node->dim);
+        $dimType = $scope->getType($node->dim);
 
         if ($nodeType instanceof ConstantStringType) {
             if ($dimType instanceof ConstantIntegerType) {
@@ -58,6 +58,6 @@ class AppendedArrayItemToStringRule implements \PHPStan\Rules\Rule
             ];
         }
 
-		return [];
-	}
+        return [];
+    }
 }

--- a/src/Rules/Arrays/AppendedArrayItemToStringRule.php
+++ b/src/Rules/Arrays/AppendedArrayItemToStringRule.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Arrays;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\VerbosityLevel;
+
+class AppendedArrayItemToStringRule implements \PHPStan\Rules\Rule
+{
+	/** @var \PHPStan\Rules\RuleLevelHelper */
+	private $ruleLevelHelper;
+
+	public function __construct(
+		RuleLevelHelper $ruleLevelHelper
+	)
+	{
+		$this->ruleLevelHelper = $ruleLevelHelper;
+	}
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\ArrayDimFetch::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[]
+	 */
+	public function processNode(\PhpParser\Node $node, Scope $scope): array
+	{
+	    if (version_compare(PHP_VERSION, '5.4') < 0) {
+	        return [];
+        }
+
+        $nodeType = $scope->getType($node->var);
+        if ($nodeType instanceof ConstantStringType) {
+            return [
+                sprintf(
+                    'Append array to variable of invalid type %s',
+                    $nodeType->describe(VerbosityLevel::typeOnly())
+                )
+            ];
+        }
+
+		return [];
+	}
+}

--- a/tests/PHPStan/Levels/data/acceptTypes-7.json
+++ b/tests/PHPStan/Levels/data/acceptTypes-7.json
@@ -1,7 +1,22 @@
 [
     {
-        "message": "Internal error: Argument 1 passed to PHPStan\\Analyser\\Scope::getType() must be an instance of PhpParser\\Node\\Expr, null given, called in /Users/luoxiaojun/php/phpstan/src/Rules/Arrays/AppendedArrayItemToStringRule.php on line 40\nRun PHPStan with --debug option and post the stack trace to:\nhttps://github.com/phpstan/phpstan/issues/new",
-        "line": null,
+        "message": "Parameter #1 $i of method Levels\\AcceptTypes\\Foo::doBar() expects int, int|null given.",
+        "line": 26,
+        "ignorable": true
+    },
+    {
+        "message": "Parameter #1 $a of method Levels\\AcceptTypes\\Foo::doLorem() expects int|resource, int|null given.",
+        "line": 51,
+        "ignorable": true
+    },
+    {
+        "message": "Parameter #1 $i of method Levels\\AcceptTypes\\Foo::doBarArray() expects array<int>, array<int|null> given.",
+        "line": 91,
+        "ignorable": true
+    },
+    {
+        "message": "Parameter #1 $i of method Levels\\AcceptTypes\\Foo::doBarArray() expects array<int>, array<int, int|null> given.",
+        "line": 131,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/acceptTypes-7.json
+++ b/tests/PHPStan/Levels/data/acceptTypes-7.json
@@ -1,22 +1,7 @@
 [
     {
-        "message": "Parameter #1 $i of method Levels\\AcceptTypes\\Foo::doBar() expects int, int|null given.",
-        "line": 26,
-        "ignorable": true
-    },
-    {
-        "message": "Parameter #1 $a of method Levels\\AcceptTypes\\Foo::doLorem() expects int|resource, int|null given.",
-        "line": 51,
-        "ignorable": true
-    },
-    {
-        "message": "Parameter #1 $i of method Levels\\AcceptTypes\\Foo::doBarArray() expects array<int>, array<int|null> given.",
-        "line": 91,
-        "ignorable": true
-    },
-    {
-        "message": "Parameter #1 $i of method Levels\\AcceptTypes\\Foo::doBarArray() expects array<int>, array<int, int|null> given.",
-        "line": 131,
+        "message": "Internal error: Argument 1 passed to PHPStan\\Analyser\\Scope::getType() must be an instance of PhpParser\\Node\\Expr, null given, called in /Users/luoxiaojun/php/phpstan/src/Rules/Arrays/AppendedArrayItemToStringRule.php on line 40\nRun PHPStan with --debug option and post the stack trace to:\nhttps://github.com/phpstan/phpstan/issues/new",
+        "line": null,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Rules/Arrays/AppendedArrayItemToStringRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/AppendedArrayItemToStringRuleTest.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Rules\Arrays;
 
-use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\Rules\RuleLevelHelper;
 
 class AppendedArrayItemToStringRuleTest extends \PHPStan\Testing\RuleTestCase
@@ -22,7 +21,7 @@ class AppendedArrayItemToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 			[
 				[
 					'Append array to variable of invalid type string',
-					14,
+					14, //line no
 				],
 			]
 		);

--- a/tests/PHPStan/Rules/Arrays/AppendedArrayItemToStringRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/AppendedArrayItemToStringRuleTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Arrays;
+
+use PHPStan\Rules\Properties\PropertyReflectionFinder;
+use PHPStan\Rules\RuleLevelHelper;
+
+class AppendedArrayItemToStringRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		return new AppendedArrayItemToStringRule(
+			new RuleLevelHelper($this->createBroker(), true, false, true)
+		);
+	}
+
+	public function testAppendedArrayItemType(): void
+	{
+		$this->analyse(
+			[__DIR__ . '/data/appended-array-item-to-string.php'],
+			[
+				[
+					'Append array to variable of invalid type string',
+					14,
+				],
+			]
+		);
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/appended-array-item-to-string.php
+++ b/tests/PHPStan/Rules/Arrays/data/appended-array-item-to-string.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace AppendedArrayItemToString;
+
+class Foo
+{
+
+	/** @var string */
+	private $string;
+
+	public function doFoo()
+	{
+		$this->string = '';
+		$this->string['key'] = 'value';
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/appended-array-item-to-string.php
+++ b/tests/PHPStan/Rules/Arrays/data/appended-array-item-to-string.php
@@ -2,15 +2,16 @@
 
 namespace AppendedArrayItemToString;
 
-class Foo
+class Alpha
 {
 
 	/** @var string */
 	private $string;
 
-	public function doFoo()
+	public function assign()
 	{
 		$this->string = '';
 		$this->string['key'] = 'value';
+		$this->string[0] = 'value';
 	}
 }


### PR DESCRIPTION
Test Case(test.php):

```php
$str = '';
$str['key'] = 'value';
```

After execute this case, I received a warning ```PHP Warning:  Illegal string offset ''```.
But when I execute ```phpstan analyse -l max test.php```, no output error.

In AppenedArrayItemToStringRule, it will check the type of the object append to. If the object is a string, it will check the type of key. If the key is not an integer or a digital string, it will return the error ```Append array to variable of invalid type string```. 