### PR TITLE
Adjust return type of ArrayIterator::offsetSet to mixed, not just string

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -336,7 +336,7 @@ return [
 'ArrayIterator::next' => ['void'],
 'ArrayIterator::offsetExists' => ['void', 'index'=>'string'],
 'ArrayIterator::offsetGet' => ['mixed', 'index'=>'string'],
-'ArrayIterator::offsetSet' => ['void', 'index'=>'string', 'newval'=>'string'],
+'ArrayIterator::offsetSet' => ['void', 'index'=>'string', 'newval'=>'mixed'],
 'ArrayIterator::offsetUnset' => ['void', 'index'=>'string'],
 'ArrayIterator::rewind' => ['void'],
 'ArrayIterator::seek' => ['void', 'position'=>'int'],


### PR DESCRIPTION
`offsetGet` returns `mixed`, which makes me believe `offsetSet` should also take `mixed` and not just `string`. Seems also wrong in PHP docs.