### PR TITLE
fix: errorFormat documentation. errorFormat instead of error-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ services:
 Use the name part after `errorFormatter.` as the CLI option value:
 
 ```bash
-vendor/bin/phpstan analyse -c phpstan.neon -l 4 --error-format awesome src tests
+vendor/bin/phpstan analyse -c phpstan.neon -l 4 --errorFormat=awesome src tests
 ```
 
 ### Existing error formatters to be used


### PR DESCRIPTION
```
./vendor/bin/phpstan analyse --help
```
Usage:
  analyse [options] [--] <paths> (<paths>)...
  analyze

Arguments:
  paths                              Paths with source code to run analysis on

Options:
  -c, --configuration=CONFIGURATION  Path to project configuration file
  -l, --level=LEVEL                  Level of rule options - the higher the stricter
      --no-progress                  Do not show progress bar, only results
      --debug                        Show debug information - which file is analysed, do not catch internal errors
  -a, --autoload-file=AUTOLOAD-FILE  Project's additional autoload file path
      **--errorFormat=ERRORFORMAT      Format in which to print the result of the analysis [default: "table"]**
      --memory-limit=MEMORY-LIMIT    Memory limit for analysis
  -h, --help                         Display this help message
  -q, --quiet                        Do not output any message
  -V, --version                      Display this application version
      --ansi                         Force ANSI output
      --no-ansi                      Disable ANSI output
  -n, --no-interaction               Do not ask any interactive question
  -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
