### PR TITLE
Fix filename of anonymous class

### DIFF
--- a/src/Broker/Broker.php
+++ b/src/Broker/Broker.php
@@ -305,7 +305,7 @@ class Broker
 		self::$anonymousClasses[$className] = $this->getClassFromReflection(
 			new \ReflectionClass('\\' . $className),
 			sprintf('class@anonymous/%s:%s', $filename, $node->getLine()),
-			$filename
+			$scopeFile
 		);
 		$this->classReflections[$className] = self::$anonymousClasses[$className];
 


### PR DESCRIPTION
Closes #1524

@ondrejmirtes It was easier to just fix the problem. The path sent to `file_get_contents` was relative instead of absolute.
