### PR TITLE
Check invalid comparison between object and number

### DIFF
--- a/conf/config.level2.neon
+++ b/conf/config.level2.neon
@@ -12,6 +12,7 @@ rules:
 	- PHPStan\Rules\Cast\PrintRule
 	- PHPStan\Rules\Operators\InvalidBinaryOperationRule
 	- PHPStan\Rules\Operators\InvalidUnaryOperationRule
+	- PHPStan\Rules\Operators\InvalidComparisonOperationRule
 	- PHPStan\Rules\PhpDoc\IncompatiblePhpDocTypeRule
 	- PHPStan\Rules\PhpDoc\InvalidPhpDocTagValueRule
 	- PHPStan\Rules\PhpDoc\InvalidThrowsPhpDocValueRule

--- a/src/Rules/Operators/InvalidComparisonOperationRule.php
+++ b/src/Rules/Operators/InvalidComparisonOperationRule.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
+
+class InvalidComparisonOperationRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var \PHPStan\Rules\RuleLevelHelper */
+	private $ruleLevelHelper;
+
+	public function __construct(RuleLevelHelper $ruleLevelHelper)
+	{
+		$this->ruleLevelHelper = $ruleLevelHelper;
+	}
+
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\BinaryOp::class;
+	}
+
+	/**
+	 * @param Node $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (
+			!$node instanceof Node\Expr\BinaryOp\Equal
+			&& !$node instanceof Node\Expr\BinaryOp\NotEqual
+			&& !$node instanceof Node\Expr\BinaryOp\Smaller
+			&& !$node instanceof Node\Expr\BinaryOp\SmallerOrEqual
+			&& !$node instanceof Node\Expr\BinaryOp\Greater
+			&& !$node instanceof Node\Expr\BinaryOp\GreaterOrEqual
+			&& !$node instanceof Node\Expr\BinaryOp\Spaceship
+		) {
+			return [];
+		}
+
+		$isNumericLeft = $this->isNumberType($scope, $node->left);
+		$isObjectLeft = $this->isObjectType($scope, $node->left);
+		$isNumericRight = $this->isNumberType($scope, $node->right);
+		$isObjectRight = $this->isObjectType($scope, $node->right);
+
+		if (($isNumericLeft && $isObjectRight) || ($isObjectLeft && $isNumericRight)) {
+			return [
+				sprintf(
+					'Comparison operation "%s" between %s and %s results in an error.',
+					$node->getOperatorSigil(),
+					$scope->getType($node->left)->describe(VerbosityLevel::value()),
+					$scope->getType($node->right)->describe(VerbosityLevel::value())
+				),
+			];
+		}
+
+		return [];
+	}
+
+	private function isNumberType(Scope $scope, Node\Expr $expr): bool
+	{
+		$acceptedType = new UnionType([new IntegerType(), new FloatType()]);
+
+		$alwaysYes = static function (): bool {
+			return true;
+		};
+		$onlyNumber = static function (Type $type) use ($acceptedType): bool {
+			return $acceptedType->accepts($type, true)->yes();
+		};
+
+		$type = $this->ruleLevelHelper->findTypeToCheck($scope, $expr, '', $onlyNumber)->getType();
+		$fulltype = $this->ruleLevelHelper->findTypeToCheck($scope, $expr, '', $alwaysYes)->getType();
+
+		if ($type instanceof ErrorType || !$type->equals($fulltype)) {
+			return false;
+		}
+
+		return !TrinaryLogic::createNo()->or(
+			$type->isSuperTypeOf(new IntegerType()),
+			$type->isSuperTypeOf(new FloatType())
+		)->no();
+	}
+
+
+	private function isObjectType(Scope $scope, Node\Expr $expr): bool
+	{
+		$acceptedType = new ObjectWithoutClassType();
+
+		$type = $this->ruleLevelHelper->findTypeToCheck(
+			$scope,
+			$expr,
+			'',
+			static function (Type $type) use ($acceptedType): bool {
+				return $acceptedType->isSuperTypeOf($type)->yes();
+			}
+		)->getType();
+
+		if ($type instanceof ErrorType) {
+			return false;
+		}
+
+		$isSuperType = $acceptedType->isSuperTypeOf($type);
+		if ($type instanceof \PHPStan\Type\BenevolentUnionType) {
+			return !$isSuperType->no();
+		}
+
+		return $isSuperType->yes();
+	}
+
+}

--- a/src/Testing/LevelsTestCase.php
+++ b/src/Testing/LevelsTestCase.php
@@ -111,7 +111,7 @@ abstract class LevelsTestCase extends \PHPUnit\Framework\TestCase
 				$this->assertFileNotExists($expectedJsonFile);
 				return null;
 			} catch (\PHPUnit\Framework\AssertionFailedError $e) {
-				unlink($expectedJsonFile);
+				//unlink($expectedJsonFile);
 				return $e;
 			}
 		}

--- a/tests/PHPStan/Levels/LevelsIntegrationTest.php
+++ b/tests/PHPStan/Levels/LevelsIntegrationTest.php
@@ -19,6 +19,7 @@ class LevelsIntegrationTest extends \PHPStan\Testing\LevelsTestCase
 			['clone'],
 			['iterable'],
 			['binaryOps'],
+			['comparison'],
 			['throwValues'],
 			['casts'],
 			['unreachable'],

--- a/tests/PHPStan/Levels/data/comparison-2.json
+++ b/tests/PHPStan/Levels/data/comparison-2.json
@@ -1,0 +1,12 @@
+[
+    {
+        "message": "Comparison operation \"==\" between stdClass and int results in an error.",
+        "line": 25,
+        "ignorable": true
+    },
+    {
+        "message": "Comparison operation \"==\" between stdClass and float results in an error.",
+        "line": 26,
+        "ignorable": true
+    }
+]

--- a/tests/PHPStan/Levels/data/comparison-6.json
+++ b/tests/PHPStan/Levels/data/comparison-6.json
@@ -1,0 +1,13 @@
+[
+    {
+        "message": "Comparison operation \"==\" between stdClass and int|string results in an error.",
+        "line": 28,
+        "ignorable": true
+    },
+    {
+        "message": "Comparison operation \"==\" between stdClass and int|stdClass results in an error.",
+        "line": 29,
+        "ignorable": true
+    }
+
+]

--- a/tests/PHPStan/Levels/data/comparison.php
+++ b/tests/PHPStan/Levels/data/comparison.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Levels\Comparison;
+
+class Foo
+{
+
+	/**
+     * @param \stdClass $object
+	 * @param int $int
+     * @param float $float
+	 * @param string $string
+	 * @param int|string $intOrString
+	 * @param int|\stdClass $intOrObject
+	 */
+	public function doFoo(
+	    \stdClass $object,
+		int $int,
+		float $float,
+		string $string,
+		$intOrString,
+        $intOrObject
+	)
+	{
+        $object == $int;
+        $object == $float;
+        $object == $string;
+        $object == $intOrString;
+        $object == $intOrObject;
+	}
+
+}

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -102,6 +102,10 @@ class InvalidBinaryOperationRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Binary operation "+" between (array|string) and 1 results in an error.',
 				130,
 			],
