### PR TITLE
Optional parameters for ldap (fixes #1585)

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -5842,7 +5842,7 @@ return [
 'ldap_compare' => ['bool', 'link_identifier'=>'resource', 'dn'=>'string', 'attr'=>'string', 'value'=>'string'],
 'ldap_connect' => ['resource|false', 'host='=>'string', 'port='=>'int', 'wallet='=>'string', 'wallet_passwd='=>'string', 'authmode='=>'int'],
 'ldap_control_paged_result' => ['bool', 'link_identifier'=>'resource', 'pagesize'=>'int', 'iscritical'=>'bool', 'cookie'=>'string'],
-'ldap_control_paged_result_response' => ['bool', 'link_identifier'=>'resource', 'result_identifier'=>'resource', '&w_cookie'=>'string', '&w_estimated'=>'int'],
+'ldap_control_paged_result_response' => ['bool', 'link_identifier'=>'resource', 'result_identifier'=>'resource', '&w_cookie='=>'string', '&w_estimated='=>'int'],
 'ldap_count_entries' => ['int', 'link_identifier'=>'resource', 'result'=>'resource'],
 'ldap_delete' => ['bool', 'link_identifier'=>'resource', 'dn'=>'string'],
 'ldap_dn2ufn' => ['string', 'dn'=>'string'],


### PR DESCRIPTION
The 3rd and 4th parameters to [ldap_control_paged_result_response()](http://php.net/manual/en/function.ldap-control-paged-result-response.php) are optional.