### PR TITLE
Add link to Yii2 phpstan extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Unofficial extensions for other frameworks and libraries are also available:
 * [Prophecy](https://github.com/Jan0707/phpstan-prophecy)
 * [Laravel](https://github.com/nunomaduro/larastan)
 * [myclabs/php-enum](https://github.com/timeweb/phpstan-enum)
+* [Yii2](https://github.com/proget-hq/phpstan-yii2)
 
 New extensions are becoming available on a regular basis!
 


### PR DESCRIPTION
There is still some work to be done but it may be useful to someone.