### PR TITLE
Set analyse command as default command

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -35,5 +35,8 @@ $application = new \Symfony\Component\Console\Application(
 	'PHPStan - PHP Static Analysis Tool',
 	$version
 );
-$application->add(new AnalyseCommand());
+
+$command = new AnalyseCommand();
+$application->add($command);
+$application->setDefaultCommand($command->getName());
 $application->run();


### PR DESCRIPTION
will replace `phpstan analyse src/` by `phpstan src/` as phpstan does contain only one command.

See https://symfony.com/doc/current/components/console/changing_default_command.html for the documentation