### PR TITLE
Add properties for DatePeriod class

### DIFF
--- a/src/Reflection/PhpDefect/PhpDefectClassReflectionExtension.php
+++ b/src/Reflection/PhpDefect/PhpDefectClassReflectionExtension.php
@@ -23,6 +23,14 @@ class PhpDefectClassReflectionExtension implements PropertiesClassReflectionExte
 			'days' => 'mixed',
 			'f' => 'float',
 		],
+		\DatePeriod::class => [
+			'recurrences' => 'int',
+			'include_start_date' => 'bool',
+			'start' => \DateTimeInterface::class,
+			'current' => \DateTimeInterface::class,
+			'end' => \DateTimeInterface::class,
+			'interval' => \DateInterval::class,
+		],
 		'Directory' => [
 			'handle' => 'resource',
 			'path' => 'string',

--- a/tests/PHPStan/Reflection/PhpDefect/PhpDefectClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/PhpDefect/PhpDefectClassReflectionExtensionTest.php
@@ -13,6 +13,7 @@ class PhpDefectClassReflectionExtensionTest extends \PHPStan\Testing\TestCase
 
 	/**
 	 * @dataProvider dataDateIntervalProperties
+	 * @dataProvider dataDatePeriodProperties
 	 * @dataProvider dataDomAttrProperties
 	 * @dataProvider dataDomCharacterDataProperties
 	 * @dataProvider dataDomDocumentProperties
@@ -78,6 +79,36 @@ class PhpDefectClassReflectionExtensionTest extends \PHPStan\Testing\TestCase
 					's' => 'int',
 					'invert' => 'int',
 					'days' => 'mixed',
+				],
+			],
+		];
+	}
+
+	public function dataDatePeriodProperties(): array
+	{
+		return [
+			[
+				\DatePeriod::class,
+				\DatePeriod::class,
+				[
+					'recurrences' => 'int',
+					'include_start_date' => 'bool',
+					'start' => \DateTimeInterface::class,
+					'current' => \DateTimeInterface::class,
+					'end' => \DateTimeInterface::class,
+					'interval' => \DateInterval::class,
+				],
+			],
+			[
+				\PhpDefectClasses\DatePeriodChild::class,
+				\DatePeriod::class,
+				[
+					'recurrences' => 'int',
+					'include_start_date' => 'bool',
+					'start' => \DateTimeInterface::class,
+					'current' => \DateTimeInterface::class,
+					'end' => \DateTimeInterface::class,
+					'interval' => \DateInterval::class,
 				],
 			],
 		];

--- a/tests/PHPStan/Reflection/PhpDefect/data/DatePeriodChild.php
+++ b/tests/PHPStan/Reflection/PhpDefect/data/DatePeriodChild.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PhpDefectClasses;
+
+class DatePeriodChild extends \DatePeriod
+{
+
+}


### PR DESCRIPTION
This teaches PHPStan about the properties on the `DatePeriod` class which are missing from reflection.

Is it an issue that these properties were not added until PHP 5.3.27/5.4.17?

http://php.net/manual/en/class.dateperiod.php#dateperiod.props

https://phpstan.org/r/2ad0f4a7e81cf4d2c1024733bf251aea