### PR TITLE
Prevent using symfony/console with broken exit code handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
 		"symfony/console": "~3.2 || ~4.0",
 		"symfony/finder": "~3.2 || ~4.0"
 	},
+	"conflict": {
+		"symfony/console": "3.4.16 || 4.1.5"
+	},
 	"require-dev": {
 		"ext-gd": "*",
 		"ext-intl": "*",


### PR DESCRIPTION
There's a [bug](https://github.com/symfony/symfony/issues/28666) in symfony/console 3.4.16 and 4.1.5 where the exit code is reported as success if it failed.

This obviously affects this tool in a major way rendering it useless in a CI environment, so this PR ensures this bug cannot be installed.