### PR TITLE
Fix XMLReader::expand() signature

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -12925,7 +12925,7 @@ return [
 'XMLDiff\Memory::diff' => ['string', 'from'=>'string', 'to'=>'string'],
 'XMLDiff\Memory::merge' => ['string', 'src'=>'string', 'diff'=>'string'],
 'XMLReader::close' => ['bool'],
-'XMLReader::expand' => ['DOMNode'],
+'XMLReader::expand' => ['DOMNode', 'basenode='=>'DOMNode'],
 'XMLReader::getAttribute' => ['string|null', 'name'=>'string'],
 'XMLReader::getAttributeNo' => ['string|null', 'index'=>'int'],
 'XMLReader::getAttributeNs' => ['string|null', 'name'=>'string', 'namespaceuri'=>'string'],


### PR DESCRIPTION
According to [documentation](https://secure.php.net/xmlreader.expand), `XMLReader::expand()` method takes an optional `DOMNode` argument.

Test case : https://phpstan.org/r/4acbc01009a8562bb9a963daa6675985