### PR TITLE
WIP - Generics

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -23,6 +23,7 @@ use PHPStan\Type\ClosureType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\Generic\GenericType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
@@ -38,6 +39,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VoidType;
 
@@ -65,7 +67,7 @@ class TypeNodeResolver
 
 	public function getCacheKey(): string
 	{
-		$key = 'v50';
+		$key = 'v51';
 		foreach ($this->extensions as $extension) {
 			$key .= sprintf('-%s', $extension->getCacheKey());
 		}
@@ -312,6 +314,10 @@ class TypeNodeResolver
 					new IterableType($genericTypes[0], $genericTypes[1])
 				);
 			}
+		}
+
+		if ($mainType instanceof TypeWithClassName) {
+			return new GenericType($mainType->getClassName(), $genericTypes);
 		}
 
 		return new ErrorType();

--- a/src/Type/Generic/GenericType.php
+++ b/src/Type/Generic/GenericType.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+class GenericType extends ObjectType
+{
+
+	/** @var Type[] */
+	private $types;
+
+	/**
+	 * @param string $mainType
+	 * @param Type[] $types
+	 */
+	public function __construct(string $mainType, array $types)
+	{
+		parent::__construct($mainType);
+		$this->types = $types;
+	}
+
+	public function describe(VerbosityLevel $level): string
+	{
+		return sprintf(
+			'%s<%s>',
+			parent::describe($level),
+			implode(', ', array_map(function (Type $type) use ($level): string {
+				return $type->describe($level);
+			}, $this->types))
+		);
+	}
+
+	// todo isSuperTypeOf(), accepts()
+
+}

--- a/src/Type/Generic/TemplateType.php
+++ b/src/Type/Generic/TemplateType.php
@@ -1,0 +1,185 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Reflection\ClassMemberAccessAnswerer;
+use PHPStan\Reflection\ConstantReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+class TemplateType implements Type
+{
+
+	/** @var string */
+	private $identifier;
+
+	public function __construct(string $identifier)
+	{
+		$this->identifier = $identifier;
+	}
+
+	public function getReferencedClasses(): array
+	{
+		return [];
+	}
+
+	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
+	{
+		// TODO: Implement accepts() method.
+	}
+
+	public function isSuperTypeOf(Type $type): TrinaryLogic
+	{
+		// TODO: Implement isSuperTypeOf() method.
+	}
+
+	public function equals(Type $type): bool
+	{
+		// TODO: Implement equals() method.
+	}
+
+	public function describe(VerbosityLevel $level): string
+	{
+		return $this->identifier;
+	}
+
+	public function canAccessProperties(): TrinaryLogic
+	{
+		// TODO: Implement canAccessProperties() method.
+	}
+
+	public function hasProperty(string $propertyName): TrinaryLogic
+	{
+		// TODO: Implement hasProperty() method.
+	}
+
+	public function getProperty(string $propertyName, ClassMemberAccessAnswerer $scope): PropertyReflection
+	{
+		// TODO: Implement getProperty() method.
+	}
+
+	public function canCallMethods(): TrinaryLogic
+	{
+		// TODO: Implement canCallMethods() method.
+	}
+
+	public function hasMethod(string $methodName): TrinaryLogic
+	{
+		// TODO: Implement hasMethod() method.
+	}
+
+	public function getMethod(string $methodName, ClassMemberAccessAnswerer $scope): MethodReflection
+	{
+		// TODO: Implement getMethod() method.
+	}
+
+	public function canAccessConstants(): TrinaryLogic
+	{
+		// TODO: Implement canAccessConstants() method.
+	}
+
+	public function hasConstant(string $constantName): TrinaryLogic
+	{
+		// TODO: Implement hasConstant() method.
+	}
+
+	public function getConstant(string $constantName): ConstantReflection
+	{
+		// TODO: Implement getConstant() method.
+	}
+
+	public function isIterable(): TrinaryLogic
+	{
+		// TODO: Implement isIterable() method.
+	}
+
+	public function isIterableAtLeastOnce(): TrinaryLogic
+	{
+		// TODO: Implement isIterableAtLeastOnce() method.
+	}
+
+	public function getIterableKeyType(): Type
+	{
+		// TODO: Implement getIterableKeyType() method.
+	}
+
+	public function getIterableValueType(): Type
+	{
+		// TODO: Implement getIterableValueType() method.
+	}
+
+	public function isOffsetAccessible(): TrinaryLogic
+	{
+		// TODO: Implement isOffsetAccessible() method.
+	}
+
+	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
+	{
+		// TODO: Implement hasOffsetValueType() method.
+	}
+
+	public function getOffsetValueType(Type $offsetType): Type
+	{
+		// TODO: Implement getOffsetValueType() method.
+	}
+
+	public function setOffsetValueType(?Type $offsetType, Type $valueType): Type
+	{
+		// TODO: Implement setOffsetValueType() method.
+	}
+
+	public function isCallable(): TrinaryLogic
+	{
+		// TODO: Implement isCallable() method.
+	}
+
+	public function getCallableParametersAcceptors(ClassMemberAccessAnswerer $scope): array
+	{
+		// TODO: Implement getCallableParametersAcceptors() method.
+	}
+
+	public function isCloneable(): TrinaryLogic
+	{
+		// TODO: Implement isCloneable() method.
+	}
+
+	public function toBoolean(): BooleanType
+	{
+		// TODO: Implement toBoolean() method.
+	}
+
+	public function toNumber(): Type
+	{
+		// TODO: Implement toNumber() method.
+	}
+
+	public function toInteger(): Type
+	{
+		// TODO: Implement toInteger() method.
+	}
+
+	public function toFloat(): Type
+	{
+		// TODO: Implement toFloat() method.
+	}
+
+	public function toString(): Type
+	{
+		// TODO: Implement toString() method.
+	}
+
+	public function toArray(): Type
+	{
+		// TODO: Implement toArray() method.
+	}
+
+	public static function __set_state(array $properties): Type
+	{
+		return new self($properties['identifier']);
+	}
+
+}


