### PR TITLE
Array from `pathinfo` may or may not contain `extension` key

### DIFF
--- a/src/Type/Php/PathinfoFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PathinfoFunctionDynamicReturnTypeExtension.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 
 class PathinfoFunctionDynamicReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
@@ -30,16 +31,20 @@ class PathinfoFunctionDynamicReturnTypeExtension implements \PHPStan\Type\Dynami
 		} elseif ($argsCount === 1) {
 			$stringType = new StringType();
 
-			return new ConstantArrayType([
-				new ConstantStringType('dirname'),
-				new ConstantStringType('basename'),
-				new ConstantStringType('extension'),
-				new ConstantStringType('filename'),
-			], [
-				$stringType,
-				$stringType,
-				$stringType,
-				$stringType,
+			$dirname = new ConstantStringType('dirname');
+			$basename = new ConstantStringType('basename');
+			$extension = new ConstantStringType('extension');
+			$filename = new ConstantStringType('filename');
+
+			return new UnionType([
+				new ConstantArrayType(
+					[$dirname, $basename, $filename],
+					[$stringType, $stringType, $stringType]
+				),
+				new ConstantArrayType(
+					[$dirname, $basename, $extension, $filename],
+					[$stringType, $stringType, $stringType, $stringType]
+				),
 			]);
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -2767,7 +2767,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$unshiftedConditionalArray',
 			],
 			[
-				'array(\'dirname\' => string, \'basename\' => string, \'extension\' => string, \'filename\' => string)',
+				'array(\'dirname\' => string, \'basename\' => string, \'filename\' => string, ?\'extension\' => string)',
 				'pathinfo($string)',
 			],
 			[


### PR DESCRIPTION
Make 'extension' optional by returning a `UnionType` in `PathinfoFunctionDynamicReturnTypeExtension`.
Fixes #1630