+			[
+				'Binary operation "+" between stdClass and int results in an error.',
+				151,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Operators/InvalidComparisonOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidComparisonOperationRuleTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\RuleLevelHelper;
+
+class InvalidComparisonOperationRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		return new InvalidComparisonOperationRule(
+			new RuleLevelHelper($this->createBroker(), true, false, true)
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/invalid-comparison.php'], [
+			[
+				'Comparison operation "==" between stdClass and int results in an error.',
+				15,
+			],
+			[
+				'Comparison operation "!=" between stdClass and int results in an error.',
+				16,
+			],
+			[
+				'Comparison operation "<" between stdClass and int results in an error.',
+				17,
+			],
+			[
+				'Comparison operation ">" between stdClass and int results in an error.',
+				18,
+			],
+			[
+				'Comparison operation "<=" between stdClass and int results in an error.',
+				19,
+			],
+			[
+				'Comparison operation ">=" between stdClass and int results in an error.',
+				20,
+			],
+			[
+				'Comparison operation "<=>" between stdClass and int results in an error.',
+				21,
+			],
+			[
+				'Comparison operation "==" between stdClass and float|null results in an error.',
+				25,
+			],
+			[
+				'Comparison operation "<" between stdClass and float|null results in an error.',
+				26,
+			],
+			[
+				'Comparison operation "==" between stdClass and float|int|null results in an error.',
+				43,
+			],
+			[
+				'Comparison operation "<" between stdClass and float|int|null results in an error.',
+				44,
+			],
+			[
+				'Comparison operation "==" between stdClass and 1 results in an error.',
+				48,
+			],
+			[
+				'Comparison operation "<" between stdClass and 1 results in an error.',
+				49,
+			],
+			[
+				'Comparison operation "==" between stdClass and int|stdClass results in an error.',
+				56,
+			],
+			[
+				'Comparison operation "<" between stdClass and int|stdClass results in an error.',
+				57,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Operators/data/invalid-binary.php
+++ b/tests/PHPStan/Rules/Operators/data/invalid-binary.php
@@ -145,3 +145,8 @@ function (array $a) {
 	}
 	$a + $b;
 };
+
+function (stdClass $ob, int $n) {
+    $ob == $n;
+    $ob + $n;
+};

--- a/tests/PHPStan/Rules/Operators/data/invalid-comparison.php
+++ b/tests/PHPStan/Rules/Operators/data/invalid-comparison.php
@@ -1,0 +1,58 @@
+<?php
+
+function (stdClass $ob, $a)
+{
+    $ob == $a;
+    $ob != $a;
+    $ob < $a;
+    $ob > $a;
+    $ob <= $a;
+    $ob >= $a;
+    $ob <=> $a;
+};
+
+function (stdClass $ob, int $n) {
+    $ob == $n;
+    $ob != $n;
+    $ob < $n;
+    $ob > $n;
+    $ob <= $n;
+    $ob >= $n;
+    $ob <=> $n;
+};
+
+function (stdClass $ob, ?float $n) {
+    $ob == $n;
+    $ob < $n;
+};
+
+function (stdClass $ob, string $str) {
+    $ob == $str;
+    $ob < $str;
+};
+
+function (string $str, int $n) {
+    $str == $n;
+    $str < $n;
+};
+
+function (stdClass $ob, callable $fn) {
+    /** @var int|float|null $n */
+    $n = $fn();
+
+    $ob == $n;
+    $ob < $n;
+};
+
+function (stdClass $ob) {
+    $ob == 1;
+    $ob < 1;
+};
+
+function (stdClass $ob, callable $fn) {
+    /** @var int|stdClass $a */
+    $a = $fn();
+
+    $ob == $a;
+    $ob < $a;
+};


### PR DESCRIPTION
Trying to do any loose comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`, `<=>`) between an object and an integer or float will result in a Notice.

    Object of class ... could not be converted to int

![screenshot-github com-2018 11 06-20-28-28](https://user-images.githubusercontent.com/100821/48088815-36626f00-e203-11e8-800d-1d0c6e99fd79.png)

This is a similar error to using an arithmetic operator with an object .

Note that comparing objects to any other type of variable does not trigger any error.