### PR TITLE
@inheritdoc from trait

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1976,6 +1976,7 @@ class NodeScopeResolver
 				$this->broker,
 				$docComment,
 				$scope->getClassReflection()->getName(),
+				$trait,
 				$functionLike->name->name,
 				$file
 			);
@@ -1984,6 +1985,7 @@ class NodeScopeResolver
 				$docComment = $phpDocBlock->getDocComment();
 				$file = $phpDocBlock->getFile();
 				$class = $phpDocBlock->getClass();
+				$trait = $phpDocBlock->getTrait();
 			}
 		}
 

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -137,6 +137,7 @@ class PhpClassReflectionExtension
 				$this->broker,
 				$docComment,
 				$declaringClassReflection->getName(),
+				null,
 				$propertyName,
 				$declaringClassReflection->getFileName()
 			);
@@ -331,6 +332,7 @@ class PhpClassReflectionExtension
 				$this->broker,
 				$docComment,
 				$declaringClass->getName(),
+				null,
 				$methodReflection->getName(),
 				$declaringClass->getFileName()
 			);

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -134,6 +134,11 @@ class PhpMethodReflection implements MethodReflection, DeprecatableReflection, I
 		return $this->declaringClass;
 	}
 
+	public function getDeclaringTrait(): ?ClassReflection
+	{
+		return $this->declaringTrait;
+	}
+
 	/**
 	 * @return string|false
 	 */

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -6133,6 +6133,62 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		);
 	}
 
+	public function dataInheritDocFromTrait(): array
+	{
+		return [
+			[
+				'string',
+				'$string',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataInheritDocFromTrait
+	 * @param string $description
+	 * @param string $expression
+	 */
+	public function testInheritDocFromTrait(
+		string $description,
+		string $expression
+	): void
+	{
+		$this->assertTypes(
+			__DIR__ . '/data/inheritdoc-from-trait.php',
+			$description,
+			$expression
+		);
+	}
+
+	public function dataInheritDocFromTrait2(): array
+	{
+		return [
+			[
+				'string',
+				'$string',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataInheritDocFromTrait2
+	 * @param string $description
+	 * @param string $expression
+	 */
+	public function testInheritDocFromTrait2(
+		string $description,
+		string $expression
+	): void
+	{
+		require_once __DIR__ . '/data/inheritdoc-from-trait2-definition.php';
+		require_once __DIR__ . '/data/inheritdoc-from-trait2-definition2.php';
+		$this->assertTypes(
+			__DIR__ . '/data/inheritdoc-from-trait2.php',
+			$description,
+			$expression
+		);
+	}
+
 	public function dataResolveStatic(): array
 	{
 		return [

--- a/tests/PHPStan/Analyser/data/inheritdoc-from-trait.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-from-trait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace InheritDocFromTrait;
+
+class Foo implements FooInterface
+{
+	use FooTrait;
+}
+
+trait FooTrait
+{
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function doFoo($string)
+	{
+		die;
+	}
+
+}
+
+interface FooInterface
+{
+
+	/**
+	 * @param string $string
+	 */
+	public function doFoo($string);
+
+}

--- a/tests/PHPStan/Analyser/data/inheritdoc-from-trait2-definition.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-from-trait2-definition.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace InheritDocFromTrait2;
+
+trait FooTrait
+{
+
+	/**
+	 * @param string $string
+	 */
+	public function doFoo($string)
+	{
+		die;
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/inheritdoc-from-trait2-definition2.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-from-trait2-definition2.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace InheritDocFromTrait2;
+
+class FooParent
+{
+	use FooTrait;
+}

--- a/tests/PHPStan/Analyser/data/inheritdoc-from-trait2.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-from-trait2.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace InheritDocFromTrait2;
+
+class Foo extends FooParent
+{
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function doFoo($string)
+	{
+		die;
+	}
+
+}


### PR DESCRIPTION
I'm not sure how to fix this one. The problem is that the [`$trait`](https://github.com/phpstan/phpstan/blob/ad0406193c72a5ea108e7d7be86b61e3269e8df6/src/Analyser/NodeScopeResolver.php#L1970) variable is never reset if the `@inheritdoc` comes from another source.

@ondrejmirtes Any ideas?