### PR TITLE
[BUGFIX] UnionType::accepts() always results in Yes

### DIFF
--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -65,9 +65,12 @@ class UnionType implements CompoundType, StaticResolvableType
 			return CompoundTypeHelper::accepts($type, $this, $strictTypes);
 		}
 
-		return $this->unionResults(static function (Type $innerType) use ($strictTypes): TrinaryLogic {
-			return $innerType->accepts($innerType, $strictTypes);
-		});
+		$results = [];
+		foreach ($this->getTypes() as $innerType) {
+			$results[] = $innerType->accepts($type, $strictTypes);
+		}
+
+		return TrinaryLogic::createNo()->or(...$results);
 	}
 
 	public function isSuperTypeOf(Type $otherType): TrinaryLogic

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -601,16 +601,16 @@ class UnionTypeTest extends \PHPStan\Testing\TestCase
 				new ClosureType([], new StringType(), false),
 				TrinaryLogic::createYes(),
 			],
-            [
-                new UnionType([new CallableType(), new NullType()]),
-                new UnionType([new ClosureType([], new StringType(), false), new BooleanType()]),
-                TrinaryLogic::createMaybe(),
-            ],
-            [
-                new UnionType([new CallableType(), new NullType()]),
-                new BooleanType(),
-                TrinaryLogic::createNo(),
-            ],
+			[
+				new UnionType([new CallableType(), new NullType()]),
+				new UnionType([new ClosureType([], new StringType(), false), new BooleanType()]),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new UnionType([new CallableType(), new NullType()]),
+				new BooleanType(),
+				TrinaryLogic::createNo(),
+			],
 		];
 	}
 

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -601,6 +601,16 @@ class UnionTypeTest extends \PHPStan\Testing\TestCase
 				new ClosureType([], new StringType(), false),
 				TrinaryLogic::createYes(),
 			],
+            [
+                new UnionType([new CallableType(), new NullType()]),
+                new UnionType([new ClosureType([], new StringType(), false), new BooleanType()]),
+                TrinaryLogic::createMaybe(),
+            ],
+            [
+                new UnionType([new CallableType(), new NullType()]),
+                new BooleanType(),
+                TrinaryLogic::createNo(),
+            ],
 		];
 	}
 


### PR DESCRIPTION
`UnionType::accepts()` will always return `Yes` if non-union type is passed and `Maybe` if union type is passed because accepted type is checked against itself.

Fixed by checking inner type to given type and doing an `or`, similar to `UnionType::isSuperTypeOf()`.

Issue is in
https://github.com/phpstan/phpstan/blob/8dea06c4f011f9282ea09df38d4cb1cc357b5c99/src/Type/UnionType.php#L62-L71

Specifically
https://github.com/phpstan/phpstan/blob/8dea06c4f011f9282ea09df38d4cb1cc357b5c99/src/Type/UnionType.php#L69