### PR TITLE
Fix DOMDocument::saveHTML()

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -1924,7 +1924,7 @@ return [
 'DOMDocument::relaxNGValidate' => ['bool', 'filename'=>'string'],
 'DOMDocument::relaxNGValidateSource' => ['bool', 'source'=>'string'],
 'DOMDocument::save' => ['int', 'filename'=>'string', 'options='=>'int'],
-'DOMDocument::saveHTML' => ['string', 'node='=>'?DOMNode'],
+'DOMDocument::saveHTML' => ['string|false', 'node='=>'?DOMNode'],
 'DOMDocument::saveHTMLFile' => ['int', 'filename'=>'string'],
 'DOMDocument::saveXML' => ['string', 'node='=>'DOMNode', 'options='=>'int'],
 'DOMDocument::schemaValidate' => ['bool', 'filename'=>'string', 'flags='=>'int'],


### PR DESCRIPTION
This method can return false according to [documentation](php.net/manual/en/domdocument.savehtml.php).