### PR TITLE
ErrorFormatter: get rid of symfony dependency in interface

### DIFF
--- a/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
+++ b/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
@@ -12,7 +12,13 @@ class CheckstyleErrorFormatter implements ErrorFormatter
 	/** @var RelativePathHelper */
 	private $relativePathHelper;
 
-	public function __construct(RelativePathHelper $relativePathHelper)
+	/** @var OutputStyle */
+	private $outputStyle;
+
+	public function __construct(
+		RelativePathHelper $relativePathHelper,
+		OutputStyle $outputStyle
+	)
 	{
 		$this->relativePathHelper = $relativePathHelper;
 	}
@@ -21,34 +27,32 @@ class CheckstyleErrorFormatter implements ErrorFormatter
 	 * Formats the errors and outputs them to the console.
 	 *
 	 * @param \PHPStan\Command\AnalysisResult $analysisResult
-	 * @param \Symfony\Component\Console\Style\OutputStyle $style
 	 * @return int Error code.
 	 */
 	public function formatErrors(
-		AnalysisResult $analysisResult,
-		OutputStyle $style
+		AnalysisResult $analysisResult
 	): int
 	{
-		$style->writeln('<?xml version="1.0" encoding="UTF-8"?>');
-		$style->writeln('<checkstyle>');
+		$this->outputStyle->writeln('<?xml version="1.0" encoding="UTF-8"?>');
+		$this->outputStyle->writeln('<checkstyle>');
 
 		foreach ($this->groupByFile($analysisResult) as $relativeFilePath => $errors) {
-			$style->writeln(sprintf(
+			$this->outputStyle->writeln(sprintf(
 				'<file name="%s">',
 				$this->escape($relativeFilePath)
 			));
 
 			foreach ($errors as $error) {
-				$style->writeln(sprintf(
+				$this->outputStyle->writeln(sprintf(
 					'  <error line="%d" column="1" severity="error" message="%s" />',
 					$this->escape((string) $error->getLine()),
 					$this->escape((string) $error->getMessage())
 				));
 			}
-			$style->writeln('</file>');
+			$this->outputStyle->writeln('</file>');
 		}
 
-		$style->writeln('</checkstyle>');
+		$this->outputStyle->writeln('</checkstyle>');
 
 		return $analysisResult->hasErrors() ? 1 : 0;
 	}

--- a/src/Command/ErrorFormatter/ErrorFormatter.php
+++ b/src/Command/ErrorFormatter/ErrorFormatter.php
@@ -11,12 +11,10 @@ interface ErrorFormatter
 	 * Formats the errors and outputs them to the console.
 	 *
 	 * @param \PHPStan\Command\AnalysisResult $analysisResult
-	 * @param \Symfony\Component\Console\Style\OutputStyle $style
 	 * @return int Error code.
 	 */
 	public function formatErrors(
-		AnalysisResult $analysisResult,
-		\Symfony\Component\Console\Style\OutputStyle $style
+		AnalysisResult $analysisResult
 	): int;
 
 }

--- a/src/Command/ErrorFormatter/JsonErrorFormatter.php
+++ b/src/Command/ErrorFormatter/JsonErrorFormatter.php
@@ -12,12 +12,19 @@ class JsonErrorFormatter implements ErrorFormatter
 	/** @var bool */
 	private $pretty;
 
-	public function __construct(bool $pretty)
+	/** @var OutputStyle */
+	private $outputStyle;
+
+	public function __construct(
+		bool $pretty,
+		OutputStyle $outputStyle
+	)
 	{
 		$this->pretty = $pretty;
+		$this->outputStyle = $outputStyle;
 	}
 
-	public function formatErrors(AnalysisResult $analysisResult, OutputStyle $style): int
+	public function formatErrors(AnalysisResult $analysisResult): int
 	{
 		$errorsArray = [
 			'totals' => [
@@ -51,7 +58,7 @@ class JsonErrorFormatter implements ErrorFormatter
 
 		$json = Json::encode($errorsArray, $this->pretty ? Json::PRETTY : 0);
 
-		$style->write($json);
+		$this->outputStyle->write($json);
 
 		return $analysisResult->hasErrors() ? 1 : 0;
 	}

--- a/src/Command/ErrorFormatter/OutputStyle.php
+++ b/src/Command/ErrorFormatter/OutputStyle.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+
+namespace PHPStan\Command\ErrorFormatter;
+
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\StyleInterface;
+
+interface OutputStyle extends OutputInterface, StyleInterface
+{
+
+}

--- a/src/Command/ErrorFormatter/OutputStyle.php
+++ b/src/Command/ErrorFormatter/OutputStyle.php
@@ -1,13 +1,101 @@
-<?php declare(strict_types=1);
-
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Command\ErrorFormatter;
 
-
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\StyleInterface;
-
-interface OutputStyle extends OutputInterface, StyleInterface
+interface OutputStyle
 {
+	public const VERBOSITY_QUIET = 16;
+	public const VERBOSITY_NORMAL = 32;
+	public const VERBOSITY_VERBOSE = 64;
+	public const VERBOSITY_VERY_VERBOSE = 128;
+	public const VERBOSITY_DEBUG = 256;
 
+	public const OUTPUT_NORMAL = 1;
+	public const OUTPUT_RAW = 2;
+	public const OUTPUT_PLAIN = 4;
+
+	public function write(string $message, int $options = self::OUTPUT_NORMAL): void;
+
+	public function writeln(string $message, int $options = self::OUTPUT_NORMAL): void;
+
+	public function setVerbosity(int $level): void;
+
+	public function getVerbosity(): int;
+
+	public function isQuiet(): bool;
+
+	public function isVerbose(): bool;
+
+	public function isVeryVerbose(): bool;
+
+	public function isDebug(): bool;
+
+	public function setDecorated(bool $decorated): void;
+
+	public function isDecorated(): bool;
+
+	public function title(string $message): void;
+
+	public function section(string $message): void;
+
+	/** @param $elements string[] */
+	public function listing(array $elements): void;
+
+	public function text(string $message): void;
+
+	public function success(string $message): void;
+
+	public function error(string $message): void;
+
+	public function warning(string $message): void;
+
+	public function note(string $message): void;
+
+	public function caution(string $message): void;
+
+	/**
+	 * @param string[] $headers
+	 * @param string[][] $rows
+	 */
+	public function table(array $headers, array $rows): void;
+
+	/**
+	 * @return mixed
+	 */
+	public function ask(string $question, string $default = null, callable $validator = null);
+
+	/**
+	 * @return mixed
+	 */
+	public function askHidden(string $question, callable $validator = null);
+
+	public function confirm(string $question, bool $default = true): bool;
+
+	/**
+	 * @param string[] $choices
+	 * @param string|int|null $default
+	 * @return mixed
+	 */
+	public function choice(string $question, array $choices, $default = null);
+
+	public function newLine(int $count = 1): void;
+
+	/**
+	 * Starts the progress output.
+	 *
+	 * @param int $max Maximum steps (0 if unknown)
+	 */
+	public function progressStart(int $max = 0): void;
+
+	/**
+	 * Advances the progress output X steps.
+	 *
+	 * @param int $step Number of steps to advance
+	 */
+	public function progressAdvance(int $step = 1): void;
+
+	/**
+	 * Finishes the progress output.
+	 */
+	public function progressFinish(): void;
 }

--- a/src/Command/ErrorFormatter/OutputStyleSymfonyBridge.php
+++ b/src/Command/ErrorFormatter/OutputStyleSymfonyBridge.php
@@ -1,0 +1,189 @@
+<?php declare(strict_types = 1);
+
+
+namespace PHPStan\Command\ErrorFormatter;
+
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+
+final class OutputStyleSymfonyBridge implements OutputStyle
+{
+
+	/** @var \Symfony\Component\Console\Style\OutputStyle */
+	private $style;
+
+	public function __construct(\Symfony\Component\Console\Style\OutputStyle $style)
+	{
+		$this->style = $style;
+	}
+
+	public function write(string $message, int $options = self::OUTPUT_NORMAL): void
+	{
+		$this->style->write($message, false, $options);
+	}
+
+	public function writeln(string $message, int $options = self::OUTPUT_NORMAL): void
+	{
+		$this->style->writeln($message, $options);
+	}
+
+	public function setVerbosity(int $level): void
+	{
+		$this->style->setVerbosity($level);
+	}
+
+	public function getVerbosity(): int
+	{
+		return $this->style->getVerbosity();
+	}
+
+	public function isQuiet(): bool
+	{
+		return $this->style->isQuiet();
+	}
+
+	public function isVerbose(): bool
+	{
+		return $this->style->isVerbose();
+	}
+
+	public function isVeryVerbose(): bool
+	{
+		return $this->style->isVeryVerbose();
+	}
+
+	public function isDebug(): bool
+	{
+		return $this->style->isDebug();
+	}
+
+	public function setDecorated(bool $decorated): void
+	{
+		$this->style->setDecorated($decorated);
+	}
+
+	public function isDecorated(): bool
+	{
+		return $this->style->isDecorated();
+	}
+
+
+	public function title(string $message): void
+	{
+		$this->style->title($message);
+	}
+
+	public function section(string $message): void
+	{
+		$this->style->section($message);
+	}
+
+	/** @param $elements string[] */
+	public function listing(array $elements): void
+	{
+		$this->style->listing($elements);
+	}
+
+	public function text(string $message): void
+	{
+		$this->style->text($message);
+	}
+
+	public function success(string $message): void
+	{
+		$this->style->success($message);
+	}
+
+	public function error(string $message): void
+	{
+		$this->style->error($message);
+	}
+
+	public function warning(string $message): void
+	{
+		$this->style->warning($message);
+	}
+
+	public function note(string $message): void
+	{
+		$this->style->note($message);
+	}
+
+	public function caution(string $message): void
+	{
+		$this->style->caution($message);
+	}
+
+	/**
+	 * @param string[] $headers
+	 * @param string[][] $rows
+	 */
+	public function table(array $headers, array $rows): void
+	{
+		$this->style->table($headers, $rows);
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function ask(string $question, string $default = null, callable $validator = null)
+	{
+		return $this->style->ask($question, $default, $validator);
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function askHidden(string $question, callable $validator = null)
+	{
+		return $this->style->askHidden($question, $validator);
+	}
+
+	public function confirm(string $question, bool $default = true): bool
+	{
+		return $this->style->confirm($question, $default);
+	}
+
+	/**
+	 * @param string[] $choices
+	 * @param string|int|null $default
+	 * @return mixed
+	 */
+	public function choice(string $question, array $choices, $default = null)
+	{
+		return $this->style->choice($question, $choices, $default);
+	}
+
+	public function newLine(int $count = 1): void
+	{
+		$this->style->newLine($count);
+	}
+
+	/**
+	 * Starts the progress output.
+	 *
+	 * @param int $max Maximum steps (0 if unknown)
+	 */
+	public function progressStart(int $max = 0): void
+	{
+		$this->style->progressStart($max);
+	}
+
+	/**
+	 * Advances the progress output X steps.
+	 *
+	 * @param int $step Number of steps to advance
+	 */
+	public function progressAdvance(int $step = 1): void
+	{
+		$this->style->progressAdvance($step);
+	}
+
+	/**
+	 * Finishes the progress output.
+	 */
+	public function progressFinish(): void
+	{
+		$this->style->progressFinish();
+	}
+}

--- a/src/Command/ErrorFormatter/RawErrorFormatter.php
+++ b/src/Command/ErrorFormatter/RawErrorFormatter.php
@@ -8,9 +8,21 @@ use Symfony\Component\Console\Style\OutputStyle;
 class RawErrorFormatter implements ErrorFormatter
 {
 
+	/** @var OutputStyle */
+	private $outputStyle;
+
+	/**
+	 * RawErrorFormatter constructor.
+	 * @param OutputStyle $outputStyle
+	 */
+	public function __construct(OutputStyle $outputStyle)
+	{
+		$this->outputStyle = $outputStyle;
+	}
+
+
 	public function formatErrors(
-		AnalysisResult $analysisResult,
-		OutputStyle $style
+		AnalysisResult $analysisResult
 	): int
 	{
 		if (!$analysisResult->hasErrors()) {
@@ -18,11 +30,11 @@ class RawErrorFormatter implements ErrorFormatter
 		}
 
 		foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
-			$style->writeln(sprintf('?:?:%s', $notFileSpecificError));
+			$this->outputStyle->writeln(sprintf('?:?:%s', $notFileSpecificError));
 		}
 
 		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
-			$style->writeln(
+			$this->outputStyle->writeln(
 				sprintf(
 					'%s:%d:%s',
 					$fileSpecificError->getFile(),

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -13,20 +13,26 @@ class TableErrorFormatter implements ErrorFormatter
 	/** @var RelativePathHelper */
 	private $relativePathHelper;
 
-	public function __construct(RelativePathHelper $relativePathHelper)
+	/** @var OutputStyle */
+	private $outputStyle;
+
+	public function __construct(
+		RelativePathHelper $relativePathHelper,
+		OutputStyle $outputStyle
+	)
 	{
 		$this->relativePathHelper = $relativePathHelper;
+		$this->outputStyle = $outputStyle;
 	}
 
 	public function formatErrors(
-		AnalysisResult $analysisResult,
-		OutputStyle $style
+		AnalysisResult $analysisResult
 	): int
 	{
 		if (!$analysisResult->hasErrors()) {
-			$style->success('No errors');
+			$this->outputStyle->success('No errors');
 			if ($analysisResult->isDefaultLevelUsed()) {
-				$style->note(sprintf(
+				$this->outputStyle->note(sprintf(
 					'PHPStan is performing only the most basic checks. You can pass a higher rule level through the --%s option (the default and current level is %d) to analyse code more thoroughly.',
 					AnalyseCommand::OPTION_LEVEL,
 					AnalyseCommand::DEFAULT_LEVEL
@@ -56,16 +62,16 @@ class TableErrorFormatter implements ErrorFormatter
 
 			$relativeFilePath = $this->relativePathHelper->getRelativePath($file);
 
-			$style->table(['Line', $relativeFilePath], $rows);
+			$this->outputStyle->table(['Line', $relativeFilePath], $rows);
 		}
 
 		if (count($analysisResult->getNotFileSpecificErrors()) > 0) {
-			$style->table(['Error'], array_map(static function (string $error): array {
+			$this->outputStyle->table(['Error'], array_map(static function (string $error): array {
 				return [$error];
 			}, $analysisResult->getNotFileSpecificErrors()));
 		}
 
-		$style->error(sprintf($analysisResult->getTotalErrorsCount() === 1 ? 'Found %d error' : 'Found %d errors', $analysisResult->getTotalErrorsCount()));
+		$this->outputStyle->error(sprintf($analysisResult->getTotalErrorsCount() === 1 ? 'Found %d error' : 'Found %d errors', $analysisResult->getTotalErrorsCount()));
 		return 1;
 	}
 


### PR DESCRIPTION
This made impossible to build custom error formatter for phpstan-shim. [tweet](https://twitter.com/honzakuchar/status/1070300909702389761)