### PR TITLE
Fixing return type of ReflectionParameter::getType

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9708,7 +9708,7 @@ return [
 'ReflectionParameter::getDefaultValueConstantName' => ['string'],
 'ReflectionParameter::getName' => ['string'],
 'ReflectionParameter::getPosition' => ['int'],
-'ReflectionParameter::getType' => ['ReflectionType'],
+'ReflectionParameter::getType' => ['ReflectionType|null'],
 'ReflectionParameter::hasType' => ['bool'],
 'ReflectionParameter::isArray' => ['bool'],
 'ReflectionParameter::isCallable' => ['bool'],


### PR DESCRIPTION
According to [the documentation](http://php.net/manual/fr/reflectionparameter.gettype.php), ReflectionParameter::getType will return a null value if there is no type specified for the parameter.