### PR TITLE
Adds support for scoped ignored errors by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,7 @@ parameters:
 		- '#Call to an undefined method PHPUnit_Framework_MockObject_MockObject::[a-zA-Z0-9_]+\(\)#'
 ```
 
-If you need to exclude a certain error in a specific directory or file, it's easy.
-Just specify a `path` along with the `message`:
+To exclude an error in a specific directory or file, specify a `path` along with the `message`:
 
 ```
 parameters:

--- a/README.md
+++ b/README.md
@@ -329,14 +329,17 @@ parameters:
 ```
 
 If you need to exclude a certain error in a specific directory or file, it's easy.
-Just specify a `path` along with the `message` (always use forward slashes, even on Windows):
+Just specify a `path` along with the `message`:
 
 ```
 parameters:
 	ignoreErrors:
 		-
 			message: '#Call to an undefined method [a-zA-Z0-9\\_]+::method\(\)#'
-			path: '#some/dir/SomeFile.php#'
+			path: %currentWorkingDirectory%/some/dir/SomeFile.php
+		-
+			message: '#Call to an undefined method [a-zA-Z0-9\\_]+::method\(\)#'
+			path: %currentWorkingDirectory%/other/dir/*
 		- '#Other error to catch anywhere#'
 ```
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,18 @@ parameters:
 		- '#Call to an undefined method PHPUnit_Framework_MockObject_MockObject::[a-zA-Z0-9_]+\(\)#'
 ```
 
+If you need to exclude a certain error in a specific directory or file, it's easy.
+Just specify a `path` along with the `message` (always use forward slashes, even on Windows):
+
+```
+parameters:
+	ignoreErrors:
+		-
+			message: '#Call to an undefined method [a-zA-Z0-9\\_]+::method\(\)#'
+			path: '#some/dir/SomeFile.php#'
+		- '#Other error to catch anywhere#'
+```
+
 If some of the patterns do not occur in the result anymore, PHPStan will let you know
 and you will have to remove the pattern from the configuration. You can turn off
 this behaviour by setting `reportUnmatchedIgnoredErrors` to `false` in PHPStan configuration.

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -147,7 +147,7 @@ class Analyser
 		$addErrors = [];
 		$errors = array_values(array_filter($errors, function (Error $error) use (&$unmatchedIgnoredErrors, &$addErrors): bool {
 			foreach ($this->ignoreErrors as $i => $ignore) {
-				if (self::shouldErrorBeIgnored($error, $ignore)) {
+				if (IgnoredError::shouldIgnore($error, $ignore)) {
 					unset($unmatchedIgnoredErrors[$i]);
 					if (!$error->canBeIgnored()) {
 						$addErrors[] = sprintf(
@@ -169,7 +169,7 @@ class Analyser
 			foreach ($unmatchedIgnoredErrors as $unmatchedIgnoredError) {
 				$errors[] = sprintf(
 					'Ignored error pattern %s was not matched in reported errors.',
-					$unmatchedIgnoredError
+					IgnoredError::stringifyPattern($unmatchedIgnoredError)
 				);
 			}
 		}
@@ -179,27 +179,6 @@ class Analyser
 		}
 
 		return $errors;
-	}
-
-	/**
-	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-	 * @param Error $error
-	 * @param array<string, string>|string $ignore
-	 * @return bool To ignore or not to ignore?
-	 */
-	private static function shouldErrorBeIgnored(Error $error, $ignore): bool
-	{
-		if (is_array($ignore)) {
-			// ignore by path
-			if (isset($ignore['path'])) {
-				return \Nette\Utils\Strings::match($error->getMessage(), $ignore['message']) !== null
-					&& \Nette\Utils\Strings::match(str_replace('\\', '/', $error->getFile()), $ignore['path']) !== null;
-			}
-
-			return false;
-		}
-
-		return \Nette\Utils\Strings::match($error->getMessage(), $ignore) !== null;
 	}
 
 }

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -182,6 +182,7 @@ class Analyser
 	}
 
 	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
 	 * @param Error $error
 	 * @param array<string, string>|string $ignore
 	 * @return bool To ignore or not to ignore?

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -184,7 +184,7 @@ class Analyser
 	/**
 	 * @param Error $error
 	 * @param array<string, string>|string $ignore
-	 * @return boolean To ignore or not to ignore?
+	 * @return bool To ignore or not to ignore?
 	 */
 	private static function shouldErrorBeIgnored(Error $error, $ignore): bool
 	{
@@ -193,9 +193,9 @@ class Analyser
 			if (isset($ignore['path'])) {
 				return \Nette\Utils\Strings::match($error->getMessage(), $ignore['message']) !== null
 					&& \Nette\Utils\Strings::match(str_replace('\\', '/', $error->getFile()), $ignore['path']) !== null;
-			} else {
-				return false;
 			}
+
+			return false;
 		}
 
 		return \Nette\Utils\Strings::match($error->getMessage(), $ignore) !== null;

