### PR TITLE
Make optional the parameter  of the function session_create_id

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9979,7 +9979,7 @@ return [
 'session_cache_expire' => ['int', 'new_cache_expire='=>'int'],
 'session_cache_limiter' => ['string', 'new_cache_limiter='=>'string'],
 'session_commit' => ['bool'],
-'session_create_id' => ['string', 'prefix'=>'string'],
+'session_create_id' => ['string', 'prefix='=>'string'],
 'session_decode' => ['bool', 'data'=>'string'],
 'session_destroy' => ['bool'],
 'session_encode' => ['string'],


### PR DESCRIPTION
This PR fixes an incorrectly reported issue that happens when the function `session_create_id` is used without passing the `$prefix` parameter. PHPStan warns that it is required, but it's not.

(PR from issue #1495).