### PR TITLE
Limit amount of cached files for parser

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -23,6 +23,9 @@ parameters:
 	reportMagicProperties: false
 	ignoreErrors: []
 	internalErrorsCountLimit: 50
+	cache:
+	    nodesByFileCountMax: 512
+	    nodesByStringCountMax: 512
 	reportUnmatchedIgnoredErrors: true
 	scopeClass: PHPStan\Analyser\Scope
 	universalObjectCratesClasses:
@@ -170,6 +173,8 @@ services:
 		class: PHPStan\Parser\CachedParser
 		arguments:
 			originalParser: @directParser
+			cachedNodesByFileCountMax: %cache.nodesByFileCountMax%
+			cachedNodesByStringCountMax: %cache.nodesByStringCountMax%
 
 	-
 		class: PHPStan\Parser\FunctionCallStatementFinder

--- a/src/Parser/CachedParser.php
+++ b/src/Parser/CachedParser.php
@@ -11,12 +11,30 @@ class CachedParser implements Parser
 	/** @var mixed[] */
 	private $cachedNodesByFile = [];
 
+	/** @var int */
+	private $cachedNodesByFileCount = 0;
+
+	/** @var int */
+	private $cachedNodesByFileCountMax;
+
 	/** @var mixed[] */
 	private $cachedNodesByString = [];
 
