### PR TITLE
Fixing NodeScopeResolver var annotation detection tests

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1120,68 +1120,40 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 
 	public function dataVarAnnotations(): array
 	{
-		return [
-			[
-				'int',
-				'$integer',
-			],
-			[
-				'bool',
-				'$boolean',
-			],
-			[
-				'string',
-				'$string',
-			],
-			[
-				'float',
-				'$float',
-			],
-			[
-				'VarAnnotations\Lorem',
-				'$loremObject',
-			],
-			[
-				'AnotherNamespace\Bar',
-				'$barObject',
-			],
-			[
-				'mixed',
-				'$mixed',
-			],
-			[
-				'array',
-				'$array',
-			],
-			[
-				'bool|null',
-				'$isNullable',
-			],
-			[
-				'callable',
-				'$callable',
-			],
-			[
-				'callable',
-				'$callableWithTypes',
-			],
-			[
-				'Closure(int, array<int, string>): void',
-				'$closureWithTypes',
-			],
-			[
-				'VarAnnotations\Foo',
-				'$self',
-			],
-			[
-				'float',
-				'$invalidInteger',
-			],
-			[
-				'static(VarAnnotations\Foo)',
-				'$static',
-			],
+		$varAnnotations = [
+			'Integer' => 'int',
+			'Boolean' => 'bool',
+			'String' => 'string',
+			'Float' => 'float',
+			'LoremObject' => 'VarAnnotations\Lorem',
+			'BarObject' => 'AnotherNamespace\Bar',
+			'Mixed' => 'mixed',
+			'Array' => 'array',
+			'IsNullable' => 'bool|null',
+			'Callable' => 'callable',
+			'CallableWithTypes' => 'callable',
+			'ClosureWithTypes' => 'Closure(int, array<int, string>): void',
+			'Self' => 'VarAnnotations\Foo',
+			'InvalidInteger' => 'int',
+			'Static' => 'static(VarAnnotations\Foo)',
 		];
+
+		$varPrefixes = [
+			'withTypeAndVariable',
+			'withTypeOnly',
+		];
+
+		$data = [];
+		foreach ($varPrefixes as $varPrefix) {
+			foreach ($varAnnotations as $varSuffix => $description) {
+				$data[] = [
+					$description,
+					sprintf('$%s%s', $varPrefix, $varSuffix),
+				];
+			}
+		}
+
+		return $data;
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/var-annotations.php
+++ b/tests/PHPStan/Analyser/data/var-annotations.php
@@ -7,100 +7,97 @@ class Foo
 
 	public function doFoo()
 	{
-		/** @var int $integer */
-		$integer = getFoo();
+		/** @var int $withTypeAndVariableInteger */
+		$withTypeAndVariableInteger = getFoo();
 
-		/** @var bool $boolean */
-		$boolean = getFoo();
+		/** @var bool $withTypeAndVariableBoolean */
+		$withTypeAndVariableBoolean = getFoo();
 
-		/** @var string $string */
-		$string = getFoo();
+		/** @var string $withTypeAndVariableString */
+		$withTypeAndVariableString = getFoo();
 
-		/** @var float $float */
-		$float = getFoo();
+		/** @var float $withTypeAndVariableFloat */
+		$withTypeAndVariableFloat = getFoo();
 
-		/** @var Lorem $loremObject */
-		$loremObject = getFoo();
+		/** @var Lorem $withTypeAndVariableLoremObject */
+		$withTypeAndVariableLoremObject = getFoo();
 
-		/** @var \AnotherNamespace\Bar $barObject */
-		$barObject = getFoo();
+		/** @var \AnotherNamespace\Bar $withTypeAndVariableBarObject */
+		$withTypeAndVariableBarObject = getFoo();
 
-		/** @var mixed $mixed */
-		$mixed = getFoo();
+		/** @var mixed $withTypeAndVariableMixed */
+		$withTypeAndVariableMixed = getFoo();
 
-		/** @var array $array */
-		$array = getFoo();
+		/** @var array $withTypeAndVariableArray */
+		$withTypeAndVariableArray = getFoo();
 
-		/** @var bool|null $isNullable */
-		$isNullable = getFoo();
+		/** @var bool|null $withTypeAndVariableIsNullable */
+		$withTypeAndVariableIsNullable = getFoo();
 
-		/** @var callable $callable */
-		$callable = getFoo();
+		/** @var callable $withTypeAndVariableCallable */
+		$withTypeAndVariableCallable = getFoo();
 
-		/** @var callable(int $x, string ...$y): void $callableWithTypes */
-		$callableWithTypes = getFoo();
+		/** @var callable(int $x, string ...$y): void $withTypeAndVariableCallableWithTypes */
+		$withTypeAndVariableCallableWithTypes = getFoo();
 
-		/** @var \Closure(int $x, string ...$y): void $closureWithTypes */
-		$closureWithTypes = getFoo();
+		/** @var \Closure(int $x, string ...$y): void $withTypeAndVariableClosureWithTypes */
+		$withTypeAndVariableClosureWithTypes = getFoo();
 
-		/** @var self $self */
-		$self = getFoo();
+		/** @var self $withTypeAndVariableSelf */
+		$withTypeAndVariableSelf = getFoo();
 
-		/** @var int $invalidInt */
-		$invalidInteger = $this->getFloat();
+		/** @var int $withTypeAndVariableInvalidInteger */
+		$withTypeAndVariableInvalidInteger = $this->getFloat();
 
-		/** @var static $static */
-		$static = getFoo();
+		/** @var static $withTypeAndVariableStatic */
+		$withTypeAndVariableStatic = getFoo();
 
-		die;
-	}
+		// - - - - - - -
 
-	public function doFooBar()
-	{
 		/** @var int */
-		$integer = getFoo();
+		$withTypeOnlyInteger = getFoo();
 
 		/** @var bool */
-		$boolean = getFoo();
+		$withTypeOnlyBoolean = getFoo();
 
 		/** @var string */
-		$string = getFoo();
+		$withTypeOnlyString = getFoo();
 
 		/** @var float */
-		$float = getFoo();
+		$withTypeOnlyFloat = getFoo();
 
 		/** @var Lorem */
-		$loremObject = getFoo();
+		$withTypeOnlyLoremObject = getFoo();
 
 		/** @var \AnotherNamespace\Bar */
-		$barObject = getFoo();
+		$withTypeOnlyBarObject = getFoo();
 
 		/** @var mixed */
-		$mixed = getFoo();
+		$withTypeOnlyMixed = getFoo();
 
 		/** @var array */
-		$array = getFoo();
+		$withTypeOnlyArray = getFoo();
 
 		/** @var bool|null */
-		$isNullable = getFoo();
+		$withTypeOnlyIsNullable = getFoo();
 
 		/** @var callable */
-		$callable = getFoo();
+		$withTypeOnlyCallable = getFoo();
 
 		/** @var callable(int $x, string &...$y): void */
-		$callableWithTypes = getFoo();
+		$withTypeOnlyCallableWithTypes = getFoo();
 
 		/** @var \Closure(int $x, string &...$y): void */
-		$closureWithTypes = getFoo();
+		$withTypeOnlyClosureWithTypes = getFoo();
 
 		/** @var self */
-		$self = getFoo();
+		$withTypeOnlySelf = getFoo();
 
-		/** @var float */
-		$invalidInteger = 1.0;
+		/** @var int */
+		$withTypeOnlyInvalidInteger = $this->getFloat();
 
 		/** @var static */
-		$static = getFoo();
+		$withTypeOnlyStatic = getFoo();
 
 		die;
 	}


### PR DESCRIPTION
As I was going through some tests, when trying to implement another feature, I noticed the test was not really running every expected check or was having false positive results.

Details:
1. The tests in `var-annotations.php` were split into 2 method but having the exact same var names. This resulted in the second method overriding the detected type of the first methods vars, which lead to some weird false positive results.
   * For example L49 had `$invalidInt` in the annotation instead of `$invalidInteger`, but wasn't reported as faulty because it was "overridden" by L99-100 later
2. As this test focuses on detecting type from var annotations, the old `var-annotations.php` L99 was giving false positive results (and was different from the other `$invalidInteger` definition from the method above
3. I also tried to improve the dataProvider so it reflects that we are testing different var annotation styles but are expecting the same results. 

Let me know if you need anymore details or this needs further work.