### PR TITLE
Make `if` branch scope including `continue` intersects an outer scope

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1711,6 +1711,13 @@ class NodeScopeResolver
 				$earlyTerminationStatement = $this->findStatementEarlyTermination($statement, $branchScope);
 				if ($earlyTerminationStatement !== null) {
 					if ($lookForAssignsSettings->shouldSkipBranch($earlyTerminationStatement)) {
+						if ($earlyTerminationStatement instanceof Continue_) {
+							if ($intersectedScope === null) {
+								$intersectedScope = $initialScope->createIntersectedScope($branchScopeWithInitialScopeRemoved);
+							} else {
+								$intersectedScope = $intersectedScope->intersectVariables($branchScopeWithInitialScopeRemoved);
+							}
+						}
 						continue 2;
 					}
 					$branchScopeWithInitialScopeRemoved = $branchScopeWithInitialScopeRemoved->removeSpecified($initialScope);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -6356,7 +6356,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				"'afterAssign'",
 			],
 			[
-				'LoopVariables\Foo',
+				'LoopVariables\Foo|LoopVariables\Lorem',
 				'$foo',
 				"'end'",
 			],
@@ -6399,6 +6399,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'int|null',
 				'$nullableVal',
 				"'afterLoop'",
+			],
+			[
+				'bool',
+				'$bar',
+				"'afterContinueInLoopWithEarlyTermination'",
 			],
 		];
 	}
@@ -6556,7 +6561,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				"'afterAssign'",
 			],
 			[
-				'LoopVariables\Foo',
+				'LoopVariables\Foo|LoopVariables\Lorem',
 				'$foo',
 				"'end'",
 			],
@@ -6599,6 +6604,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'int',
 				'$nullableVal',
 				"'afterLoop'",
+			],
+			[
+				'bool',
+				'$bar',
+				"'afterContinueInLoopWithEarlyTermination'",
 			],
 		];
 	}

--- a/tests/PHPStan/Analyser/data/do-while-loop-variables.php
+++ b/tests/PHPStan/Analyser/data/do-while-loop-variables.php
@@ -38,4 +38,16 @@ function () {
 	} while (doFoo() && $i++ < 10);
 
 	'afterLoop';
+
+	$bar = false;
+	do {
+		if (something()) {
+			$bar = true;
+			continue;
+		}
+
+		'afterContinueInLoopWithEarlyTermination';
+
+		return;
+	} while (condition());
 };

--- a/tests/PHPStan/Analyser/data/for-loop-variables.php
+++ b/tests/PHPStan/Analyser/data/for-loop-variables.php
@@ -35,4 +35,16 @@ function () {
 	}
 
 	'afterLoop';
+
+	$bar = false;
+	for ($i = 0; $i < 10; $i++) {
+		if (something()) {
+			$bar = true;
+			continue;
+		}
+
+		'afterContinueInLoopWithEarlyTermination';
+
+		return;
+	}
 };

--- a/tests/PHPStan/Analyser/data/foreach-loop-variables.php
+++ b/tests/PHPStan/Analyser/data/foreach-loop-variables.php
@@ -78,6 +78,18 @@ class ForeachFoo
 		}
 
 		'afterLoop';
+
+		$bar = false;
+		foreach ($iterableArray as $emptyForeachVal => $emptyForeachVal) {
+			if (something()) {
+				$bar = true;
+				continue;
+			}
+
+			'afterContinueInLoopWithEarlyTermination';
+
+			return;
+		}
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/while-loop-variables.php
+++ b/tests/PHPStan/Analyser/data/while-loop-variables.php
@@ -36,4 +36,16 @@ function () {
 	}
 
 	'afterLoop';
+
+	$bar = false;
+	while (condition()) {
+		if (something()) {
+			$bar = true;
+			continue;
+		}
+
+		'afterContinueInLoopWithEarlyTermination';
+
+		return;
+	}
 };


### PR DESCRIPTION
Fixes #902

This PR fixes a false positive which occur when using `continue` inside a loop with an early termination statement. Generally, a scope inside of a branch with `continue` should intersect an outer scope.

```php
$potential = false;
foreach (items() as $item) {

    if (condition()) {
        $potential = true;
        continue;
    }

    $potential; # => bool

    return false;
}
```

But [`lookForAssignsInBranches`](https://github.com/phpstan/phpstan/blob/3673679620874c00a6a18a573eeaf8a266b86cd4/src/Analyser/NodeScopeResolver.php#L1711-L1714) skips intersection when the `if` branch includes early termination statement. In order to prevent this, in the case of `continue`, it makes current scope intersects an outer scope.

## Why does not it occur in other cases

### Case 1: Without `return` statement

```php
$potential = false;
foreach (items() as $item) {

    if (condition()) {
        $potential = true;
        continue;
    }

    $potential; # => bool
}
```

In this case, since the loop doesn't contain an early termination statement, the scope of the `if` branch intersects the loop scope [here](https://github.com/phpstan/phpstan/blob/3673679620874c00a6a18a573eeaf8a266b86cd4/src/Analyser/NodeScopeResolver.php#L462-L467).


### Case 2: Without `continue` statement


```php
$potential = false;
foreach (items() as $item) {

    if (condition()) {
        $potential = true;
    }

    $potential; # => bool

    return false;
}
```

In this case, since the `if` branch doesn't contain an early termination state, the scope of the `if` branch intersects the loop scope [here](https://github.com/phpstan/phpstan/blob/3673679620874c00a6a18a573eeaf8a266b86cd4/src/Analyser/NodeScopeResolver.php#L1100)
