### PR TITLE
Prevent undefined property when using null coalescing operator

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -829,7 +829,8 @@ class NodeScopeResolver
 
 				$this->processNodes($subNode, $scope, $nodeCallback, $argClosureBindScope);
 			} elseif ($subNode instanceof \PhpParser\Node) {
-				if ($node instanceof Coalesce && $subNodeName === 'left') {
+				if ($node instanceof Coalesce && $subNodeName === 'left' && $subNode instanceof Expr) {
+					$scope = $this->specifyProperty($scope, $subNode);
 					$scope = $this->ensureNonNullability($scope, $subNode, false);
 
 					if (!($node->left instanceof ArrayDimFetch) || $node->left->dim !== null) {

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -123,18 +123,6 @@ class AccessPropertiesRuleTest extends \PHPStan\Testing\RuleTestCase
 					250,
 				],
 				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					264,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					266,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					270,
-				],
-				[
 					'Cannot access property $bar on TestAccessProperties\NullCoalesce|null.',
 					272,
 				],
@@ -248,18 +236,6 @@ class AccessPropertiesRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					'Access to an undefined property TestAccessProperties\FooAccessProperties::$dolor.',
 					250,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					264,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					266,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					270,
 				],
 				[
 					'Cannot access property $bar on TestAccessProperties\NullCoalesce|null.',


### PR DESCRIPTION
Fixes #1067 

When using null coalescing operator, I think that the scope should ensure that the left has properties.
I'm deleting the existing tests for this fix, but I'm wondering whether it is right... However, it seems correct not to report a warning in the following cases 🤔 

```php
<?php

class NullCoalesce
{

	/** @var self|null */
	private $foo;

	public function doFoo()
	{
		$this->foo->bar ?? 'bar';

		if ($this->foo->bar ?? 'bar') {

		}

		($this->foo->bar ?? 'bar') ? 'foo' : 'bar';

		$this->foo->foo->foo->bar;
	}

}

$obj = new NullCoalesce();
$obj->doFoo();
```

```
$ php -v
PHP 7.1.8 (cli) (built: Aug  7 2017 15:01:31) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies

$ php test.php
PHP Notice:  Trying to get property of non-object in /Users/watanabekazuma/workspace/php/phpstan/test.php on line 18

Notice: Trying to get property of non-object in /Users/watanabekazuma/workspace/php/phpstan/test.php on line 18
PHP Notice:  Trying to get property of non-object in /Users/watanabekazuma/workspace/php/phpstan/test.php on line 18

Notice: Trying to get property of non-object in /Users/watanabekazuma/workspace/php/phpstan/test.php on line 18
PHP Notice:  Trying to get property of non-object in /Users/watanabekazuma/workspace/php/phpstan/test.php on line 18

Notice: Trying to get property of non-object in /Users/watanabekazuma/workspace/php/phpstan/test.php on line 18
```

Finally, thank you for this awesome project! Please let me know if there are any mistakes.