### PR TITLE
Enhancements ternary operator constant condition rule

### DIFF
--- a/src/Rules/Comparison/TernaryOperatorConstantConditionRule.php
+++ b/src/Rules/Comparison/TernaryOperatorConstantConditionRule.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\ConstantType;
 
 class TernaryOperatorConstantConditionRule implements \PHPStan\Rules\Rule
 {
@@ -42,6 +43,17 @@ class TernaryOperatorConstantConditionRule implements \PHPStan\Rules\Rule
 			];
 		}
 
+		$ifType = $node->if === null ? $scope->getType($node->cond) : $scope->getType($node->if);
+		$elseType = $scope->getType($node->else);
+
+		if ($ifType instanceof ConstantType && $elseType instanceof ConstantType) {
+			if ($ifType->equals($elseType)) {
+				return ['If end else parts of ternary operator are equal'];
+			}
+			if ($ifType instanceof ConstantBooleanType && $elseType instanceof ConstantBooleanType) {
+				return ['Ternary operator is not needed. Use just condition casted to bool'];
+			}
+		}
 		return [];
 	}
 

--- a/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
@@ -28,6 +28,26 @@ class TernaryOperatorConstantConditionRuleTest extends \PHPStan\Testing\RuleTest
 				'Ternary operator condition is always false.',
 				15,
 			],
+			[
+				'If end else parts of ternary operator are equal',
+				17,
+			],
+			[
+				'If end else parts of ternary operator are equal',
+				22,
+			],
+			[
+				'If end else parts of ternary operator are equal',
+				24,
+			],
+			[
+				'If end else parts of ternary operator are equal',
+				25,
+			],
+			[
+				'Ternary operator is not needed. Use just condition casted to bool',
+				27,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/data/ternary.php
+++ b/tests/PHPStan/Rules/Comparison/data/ternary.php
@@ -13,6 +13,19 @@ class Ternary
 
 		$zero = 0;
 		$zero ? 'foo' : 'bar';
+
+		$i ? true : true;
+		$i ? true : null;
+		$i ? $std : true;
+		$i ? $std : false;
+		$i ? $std : null;
+		$i ? [] : [];
+		$i ? [23, 24] : [23, 25];
+		$i ? [23, 24] : [23, 24];
+		$i ? [1 => 1] : ['1' => 1];
+		$i ? [1 => 1] : ['asd' => 1];
+		$i ?: $i;
+		$i ? false : true;
 	}
 
 }


### PR DESCRIPTION
Find unnecessary ternary operators, when if and else part are equal or if and else part could be replaced by condition casted to bool.