### PR TITLE
password_hash returns null on failure

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -8215,7 +8215,7 @@ return [
 'parsekit_func_arginfo' => ['array', 'function'=>'mixed'],
 'passthru' => ['void', 'command'=>'string', '&w_return_value='=>'int'],
 'password_get_info' => ['array', 'hash'=>'string'],
-'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'int', 'options='=>'array'],
+'password_hash' => ['string|null', 'password'=>'string', 'algo'=>'int', 'options='=>'array'],
 'password_make_salt' => ['bool', 'password'=>'string', 'hash'=>'string'],
 'password_needs_rehash' => ['bool', 'hash'=>'string', 'algo'=>'int', 'options='=>'array'],
 'password_verify' => ['bool', 'password'=>'string', 'hash'=>'string'],


### PR DESCRIPTION
According to the PHP documentation, [password_hash](http://php.net/manual/en/function.password-hash.php) should return false on failure, but actually it returns null, as demonstrated [here](https://3v4l.org/DMv87).

I have submitted a bug report for the PHP documentation: https://bugs.php.net/bug.php?id=77218