### PR TITLE
Add unique name to default tmpDir

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -116,7 +116,7 @@ class CommandHelper
 		}
 
 		if (!isset($tmpDir)) {
-			$tmpDir = sys_get_temp_dir() . '/phpstan';
+			$tmpDir = sys_get_temp_dir() . '/phpstan_' . crc32($currentWorkingDirectory);
 			if (!@mkdir($tmpDir, 0777, true) && !is_dir($tmpDir)) {
 				$errorOutput->writeln(sprintf('Cannot create a temp directory %s', $tmpDir));
 				throw new \PHPStan\Command\InceptionNotSuccessfulException();


### PR DESCRIPTION
If the `tmpDir` is not set and the system hosts multiple users with multiple projects, having everyone using the same `/tmp/phpstan` path is unfeasable.

Of course it should be better to:

1. always set a `tmpDir` in each phpstan.neon
1. sets different `sys_temp_dir` per user
1. completely avoid shared environments

But it's now always doable. With this fix we should ensure a minimum segregation between different runs of phpstan on different users and projects.