### PR TITLE
Adding support for second parameter of print_r (returns string when true)

### DIFF
--- a/src/Type/Php/VarExportFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/VarExportFunctionDynamicReturnTypeExtension.php
@@ -20,6 +20,7 @@ class VarExportFunctionDynamicReturnTypeExtension implements DynamicFunctionRetu
 				'var_export',
 				'highlight_file',
 				'highlight_string',
+				'print_r',
 			],
 			true
 		);
@@ -29,6 +30,8 @@ class VarExportFunctionDynamicReturnTypeExtension implements DynamicFunctionRetu
 	{
 		if ($functionReflection->getName() === 'var_export') {
 			$fallbackReturnType = new NullType();
+		} elseif ($functionReflection->getName() === 'print_r') {
+			$fallbackReturnType = new ConstantBooleanType(true);
 		} else {
 			$fallbackReturnType = new BooleanType();
 		}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -2363,6 +2363,22 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'highlight_file($string, true)',
 			],
 			[
+				'string|true',
+				'print_r()',
+			],
+			[
+				'true',
+				'print_r($string)',
+			],
+			[
+				'true',
+				'print_r($string, false)',
+			],
+			[
+				'string',
+				'print_r($string, true)',
+			],
+			[
 				'1',
 				'$one++',
 			],


### PR DESCRIPTION
Fixes #1457 

I more or less copied the implementation of `var_export` based on suggestion from @ondrejmirtes.

I did have to explicitly use the `ConstantBooleanType(true)` type instead of the `BooleanType` as the fallback for `print_r` because it doesn't ever return `false` (according to PHP's docs, if I call `print_r` with no parameters it does return `false` but also emits a Warning. Should I modify this PR to support that? I noticed `var_export` has a no parameter test, in which case it is marked as returning `string|null`. `var_export` when called with no parameters returns `null` and also emits a Warning).