### PR DESCRIPTION
Thinking out loud about generics support which I would like to have as the main feature of 0.12. These are the use cases that come to mind:

* `Repository<T>::find()` - returns T
* `EntityManager::find(T, id)` - returns T (both are complements for certain types of dynamic return type extensions)
* Callbacks:
  1) Validating that the callback parameters and return types are correct
  2) Inferring types when the callback typehint is missing (both are applicable for example to `array_map`)

Here are some write-ups from PHP and TypeScript of how generics are used there:

* https://wiki.php.net/rfc/generics
* https://github.com/phan/phan/wiki/Generic-Types
* https://github.com/vimeo/psalm/issues/816
* https://github.com/phpstan/phpstan/issues/729#issuecomment-357481590
* https://www.typescriptlang.org/docs/handbook/generics.html
* The implementation should be tested on this: 

How to implement them in PHPStan:

* GenericType and TemplateType are the cornerstones of generics support. GenericType represents `EntityRepository<Foo>` in phpDoc and TemplateType represents type placeholder in:
  1) `@template T`
  2) `@param T $foo`
  3) `array<T>`
  4) etc.
* TemplateType can become part of types consisting of other types, like ArrayType, CallableType etc. Right now it's unknown what effect this has on the codebase, there's a lot of concrete `instanceof`s that would break with TemplateType.
* GenericType and TemplateType are hinted as part of this PR.
* `@template T` indicates a placeholder type identifier and can be bound to a class or to a function/method. It's the only new phpDoc tag that I would add in the first round.
* We have to think about when the TemplateType should be resolved to a concrete type - when a method is called? When an object is created? It should probably be done through a method on Type - something like `Type::resolveTemplateTypes()`.
* What about analysis of classes that contain TemplateType? I incline towards that TemplateType should behave mostly like MixedType.
* There's a duality that in some places, we have types indexed from zero - like `Collection<IntegerType, ObjectType(Article)>` coming from TypeNodeResolver, and in some other places, they will be indexed by their TemplateType identifier. Can we unify this? TypeNodeResolver has to be able to represent invalid data so we can write rules for them. (like having `Foo<A, B>` when there's only one `@template` above `Foo`)
* How are we going to declare templates for 3rd party code? I'm inclining towards config in phpstan.neon.
* How are we going to declare templates for built-in PHP functions? Something similar to `functionMap.php`, or even modifying the current file?

Additionally, there will have to be some rules for wrong generics usage, like:

* `Foo<A, B>` when there's only one `@template` above `Foo` (and also vice versa)
* Will we allow usage of a templated class in phpDoc without defining the type placeholders? Should they fall back to `mixed`?
* Template types with the same identifiers as existing classes/interfaces
* Using undefined template type identifiers - these will probably result in "unknown classes" error.
* Using the same type template identifier above a class and a class method.
* If a class has `@template T`, then T must occur in constructor parameters. If it's there multiple times, the passed arguments must have the same T.
* If a function/method has `@template T`, then T must occur in its parameters. If it's there multiple times, the passed arguments must have the same T.

What I consider out of scope for the first iteration of this feature:

* Thinking about inheritance at all - we will not be able to do `extends Foo<Bar>`. Let's implement this proposed first version, gain benefits and feedback and then decide what should be done.
* Generic constraints like `Foo<T extends Bar>`. Again, not needed to gain benefits from generics in the first version.