### PR TITLE
Change return type ArrayIterator::offsetExists from void to bool (closes #1415)

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -334,7 +334,7 @@ return [
 'ArrayIterator::natcasesort' => ['void'],
 'ArrayIterator::natsort' => ['void'],
 'ArrayIterator::next' => ['void'],
-'ArrayIterator::offsetExists' => ['void', 'index'=>'string'],
+'ArrayIterator::offsetExists' => ['bool', 'index'=>'string'],
 'ArrayIterator::offsetGet' => ['mixed', 'index'=>'string'],
 'ArrayIterator::offsetSet' => ['void', 'index'=>'string', 'newval'=>'string'],
 'ArrayIterator::offsetUnset' => ['void', 'index'=>'string'],


### PR DESCRIPTION
I'm not sure about other 'offsetExists' input params, return types seem ok to me (bool). The return values in `Yaf_` methods are totally unclear to me and PHP docs are also unclear, so I prefer to not touch them.