-	public function __construct(Parser $originalParser)
+	/** @var int */
+	private $cachedNodesByStringCount = 0;
+
+	/** @var int */
+	private $cachedNodesByStringCountMax;
+
+	public function __construct(
+		Parser $originalParser,
+		int $cachedNodesByFileCountMax,
+		int $cachedNodesByStringCountMax
+	)
 	{
 		$this->originalParser = $originalParser;
+		$this->cachedNodesByFileCountMax = $cachedNodesByFileCountMax;
+		$this->cachedNodesByStringCountMax = $cachedNodesByStringCountMax;
 	}
 
 	/**
@@ -25,8 +43,20 @@ class CachedParser implements Parser
 	 */
 	public function parseFile(string $file): array
 	{
+		if ($this->cachedNodesByFileCountMax !== 0 && $this->cachedNodesByFileCount >= $this->cachedNodesByFileCountMax) {
+			$this->cachedNodesByFile = array_slice(
+				$this->cachedNodesByFile,
+				1,
+				null,
+				true
+			);
+
+			--$this->cachedNodesByFileCount;
+		}
+
 		if (!isset($this->cachedNodesByFile[$file])) {
 			$this->cachedNodesByFile[$file] = $this->originalParser->parseFile($file);
+			$this->cachedNodesByFileCount++;
 		}
 
 		return $this->cachedNodesByFile[$file];
@@ -38,11 +68,53 @@ class CachedParser implements Parser
 	 */
 	public function parseString(string $sourceCode): array
 	{
+		if ($this->cachedNodesByStringCountMax !== 0 && $this->cachedNodesByStringCount >= $this->cachedNodesByStringCountMax) {
+			$this->cachedNodesByString = array_slice(
+				$this->cachedNodesByString,
+				1,
+				null,
+				true
+			);
+
+			--$this->cachedNodesByStringCount;
+		}
+
 		if (!isset($this->cachedNodesByString[$sourceCode])) {
 			$this->cachedNodesByString[$sourceCode] = $this->originalParser->parseString($sourceCode);
+			$this->cachedNodesByStringCount++;
 		}
 
 		return $this->cachedNodesByString[$sourceCode];
+	}
+
+	public function getCachedNodesByFileCount(): int
+	{
+		return $this->cachedNodesByFileCount;
+	}
+
+	public function getCachedNodesByFileCountMax(): int
+	{
+		return $this->cachedNodesByFileCountMax;
+	}
+
+	public function getCachedNodesByStringCount(): int
+	{
+		return $this->cachedNodesByStringCount;
+	}
+
+	public function getCachedNodesByStingCountMax(): int
+	{
+		return $this->cachedNodesByStringCountMax;
+	}
+
+	public function getCachedNodesByFile(): array
+	{
+		return $this->cachedNodesByFile;
+	}
+
+	public function getCachedNodesByString(): array
+	{
+		return $this->cachedNodesByString;
 	}
 
 }

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parser;
+
+class CachedParserTest extends \PHPUnit\Framework\TestCase
+{
+
+	/**
+	 * @dataProvider dataParseFileClearCache
+	 * @param int $cachedNodesByFileCountMax
+	 * @param int $cachedNodesByStringCountMax
+	 * @param int $cachedNodesByFileCountExpected
+	 * @param int $cachedNodesByStringCountExpected
+	 */
+	public function testParseFileClearCache(
+		int $cachedNodesByFileCountMax,
+		int $cachedNodesByStringCountMax,
+		int $cachedNodesByFileCountExpected,
+		int $cachedNodesByStringCountExpected
+	): void
+	{
+		$parser = new CachedParser(
+			$this->getParserMock(),
+			$cachedNodesByFileCountMax,
+			$cachedNodesByStringCountMax
+		);
+
+		$this->assertEquals(
+			$cachedNodesByFileCountMax,
+			$parser->getCachedNodesByFileCountMax()
+		);
+
+		$this->assertEquals(
+			$cachedNodesByStringCountMax,
+			$parser->getCachedNodesByStingCountMax()
+		);
+
+		// Add files to cache
+		for ($i = 0; $i <= $cachedNodesByFileCountMax; $i++) {
+			$parser->parseFile('file' . $i);
+		}
+
+		$this->assertEquals(
+			$cachedNodesByFileCountExpected,
+			$parser->getCachedNodesByFileCount()
+		);
+
+		$this->assertCount(
+			$cachedNodesByFileCountExpected,
+			$parser->getCachedNodesByFile()
+		);
+
+		// Add strings to cache
+		for ($i = 0; $i <= $cachedNodesByStringCountMax; $i++) {
+			$parser->parseString('string' . $i);
+		}
+
+		$this->assertEquals(
+			$cachedNodesByStringCountExpected,
+			$parser->getCachedNodesByStringCount()
+		);
+
+		$this->assertCount(
+			$cachedNodesByStringCountExpected,
+			$parser->getCachedNodesByString()
+		);
+	}
+
+	public function dataParseFileClearCache(): \Generator
+	{
+		yield 'even' => [
+			'cachedNodesByFileCountMax' => 100,
+			'cachedNodesByStringCountMax' => 50,
+			'cachedNodesByFileCountExpected' => 100,
+			'cachedNodesByStringCountExpected' => 50,
+		];
+
+		yield 'odd' => [
+			'cachedNodesByFileCountMax' => 101,
+			'cachedNodesByStringCountMax' => 51,
+			'cachedNodesByFileCountExpected' => 101,
+			'cachedNodesByStringCountExpected' => 51,
+		];
+	}
+
+	/**
+	 * @return Parser&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function getParserMock(): Parser
+	{
+		$mock = $this->getMockBuilder(Parser::class)
+			->setMethods(
+				[
+					'parseFile',
+					'parseString',
+				]
+			)
+			->getMock();
+
+		$mock->method('parseFile')->willReturn([$this->getPhpParserNodeMock()]);
+		$mock->method('parseString')->willReturn([$this->getPhpParserNodeMock()]);
+
+		return $mock;
+	}
+
+	/**
+	 * @return \PhpParser\Node&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function getPhpParserNodeMock(): \PhpParser\Node
+	{
+		return $this->createMock(\PhpParser\Node::class);
+	}
+
+}


### PR DESCRIPTION
I have project with more than 5000 files and when I try to analyze it requires more than 3G memory.

I added limit for that cache and hope it will decrease memory usage for huge projects.