--- a/src/Analyser/IgnoredError.php
+++ b/src/Analyser/IgnoredError.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+class IgnoredError
+{
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @param array<string, string>|string $ignoredError
+	 * @return string Representation of the ignored error
+	 */
+	public static function stringifyPattern($ignoredError): string
+	{
+		if (is_array($ignoredError)) {
+			// ignore by path
+			if (isset($ignoredError['path'])) {
+				return sprintf('%s in path %s', $ignoredError['message'], $ignoredError['path']);
+			}
+
+			return $ignoredError['message'];
+		}
+
+		return $ignoredError;
+	}
+
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 * @param Error $error
+	 * @param array<string, string>|string $ignoredError
+	 * @return bool To ignore or not to ignore?
+	 */
+	public static function shouldIgnore(Error $error, $ignoredError): bool
+	{
+		if (is_array($ignoredError)) {
+			// ignore by path
+			if (isset($ignoredError['path'])) {
+				return \Nette\Utils\Strings::match($error->getMessage(), $ignoredError['message']) !== null
+					&& \Nette\Utils\Strings::match(str_replace('\\', '/', $error->getFile()), $ignoredError['path']) !== null;
+			}
+
+			return false;
+		}
+
+		return \Nette\Utils\Strings::match($error->getMessage(), $ignoredError) !== null;
+	}
+
+}

--- a/src/Analyser/IgnoredError.php
+++ b/src/Analyser/IgnoredError.php
@@ -38,11 +38,11 @@ class IgnoredError
 		if (is_array($ignoredError)) {
 			// ignore by path
 			if (isset($ignoredError['path'])) {
-				$FileHelper   = new FileHelper(getcwd());
-				$FileExcluder = new FileExcluder($FileHelper, [$ignoredError['path']]);
+				$fileHelper   = new FileHelper(getcwd());
+				$fileExcluder = new FileExcluder($fileHelper, [$ignoredError['path']]);
 
 				return \Nette\Utils\Strings::match($error->getMessage(), $ignoredError['message']) !== null
-					&& $FileExcluder->isExcludedFromAnalysing($error->getFile());
+					&& $fileExcluder->isExcludedFromAnalysing($error->getFile());
 			}
 
 			return false;

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -57,6 +57,18 @@ class AnalyserTest extends \PHPStan\Testing\TestCase
 		$this->assertSame('Error message "Class PHPStan\Tests\Baz was not found while trying to analyse it - autoloading is probably not configured properly." cannot be ignored, use excludes_analyse instead.', $result[1]);
 	}
 
+	public function testIgnoreErrorByPath(): void
+	{
+		$ignoreErrors = [
+			[
+				'message' => '#Class IgnoreErrorsByPath\[A-Za-z]+ was not found while trying to analyse it - autoloading is probably not configured properly.#',
+				'path'    => __DIR__ . '/data/ignore-errors-by-path/not-ignored.php',
+			],
+		];
+		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/ignore-errors-by-path', false);
+		$this->assertCount(1, $result);
+	}
+
 	/**
 	 * @param string[] $ignoreErrors
 	 * @param bool $reportUnmatchedIgnoredErrors

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -61,7 +61,7 @@ class AnalyserTest extends \PHPStan\Testing\TestCase
 	{
 		$ignoreErrors = [
 			[
-				'message' => '#Class IgnoreErrorsByPath\[A-Za-z]+ was not found while trying to analyse it - autoloading is probably not configured properly.#',
+				'message' => '#Class IgnoreErrorsByPath\\[A-Za-z]+ was not found while trying to analyse it - autoloading is probably not configured properly.#',
 				'path'    => __DIR__ . '/data/ignore-errors-by-path/not-ignored.php',
 			],
 		];

--- a/tests/PHPStan/Analyser/data/ignore-errors-by-path/ignored.php
+++ b/tests/PHPStan/Analyser/data/ignore-errors-by-path/ignored.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace IgnoreErrorsByPath;
+
+class Ignored
+{
+}

--- a/tests/PHPStan/Analyser/data/ignore-errors-by-path/not-ignored.php
+++ b/tests/PHPStan/Analyser/data/ignore-errors-by-path/not-ignored.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace IgnoreErrorsByPath;
+
+class NotIgnored
+{
+}


### PR DESCRIPTION
Solves #1361.

In this implementation, I went with `path` as the scope name, to leave open the possibility of having other scope types (namespaces, file type, etc...)