### PR TITLE
Add false as possible return type of DateTime::add

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -1598,7 +1598,7 @@ return [
 'DateTime::__construct' => ['void', 'time='=>'string|null', 'timezone='=>'?DateTimeZone'],
 'DateTime::__set_state' => ['static', 'array'=>'array'],
 'DateTime::__wakeup' => ['void'],
-'DateTime::add' => ['static', 'interval'=>'DateInterval'],
+'DateTime::add' => ['static|false', 'interval'=>'DateInterval'],
 'DateTime::createFromFormat' => ['static|false', 'format'=>'string', 'time'=>'string', 'timezone='=>'DateTimeZone|null'],
 'DateTime::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTime::format' => ['string', 'format'=>'string'],


### PR DESCRIPTION
`\DateTime::add()` may return `false`:

```
var_dump(
    (new DateTime())->add('foobar')
);

// Warning: DateTime::add() expects parameter 1 to be DateInterval, string given in /in/F7qsi on line 4
// bool(false)
```