### PR TITLE
Optimize cs tools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 /build export-ignore
 /tests export-ignore
+.editorconfig
+.travis.yml
+appveyor.yml
+build.xml
+phpcs.php_cs
+phpcs.xml

--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,16 @@
 			  value="tmp/composer-require-checker-1.1.0.phar"/>
 	<property name="url.composer-require-checker"
 			  value="https://github.com/maglnet/ComposerRequireChecker/releases/download/1.1.0/composer-require-checker.phar"/>
-	<target name="check" depends="
+    <target name="cs" depends="
+		code-sniffer,
+		cs-fixer
+	"/>
+    <target name="cs-fix" depends="
+		code-sniffer-fix,
+		cs-fixer-fix,
+		code-sniffer-fix
+	"/>
+    <target name="check" depends="
 		composer-validate,
 		composer-install,
 		lint,
@@ -128,41 +137,59 @@
 		</exec>
 	</target>
 
-	<target name="cs">
+	<target name="code-sniffer">
 		<exec
 				executable="vendor/bin/phpcs"
 				logoutput="true"
 				passthru="true"
 				checkreturn="true"
 		>
-			<arg value="--colors"/>
-			<arg value="--extensions=php"/>
-			<arg value="--encoding=utf-8"/>
-			<arg value="--tab-width=4"/>
 			<arg value="--cache=tmp/cache/phpcs"/>
 			<arg value="--ignore=tests/*/data,tests/*/traits,tests/notAutoloaded,src/Reflection/SignatureMap/functionMap.php"/>
-			<arg value="-sp"/>
 			<arg path="src"/>
 			<arg path="tests"/>
 		</exec>
 	</target>
 
-	<target name="cs-fix">
-		<exec
-				executable="vendor/bin/phpcbf"
-				logoutput="true"
-				passthru="true"
-				checkreturn="true"
-		>
-			<arg value="--colors"/>
-			<arg value="--extensions=php"/>
-			<arg value="--encoding=utf-8"/>
-			<arg value="--tab-width=4"/>
-			<arg value="-sp"/>
-			<arg path="src"/>
-			<arg path="tests"/>
-		</exec>
-	</target>
+    <target name="code-sniffer-fix">
+        <exec
+                executable="vendor/bin/phpcbf"
+                logoutput="true"
+                passthru="true"
+                checkreturn="false"
+        >
+            <arg path="src"/>
+            <arg path="tests"/>
+        </exec>
+    </target>
+
+    <target name="cs-fixer">
+        <exec
+                executable="vendor/bin/php-cs-fixer"
+                logoutput="true"
+                passthru="true"
+                checkreturn="true"
+        >
+            <arg value="fix"/>
+            <arg value="--dry-run"/>
+            <arg value="--verbose"/>
+            <arg value="--config=phpcs.php_cs"/>
+        </exec>
+    </target>
+
+    <target name="cs-fixer-fix">
+        <exec
+                executable="vendor/bin/php-cs-fixer"
+                logoutput="true"
+                passthru="true"
+                checkreturn="false"
+        >
+            <arg value="fix"/>
+            <arg value="--verbose"/>
+            <arg value="--diff"/>
+            <arg value="--config=phpcs.php_cs"/>
+        </exec>
+    </target>
 
 	<target name="test-configuration-validate" depends="composer-install">
 		<xmllint schema="vendor/phpunit/phpunit/phpunit.xsd" file="tests/phpunit.xml"/>

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,7 @@
 {
 	"name": "phpstan/phpstan",
 	"description": "PHPStan - PHP Static Analysis Tool",
-	"license": [
-		"MIT"
-	],
+	"license": "MIT",
 	"require": {
 		"php": "~7.1",
 		"composer/xdebug-handler": "^1.3.0",
@@ -26,7 +24,8 @@
 		"ext-soap": "*",
 		"brianium/paratest": "^2.0",
 		"consistence/coding-standard": "^3.5",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+		"friendsofphp/php-cs-fixer": "^2.9.3",
 		"jakub-onderka/php-parallel-lint": "^1.0",
 		"localheinz/composer-normalize": "^1.0.0",
 		"phing/phing": "^2.16.0",
@@ -36,7 +35,8 @@
 		"phpstan/phpstan-strict-rules": "^0.11",
 		"phpunit/phpunit": "^7.0",
 		"slevomat/coding-standard": "^4.7.2",
-		"squizlabs/php_codesniffer": "^3.3.2"
+		"squizlabs/php_codesniffer": "^3.3.2",
+		"wimg/php-compatibility": "^9.0"
 	},
 	"config": {
 		"sort-packages": true

--- a/phpcs.php_cs
+++ b/phpcs.php_cs
@@ -1,0 +1,223 @@
+<?php declare(strict_types=1);
+
+return PhpCsFixer\Config::create()
+                        ->setUsingCache(false)
+                        ->setCacheFile(__DIR__ . '/tmp/cache/phpcs-fixer')
+                        ->setRiskyAllowed(true)
+                        ->setRules(
+	                        [
+		                        'align_multiline_comment'                       => [
+			                        'comment_type' => 'all_multiline',
+		                        ],
+		                        'array_indentation'                             => true,
+		                        'array_syntax'                                  => [
+			                        'syntax' => 'short',
+		                        ],
+		                        'backtick_to_shell_exec'                        => true,
+		                        'binary_operator_spaces'                        => [
+			                        'operators' => ['=>' => 'align_single_space_minimal'],
+		                        ],
+		                        'blank_line_after_namespace'                    => true,
+		                        'blank_line_after_opening_tag'                  => false,
+		                        'blank_line_before_statement'                   => true,
+		                        'braces'                                        => false, // disabled for now
+		                        'cast_spaces'                                   => [
+			                        'space' => 'single',
+		                        ],
+		                        'class_attributes_separation'                   => false, // disabled for now
+		                        'class_keyword_remove'                          => false,
+		                        'combine_consecutive_issets'                    => true,
+		                        'combine_consecutive_unsets'                    => true,
+		                        'combine_nested_dirname'                        => true,
+		                        'compact_nullable_typehint'                     => true,
+		                        'concat_space'                                  => [
+			                        'spacing' => 'one',
+		                        ],
+		                        'date_time_immutable'                           => false,
+		                        'declare_equal_normalize'                       => false, // disabled for now
+		                        'declare_strict_types'                          => true,
+		                        'dir_constant'                                  => true,
+		                        'elseif'                                        => true,
+		                        'encoding'                                      => true,
+		                        'ereg_to_preg'                                  => true,
+		                        'error_suppression'                             => false,
+		                        'escape_implicit_backslashes'                   => false,
+		                        'explicit_indirect_variable'                    => true,
+		                        'explicit_string_variable'                      => true,
+		                        'final_internal_class'                          => false, // disabled for now
+		                        'fopen_flag_order'                              => true,
+		                        'fopen_flags'                                   => true,
+		                        'full_opening_tag'                              => true,
+		                        'fully_qualified_strict_types'                  => false, // maybe better for readability, so keep it ...
+		                        'function_declaration'                          => true,
+		                        'function_to_constant'                          => true,
+		                        'function_typehint_space'                       => true,
+		                        'general_phpdoc_annotation_remove'              => [
+			                        'annotations' => [
+				                        'author',
+				                        'package',
+				                        'version',
+			                        ],
+		                        ],
+		                        'heredoc_to_nowdoc'                             => false,
+		                        'implode_call'                                  => false,
+		                        'include'                                       => true,
+		                        'increment_style'                               => false, // maybe better for readability, so keep it ...
+		                        'indentation_type'                              => true,
+		                        'line_ending'                                   => true,
+		                        'linebreak_after_opening_tag'                   => false,
+		                        'list_syntax'                                   => [
+		                        	'syntax' => 'short'
+		                        ],
+		                        'logical_operators'                             => true,
+		                        'lowercase_cast'                                => true,
+		                        'lowercase_constants'                           => true,
+		                        'lowercase_keywords'                            => true,
+		                        'lowercase_static_reference'                    => true,
+		                        'magic_constant_casing'                         => true,
+		                        'magic_method_casing'                           => true,
+		                        'method_argument_space'                         => [
+			                        'ensure_fully_multiline'           => true,
+			                        'keep_multiple_spaces_after_comma' => false,
+		                        ],
+		                        'method_chaining_indentation'                   => false, // maybe better for readability, so keep it ...
+		                        'modernize_types_casting'                       => true,
+		                        'multiline_comment_opening_closing'             => false, // maybe better for readability, so keep it ...
+		                        'multiline_whitespace_before_semicolons'        => [
+			                        'strategy' => 'no_multi_line',
+		                        ],
+		                        'native_constant_invocation'                    => false, // disabled for now
+		                        'native_function_casing'                        => true,
+		                        'native_function_invocation'                    => false, // disabled for now
+		                        'new_with_braces'                               => true,
+		                        'no_alias_functions'                            => true,
+		                        'no_alternative_syntax'                         => true,
+		                        'no_binary_string'                              => true,
+		                        'no_blank_lines_after_class_opening'            => false,
+		                        'no_blank_lines_after_phpdoc'                   => true,
+		                        'no_blank_lines_before_namespace'               => false,
+		                        'no_break_comment'                              => true,
+		                        'no_closing_tag'                                => true,
+		                        'no_empty_comment'                              => true,
+		                        'no_empty_phpdoc'                               => true,
+		                        'no_empty_statement'                            => true,
+		                        'no_extra_blank_lines'                          => true,
+		                        'no_homoglyph_names'                            => true,
+		                        'no_leading_import_slash'                       => true,
+		                        'no_leading_namespace_whitespace'               => true,
+		                        'no_mixed_echo_print'                           => [
+			                        'use' => 'echo',
+		                        ],
+		                        'no_multiline_whitespace_around_double_arrow'   => true,
+		                        'no_null_property_initialization'               => false, // disabled for now
+		                        'no_php4_constructor'                           => true,
+		                        'no_short_bool_cast'                            => true,
+		                        'no_short_echo_tag'                             => true,
+		                        'no_singleline_whitespace_before_semicolons'    => true,
+		                        'no_spaces_after_function_name'                 => true,
+		                        'no_spaces_around_offset'                       => true,
+		                        'no_spaces_inside_parenthesis'                  => true,
+		                        'no_superfluous_elseif'                         => false, // maybe better for readability, so keep it ...
+		                        'no_superfluous_phpdoc_tags'                    => false, // maybe add extra description, so keep it ...
+		                        'no_trailing_comma_in_list_call'                => true,
+		                        'no_trailing_comma_in_singleline_array'         => true,
+		                        'no_trailing_whitespace'                        => true,
+		                        'no_trailing_whitespace_in_comment'             => true,
+		                        'no_unneeded_control_parentheses'               => true,
+		                        'no_unneeded_curly_braces'                      => true,
+		                        'no_unneeded_final_method'                      => true,
+		                        'no_unreachable_default_argument_value'         => false, // do not changes the logic of the code ...
+		                        'no_unset_on_property'                          => true,
+		                        'no_unused_imports'                             => true,
+		                        'no_useless_else'                               => true,
+		                        'no_useless_return'                             => true,
+		                        'no_whitespace_before_comma_in_array'           => true,
+		                        'no_whitespace_in_blank_line'                   => true,
+		                        'non_printable_character'                       => true,
+		                        'normalize_index_brace'                         => true,
+		                        'not_operator_with_space'                       => false,
+		                        'not_operator_with_successor_space'             => false,
+		                        'object_operator_without_whitespace'            => true,
+		                        'ordered_class_elements'                        => false, // maybe better for readability, so keep it ...
+		                        'ordered_imports'                               => true,
+		                        'phpdoc_add_missing_param_annotation'           => [
+			                        'only_untyped' => true,
+		                        ],
+		                        'phpdoc_align'                                  => false, // maybe better for readability for very long names, so keep it ...
+		                        'phpdoc_annotation_without_dot'                 => true,
+		                        'phpdoc_indent'                                 => true,
+		                        'phpdoc_inline_tag'                             => true,
+		                        'phpdoc_no_access'                              => true,
+		                        'phpdoc_no_alias_tag'                           => true,
+		                        'phpdoc_no_empty_return'                        => false, // maybe better for readability, so keep it ...
+		                        'phpdoc_no_package'                             => true,
+		                        'phpdoc_no_useless_inheritdoc'                  => true,
+		                        'phpdoc_order'                                  => true,
+		                        'phpdoc_return_self_reference'                  => true,
+		                        'phpdoc_scalar'                                 => true,
+		                        'phpdoc_separation'                             => true,
+		                        'phpdoc_single_line_var_spacing'                => true,
+		                        'phpdoc_summary'                                => false,
+		                        'phpdoc_to_comment'                             => false,
+		                        'phpdoc_to_return_type'                         => false,
+		                        'phpdoc_trim'                                   => true,
+		                        'phpdoc_trim_consecutive_blank_line_separation' => true,
+		                        'phpdoc_types'                                  => true,
+		                        'phpdoc_types_order'                            => [
+			                        'null_adjustment' => 'always_last',
+			                        'sort_algorithm'  => 'alpha',
+		                        ],
+		                        'phpdoc_var_without_name'                       => true,
+		                        'pow_to_exponentiation'                         => true,
+		                        'pre_increment'                                 => false,
+		                        'protected_to_private'                          => true,
+		                        'return_assignment'                             => false, // not working for PHPStan
+		                        'return_type_declaration'                       => true,
+		                        'self_accessor'                                 => false, // disabled for now
+		                        'semicolon_after_instruction'                   => true,
+		                        'set_type_to_cast'                              => true,
+		                        'short_scalar_cast'                             => true,
+		                        'silenced_deprecation_error'                    => false,
+		                        'simplified_null_return'                        => true,
+		                        'single_blank_line_at_eof'                      => true,
+		                        'single_class_element_per_statement'            => true,
+		                        'single_import_per_statement'                   => true,
+		                        'single_line_after_imports'                     => true,
+		                        'single_line_comment_style'                     => [
+			                        'comment_types' => ['hash'],
+		                        ],
+		                        'single_quote'                                  => false, // keep quotes for now ...
+		                        'space_after_semicolon'                         => true,
+		                        'standardize_increment'                         => false, // maybe better for readability, so keep it ...
+		                        'standardize_not_equals'                        => true,
+		                        'static_lambda'                                 => false,
+		                        'strict_comparison'                             => true,
+		                        'strict_param'                                  => true,
+		                        'string_line_ending'                            => true,
+		                        'switch_case_semicolon_to_colon'                => true,
+		                        'switch_case_space'                             => true,
+		                        'ternary_operator_spaces'                       => true,
+		                        'ternary_to_null_coalescing'                    => true,
+		                        'trailing_comma_in_multiline_array'             => true,
+		                        'trim_array_spaces'                             => true,
+		                        'unary_operator_spaces'                         => true,
+		                        'visibility_required'                           => true,
+		                        'void_return'                                   => true,
+		                        'whitespace_after_comma_in_array'               => true,
+		                        'yoda_style'                                    => [
+			                        'equal'            => false,
+			                        'identical'        => false,
+			                        'less_and_greater' => false,
+		                        ],
+	                        ]
+                        )
+                        ->setIndent("\t")
+                        ->setLineEnding("\n")
+                        ->setFinder(
+	                        PhpCsFixer\Finder::create()
+	                                         ->in(['src/'])
+	                                         ->notPath('#.*/functionMap\.php#')
+	                                         ->name('*.php')
+	                                         ->ignoreDotFiles(true)
+	                                         ->ignoreVCS(true)
+                        );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,34 @@
 <?xml version="1.0"?>
 <ruleset name="PHPStan">
+	<config name="installed_paths" value="vendor/slevomat/coding-standard/,vendor/wimg/php-compatibility/PHPCompatibility/"/>
+
+	<!-- 0. Intro -->
+
+	<description>The PHPStan coding standard.</description>
+	<arg name="tab-width" value="4"/>
+	<arg name="encoding" value="UTF-8"/>
+	<arg name="basepath" value="."/>
+	<arg name="extensions" value="php"/>
+	<arg name="cache" value="tmp/cache/phpcs"/>
+	<arg name="colors"/>
+
+	<!-- show progress of the run and show sniff names -->
+	<arg value="sp"/>
+
+	<!-- Don't hide tokenizer exceptions -->
+	<rule ref="Internal.Tokenizer.Exception">
+		<type>error</type>
+	</rule>
+
+	<!-- Run against the PHPCompatibility ruleset -->
+	<rule ref="PHPCompatibility">
+        <exclude name="PHPCompatibility.Constants.NewConstants.json_throw_on_errorFound"/>
+    </rule>
+	<!-- Check for cross-version support for PHP 7.1 and higher. -->
+	<config name="testVersion" value="7.1-"/>
+
+	<!-- 1. Extend the "consistence"-coding standard -->
+
 	<rule ref="vendor/consistence/coding-standard/Consistence/ruleset.xml">
 		<exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword"/>
@@ -9,16 +38,789 @@
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
 		<exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch"/>
 	</rule>
+
+	<!-- 2.0 Files -->
+
+	<!-- In PHP files make sure there is no character before the opening tag -->
+	<rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
+
+	<!-- One file one class -->
+	<rule ref="Generic.Files.OneClassPerFile"/>
+
+	<!-- All PHP files MUST use the Unix LF (linefeed) line ending. -->
+	<rule ref="Generic.Files.LineEndings">
+		<properties>
+			<property name="eolChar" value="\n"/>
+		</properties>
+	</rule>
+
+	<!-- PHP code MUST use only UTF-8 without BOM. -->
+	<rule ref="Generic.Files.ByteOrderMark"/>
+
+	<!-- Check for side effects in files -->
+	<rule ref="PSR1.Files.SideEffects"/>
+
+	<!-- All PHP files MUST end with a single blank line. -->
+	<rule ref="PSR2.Files.EndFileNewline"/>
+
+	<!-- The closing ?> tag MUST be omitted from files containing only PHP. -->
+	<rule ref="PSR2.Files.ClosingTag"/>
+
+	<!-- 2.1 Basic Coding Standard -->
+
+	<!-- Check function- and closure braces -->
+	<rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman">
+		<properties>
+			<property name="checkFunctions" value="true"/>
+			<property name="checkClosures" value="false"/>
+		</properties>
+	</rule>
+
+	<!-- Check that two strings using the same quoting style by concatenation -->
+	<rule ref="Generic.Strings.UnnecessaryStringConcat">
+		<properties>
+			<property name="allowMultiline" value="true"/>
+		</properties>
+	</rule>
+
+	<!-- MUST be using CamelCaps for method names -->
+	<rule ref="PSR1.Methods.CamelCapsMethodName"/>
+
+	<!-- MUST use short list (list(...) -> [...]) -->
+	<rule ref="SlevomatCodingStandard.PHP.ShortList"/>
+
+	<!-- MUST use shorthand type cast ((integer) -> (int), ...) -->
+	<rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
+
+	<!-- MUST NOT use useless semicolons -->
+	<rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
+
+	<!-- MUST NOT use useless parentheses -->
+	<rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+
+	<!-- MUST NOT use "empty()" -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty"/>
+
+	<!-- MOST NOT use useless conditions where both branches return true or false -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.UselessConditionWithReturn"/>
+
+	<!-- MOST NOT use Yoda conditions -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
+
+	<!-- Checks and fixes language construct used with parentheses -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
+
+	<!-- MUST use "new" with parentheses -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
+
+	<!-- MOST NOT use assignments in if, elseif and do-while loop conditions -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
+
+	<!-- MUST use "=== || !==" instead of "== || !=" -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
+
+	<!-- MUST use null coalesce operator when possible -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
+
+	<!-- MUST use of early exit -->
+	<!-- not working ->
+    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+    -->
+
+	<!-- MUST NOT use short ternary operator ?: -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator"/>
+
+	<!-- MUST use combined assignment operators, eg +=, .= etc. -->
+	<rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
+
+	<!-- MUST NOT use unused variables -->
+	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
+
+	<!-- MUST NOT use useless variables -->
+	<rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
+
+	<!-- MUST use increment / decrement -->
+	<rule ref="Squiz.Operators.IncrementDecrementUsage">
+		<exclude name="Squiz.Operators.IncrementDecrementUsage.NoBrackets"/><!-- afaik there is no need for brackets -->
+	</rule>
+
+	<!-- MUST use "&&, ||" instead of "and, or" -->
+	<rule ref="Squiz.Operators.ValidLogicalOperators"/>
+
+	<!-- Forbid some functions -->
+	<rule ref="Generic.PHP.ForbiddenFunctions">
+		<properties>
+			<!-- http://php.net/manual/en/aliases.php -->
+			<property
+					name="forbiddenFunctions"
+					type="array"
+					value="
+                    var_dump => null,
+                    d => null,
+                    dd => null,
+                    ddd => null,
+                    die => exit,
+                    chop => rtrim,
+                    close => closedir,
+                    compact => null,
+                    delete => unset,
+                    doubleval => floatval,
+                    extract => null,
+                    fputs => fwrite,
+                    ini_alter => ini_set,
+                    is_double => is_float,
+                    is_integer => is_int,
+                    is_long => is_int,
+                    is_null => null,
+                    is_real => is_float,
+                    is_writeable => is_writable,
+                    join => implode,
+                    key_exists => array_key_exists,
+                    pos => current,
+                    print=>echo,
+                    settype => null,
+                    show_source => highlight_file,
+                    sizeof => count,
+                    strchr => strstr
+                "/>
+		</properties>
+	</rule>
+
+	<!-- function call MUST use new line for every multi-argument -->
+	<rule ref="PEAR.Functions.FunctionCallSignature"/>
+	<rule ref="PSR2.Methods.FunctionCallSignature">
+		<properties>
+			<property name="allowMultipleArguments" value="false"/>
+		</properties>
+		<exclude name="PSR2.Methods.FunctionCallSignature.SpaceAfterCloseBracket"/><!-- space after closing bracket should be checked depending on where function is called, not as part of the function call -->
+	</rule>
+
+	<!-- Check function closing braces -->
+	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
+
+	<!-- Check closures not using $this that are not declared static -->
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
+
+	<!-- Check for unused parameters -->
+	<!--<rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>-->
+
+	<!-- Check for unused inherited variables passed to closure via use -->
+	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
+
+	<!-- Check functions declarations -->
+	<rule ref="Squiz.Functions.FunctionDeclaration">
+		<properties>
+			<property name="ignoreComments" value="false" />
+		</properties>
+	</rule>
+
+	<!-- No global function in e.g. classes -->
+	<rule ref="Squiz.Functions.GlobalFunction"/>
+
+	<!-- Check to ensure no PHP deprecated functions have been used -->
+	<rule ref="Generic.PHP.DeprecatedFunctions"/>
+
+	<!-- Force array syntax -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+	<rule ref="Squiz.Arrays.ArrayDeclaration">
+		<exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNewLine"/><!-- does not handle wrapped content -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/><!-- expects closing brace at the same level as opening brace -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/><!-- we don't want spacing with alignment -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.FirstIndexNoNewline"/><!-- expects multi-value array always written on multiple lines -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.FirstValueNoNewline"/><!-- expects multi-value array always written on multiple lines -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/><!-- uses indentation of only single space -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed"/><!-- even a single-value array can be written on multiple lines -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.NoComma"/><!-- does not handle nested array access with complex keys on multiple lines; also already checked better by SlevomatCodingStandard.Arrays.TrailingArrayComma -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast"/><!-- expects multi-value array always written on multiple lines -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed"/><!-- multiple values can be written on a single line -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/><!-- we don't want spacing with alignment -->
+	</rule>
+	<rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+
+	<!-- Show warnings on Discouraged Functions: error_log, print_r and var_dump -->
+	<rule ref="Squiz.PHP.DiscouragedFunctions"/>
+
+	<!-- Eval is Evil -->
+	<!-- phpstan: project specific -> disable for now, because of error in "src/Broker/Broker.php" -->
+    <!--
+	<rule ref="Squiz.PHP.Eval"/>
+    -->
+
+	<!-- Dont use $GLOBALS -->
+	<rule ref="Squiz.PHP.GlobalKeyword"/>
+
+	<!-- Forbid `AND` and `OR`, require `&&` and `||` -->
+	<!--
+        $true = true;
+        $false = false;
+
+        $what = $true and $false;
+        var_dump($what); // true
+
+        $what = $true && $false;
+        var_dump($what); // false
+    -->
+	<rule ref="Squiz.Operators.ValidLogicalOperators"/>
+
+	<!-- Forbid functions inside functions -->
+	<rule ref="Squiz.PHP.InnerFunctions"/>
+
+	<!-- Require PHP function calls in lowercase -->
+	<rule ref="Squiz.PHP.LowercasePHPFunctions"/>
+
+	<!-- Checks for Code that will never be Executed by bad Design -->
+	<rule ref="Squiz.PHP.NonExecutableCode"/>
+
+	<!-- Forbid `$this` inside static function -->
+	<rule ref="Squiz.Scope.StaticThisUsage"/>
+
+	<!-- Forbid PHP 4 constructors -->
+	<rule ref="Generic.NamingConventions.ConstructorName"/>
+
+	<!-- Class constants MUST be declared in all upper case with underscore separators. -->
+	<rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+
+	<!-- Do not use e.g. "if (true)" -->
+	<rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+
+	<!-- Disallow empty statements -->
+	<rule ref="Generic.CodeAnalysis.EmptyStatement">
+		<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/><!-- empty catch statements are allowed -->
+	</rule>
+
+	<!-- Simplify loops if possible -->
+	<rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+
+	<!-- Disallow final method in final class -->
+	<rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+
+	<!-- Do not use <? -->
+	<rule ref="Generic.PHP.DisallowShortOpenTag"/>
+
+	<!-- Forbid inline HTML in PHP code -->
+	<rule ref="Generic.Files.InlineHTML"/>
+
+	<!-- A class or interface must not be defined in multiple files. -->
+	<rule ref="Generic.Classes.DuplicateClassName"/>
+
+	<!-- Complexity -->
+	<!--
+	<rule ref="Generic.Metrics.CyclomaticComplexity">
+		<properties>
+			<property name="complexity" value="250"/>
+			<property name="absoluteComplexity" value="300"/>
+		</properties>
+	</rule>
+	-->
+
+	<!-- Nesting -->
+	<!--
+	<rule ref="Generic.Metrics.NestingLevel">
+		<properties>
+			<property name="nestingLevel" value="4"/>
+			<property name="absoluteNestingLevel" value="8"/>
+		</properties>
+	</rule>
+	-->
+
+	<!-- 2.2 Lines -->
+
+	<!-- The soft limit on line length MUST be "x"-characters; automated style checkers MUST warn but MUST NOT error at the soft limit. -->
+	<!--
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="160"/>
+			<property name="absoluteLineLimit" value="0"/>
+			<property name="ignoreComments" value="true" />
+		</properties>
+	</rule>
+	-->
+
+	<!-- 2.3 Whitespace -->
+
+	<!-- Check spaces for comments -->
+	<rule ref="Squiz.Commenting.DocCommentAlignment">
+		<exclude name="Squiz.Commenting.DocCommentAlignment.SpaceAfterStar"/><!-- space needed for indented annotations -->
+	</rule>
+
+	<!-- Check spaces for "for"-loops -->
+	<rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
+
+	<!-- Check spaces after a type cast -->
+	<rule ref="Generic.Formatting.SpaceAfterCast"/>
+
+	<!-- Check padding inside parenthesis -->
+	<rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
+	<!-- MUST use spaces for TypeHints -->
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
+
+	<!-- MUST use spaces before the opening brace of control structures -->
+	<rule ref="Squiz.ControlStructures.ControlSignature"/>
+
+	<!-- Foreach structures MUST use the correct padding inside their bracketed statement -->
+	<rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
+
+	<!-- MUST use spaces fir function arguments -->
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+		<properties>
+			<property name="equalsSpacing" value="1"/>
+		</properties>
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterHint"/><!-- already checked by SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.MultipleSpacesBetweenTypeHintAndParameter -->
+	</rule>
+
+	<!-- MUST use spaces in arrays -->
+	<rule ref="Squiz.Arrays.ArrayBracketSpacing">
+		<exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceBeforeBracket"/><!-- does not handle nested array access across multiple lines -->
+	</rule>
+
+	<!-- One space after PHP language construct keywords -->
+	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
+
+	<!-- MUST use spaces for equal symbols -->
+	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
+	<!-- MUST use spaces for casts -->
+	<rule ref="Squiz.WhiteSpace.CastSpacing"/>
+
+	<!-- MUST use spaces in braces -->
+	<rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
+
+	<!-- MUST use spaces fot function declaration -->
+	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
+		<exclude name="Squiz.WhiteSpace.FunctionSpacing.After"/><!-- does not allow PHPUnit ignore comments -->
+		<properties>
+			<property name="spacing" value="1"/>
+		</properties>
+	</rule>
+
+	<!-- MUST use spaces for variables -->
+	<rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
+
+	<!-- MUST use spaces for object operators -->
+	<rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
+	<!-- There MUST NOT be a space after the opening- / before the closing parenthesis -->
+	<rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
+
+	<!-- MUST use spaces for scope keywords -->
+	<rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
+
+	<!-- Check spacing for semicolons -->
+	<rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
+
+	<!-- There MUST NOT be trailing whitespace at the end of non-blank lines. -->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile"/>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile"/>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
+
+	<!-- Require space around logical operators -->
+	<rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
+
+	<!-- MUST use padding around concatenation -->
+	<rule ref="Squiz.Strings.ConcatenationSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true"/>
+			<property name="spacing" value="1"/>
+		</properties>
+	</rule>
+
+	<!-- Force whitespace before and after concatenation -->
+	<rule ref="Squiz.Strings.ConcatenationSpacing">
+		<properties>
+			<property name="spacing" value="1"/>
+		</properties>
+	</rule>
+
+	<!-- There MUST NOT be more than one statement per line. -->
+	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+
+	<!-- Check opening / closing braces for class/interface/trait -->
+	<rule ref="SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces"/>
+
+	<!-- 2.4 Indenting -->
+
+	<!-- ? -->
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+
+	<!-- ? -->
+	<rule ref="PEAR.WhiteSpace.ObjectOperatorIndent"/>
+
+	<!-- ? -->
+	<rule ref="PEAR.Formatting.MultiLineAssignment"/>
+
+	<!-- Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. When the argument list is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
+	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration">
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace"/><!-- clashes with OpeningFunctionBraceBsdAllman -->
+	</rule>
+
+	<!-- Indenting for array -->
+	<rule ref="Generic.Arrays.ArrayIndent">
+		<exclude name="Generic.Arrays.ArrayIndent.CloseBraceNotNewLine"/><!-- multiline items causes evaluation as multiline array https://github.com/squizlabs/PHP_CodeSniffer/issues/1791 -->
+	</rule>
+
+	<!-- Code MUST use tabs for indenting. -->
+	<rule ref="Generic.WhiteSpace.ScopeIndent">
+		<properties>
+			<property name="tabIndent" value="true"/>
+			<property name="ignoreIndentationTokens" type="array" value="T_COMMENT,T_DOC_COMMENT_OPEN_TAG"/>
+		</properties>
+	</rule>
+
+	<!-- 2.5 Keywords and True/False/Null -->
+
+	<!-- PHP keywords MUST be in lower case. -->
+	<rule ref="Generic.PHP.LowerCaseKeyword"/>
+
+	<!-- The PHP constants true, false, and null MUST be in lower case. -->
+	<rule ref="Generic.PHP.LowerCaseConstant"/>
+
+	<!-- Type hints, return types, and type casting MUST be lowercase -->
+	<rule ref="Generic.PHP.LowerCaseType"/>
+
+	<!-- 2.6 Comments -->
+
+	<!-- Forbid comments starting with # -->
+	<rule ref="PEAR.Commenting.InlineComment"/>
+
+	<!-- Check empty-catch comment -->
+	<rule ref="Squiz.Commenting.EmptyCatchComment"/>
+
+	<!-- Check function comment -->
+	<rule ref="Squiz.Commenting.FunctionComment">
+		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/><!-- @throws are forbidden -->
+		<exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName"/><!-- requires long boolean and integer parameters -->
+		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/><!-- collection syntax such as string[] is not supported -->
+		<exclude name="Squiz.Commenting.FunctionComment.InvalidReturn"/><!-- enforces incorrect types -->
+		<exclude name="Squiz.Commenting.FunctionComment.InvalidReturnNotVoid"/><!-- is not able to detect return types such as string|null as correct -->
+		<exclude name="Squiz.Commenting.FunctionComment.InvalidThrows"/><!-- @throws are forbidden -->
+		<exclude name="Squiz.Commenting.FunctionComment.Missing"/><!-- PHPDoc is not required on all methods -->
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/><!-- comments are not required for @param -->
+		<exclude name="Squiz.Commenting.FunctionComment.MissingReturn"/><!-- void type is not used -->
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/><!-- comments don't have to be sentences -->
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/><!-- comments don't have to be sentences -->
+		<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/><!-- works only for code requiring PHP 7 code or better -->
+		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamName"/><!-- we don't want spacing with alignment -->
+		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/><!-- we don't want spacing with alignment -->
+		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop"/><!-- @throws are forbidden -->
+		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital"/><!-- @throws are forbidden -->
+		<exclude name="Squiz.Commenting.FunctionComment.TypeHintMissing"/><!-- doesn't work with self as typehint -->
+		<exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch"/><!-- doesn't work with e.g. closure -> @param \Closure(\PhpParser\Node $node, Scope $scope): void $nodeCallback -->
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/><!-- doesn't work with e.g. closure -> @param \Closure(\PhpParser\Node $node, Scope $scope): void $nodeCallback -->
+		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn"/><!-- phpstan: project specific -> disable for now, because of error in "src/Type/NullType.php" -->
+	</rule>
+
+	<!-- Check duplicate return comment -->
+	<rule ref="Squiz.Commenting.FunctionComment.DuplicateReturn">
+		<message>Only 1 @return annotation is allowed in a function comment</message>
+	</rule>
+
+	<!-- Check extra param comment -->
+	<rule ref="Squiz.Commenting.FunctionComment.ExtraParamComment">
+		<message>Extra @param annotation</message>
+	</rule>
+
+	<!-- Check invalid no return -->
+	<rule ref="Squiz.Commenting.FunctionComment.InvalidNoReturn">
+		<message>Function has no return statement, but annotation @return is present</message>
+	</rule>
+
+	<!-- Check missing param -->
+	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
+		<message>@param annotation for parameter "%s" missing</message>
+	</rule>
+
+	<!-- Check inline php-doc -->
+	<rule ref="Generic.Commenting.DocComment">
+		<exclude name="Generic.Commenting.DocComment.NonParamGroup"/><!-- allow mixed grouping -->
+		<exclude name="Generic.Commenting.DocComment.TagValueIndent"/><!-- no indent for comments -->
+		<exclude name="Generic.Commenting.DocComment.ParamNotFirst"/><!-- Having a @see or @internal tag before the @param tags is fine. -->
+		<exclude name="Generic.Commenting.DocComment.ContentBeforeClose"/>
+		<exclude name="Generic.Commenting.DocComment.ContentAfterOpen"/><!-- Allow one-line comment e.g. /** foo */ -->
+		<exclude name="Generic.Commenting.DocComment.MissingShort"/><!-- Short description is optional - if the method name is already good ;) -->
+	</rule>
+
+	<!-- No need to be as strict about comment punctuation for the unit tests. -->
+	<rule ref="Generic.Commenting.DocComment.ShortNotCapital">
+		<exclude-pattern>*/tests/*\.php</exclude-pattern>
+	</rule>
+
+	<!-- To do comments should be reported and completed -->
+	<rule ref="Generic.Commenting.Todo.CommentFound">
+		<message>Please review this TODO comment: %s</message>
+		<severity>3</severity>
+		<type>warning</type>
+	</rule>
+
+	<!-- Fix me comments should be reported and fixed -->
+	<rule ref="Generic.Commenting.Todo.Fixme">
+		<message>Please review this FIXME comment: %s</message>
+		<severity>5</severity>
+		<type>warning</type>
+	</rule>
+
+	<!-- MOST NOT contains empty comments -->
+	<rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+
+	<!-- Reports invalid format of inline phpDocs with @var. -->
+	<rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration">
+		<exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/><!-- this is not working for generics syntax (https://github.com/slevomat/coding-standard/issues/523) -->
+	</rule>
+
+	<!-- Requires comments with single-line content to be written as one-liners -->
+	<rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
+
+	<!-- Reports documentation comments containing only {@inheritDoc} annotation because inheritance is automatic and it's not needed to use a special annotation for it -->
+	<rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
+
+	<!-- 2.7 Strings -->
+
+	<!-- MUST NOT use heredoc string format -->
+	<rule ref="Squiz.PHP.Heredoc"/>
+
+	<!-- Check double-quote usage -->
+	<rule ref="Squiz.Strings.DoubleQuoteUsage"/>
+
+	<!-- Check double-quote + variables inside -->
+	<rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+		<message>Variable "%s" not allowed in double quoted string; use sprintf() instead</message>
+	</rule>
+
+	<!-- Check syntax of strings -->
+	<rule ref="Squiz.Strings.EchoedStrings"/>
+
+	<!-- 3. Namespace and Use Declarations -->
+
+	<!-- autoloading + namespace checks -->
+	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+		<properties>
+			<!-- phpstan: project specific -->
+			<property name="rootNamespaces" type="array" value="src => PHPStan, tests/PHPStan => PHPStan"/>
+		</properties>
+	</rule>
+
+	<!-- Checks whether uses at the top of a file are alphabetically sorted -->
 	<rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
 		<properties>
 			<property name="caseSensitive" value="false"/>
 		</properties>
 	</rule>
+
+	<!-- Group use declarations are ugly, make diffs ugly and this sniff prohibits them. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
+
+	<!-- Prohibits multiple uses separated by commas -->
+	<rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
+
+	<!-- Enforces one space after namespace, disallows content between namespace name and semicolon and disallows use of bracketed syntax -->
+	<rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
+
+	<!-- Enforces configurable number of lines before and after namespace -->
+	<rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
+
+	<!-- Enforces fully qualified type references after configurable set of language keywords -->
+	<!--
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword">
+		<properties>
+			<property name="keywordsToCheck" type="array">
+				<element value="T_EXTENDS"/>
+				<element value="T_IMPLEMENTS"/>
+				<element value="T_USE"/>
+			</property>
+		</properties>
+	</rule>
+	-->
+
+	<!-- Enforces fully qualified names of classes and interfaces in phpDocs - in @var, @param, @return, @throws. -->
+	<!--<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>-->
+
+	<!-- MUST use fully qualified names of Exceptions -->
+	<!--<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>-->
+
+	<!-- All references to global constants MUST be referenced via a fully qualified name -->
+	<!--<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>-->
+
+	<!-- All references to global functions MUST be referenced via a fully qualified name -->
+	<!--
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
+
+	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+		<properties>
+			<property name="allowFullyQualifiedExceptions" value="true"/>
+			<property name="allowFullyQualifiedGlobalFunctions" value="true"/>
+			<property name="allowFullyQualifiedGlobalConstants" value="true"/>
+			<property name="allowPartialUses" value="false"/>
+			<property name="fullyQualifiedKeywords" type="array">
+				<element value="T_EXTENDS"/>
+				<element value="T_IMPLEMENTS"/>
+				<element value="T_USE"/>
+			</property>
+		</properties>
+		<exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.PartialUse"/>
+		<exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName"/>
+	</rule>
+	-->
+
+	<!-- Requires only one namespace in a file -->
+	<rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
+
+	<!-- Looks for unused imports from other namespaces -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+		<properties>
+			<property name="searchAnnotations" value="true"/>
+		</properties>
+	</rule>
+
+	<!-- Disallows leading backslash in use statement -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
+
+	<!-- Prohibits uses from the same namespace -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
+
+	<!-- Looks for use alias that is same as unqualified name -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
+
+	<!-- When present, all use declarations MUST go after the namespace declaration.
+         There MUST be one use keyword per declaration.
+         There MUST be one blank line after the use block. -->
+	<rule ref="PSR2.Namespaces.UseDeclaration"/>
+
+	<!-- 4. Classes, Properties, and Methods -->
+
+	<!-- 4.1. Extends and Implements -->
+
+	<!-- The extends and implements keywords MUST be declared on the same line as the class name.
+         The opening brace for the class go MUST go on its own line; the closing brace for the class MUST go on the next line after the body.
+         Lists of implements MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one interface per line. -->
+	<rule ref="Squiz.Classes.ClassDeclaration"/>
+	<rule ref="PEAR.Classes.ClassDeclaration"/>
+	<rule ref="PSR1.Classes.ClassDeclaration"/>
+	<rule ref="Squiz.Classes.ClassFileName"/>
+	<rule ref="Squiz.Classes.SelfMemberReference"/>
+	<rule ref="Squiz.Classes.ValidClassName"/>
+
+	<!-- Reports use of superfluous prefix or suffix "Abstract" for abstract classes -->
+	<rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+
+	<!-- Reports use of superfluous prefix or suffix "Interface" for interfaces -->
+	<rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
+
+	<!-- Reports use of __CLASS__, get_parent_class(), get_called_class(), get_class() and get_class($this). Class names should be referenced via ::class constant when possible -->
+	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+
+	<!-- Prohibits multiple traits separated by commas in one use statement -->
+	<rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
+
+	<!-- Enforces configurable number of lines before first use, after last use and between two use statements -->
+	<rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing"/>
+
+	<!-- 4.2. Properties / Constants -->
+
+	<!-- Visibility MUST be declared on all properties.
+         The var keyword MUST NOT be used to declare a property.
+         There MUST NOT be more than one property declared per statement.
+         Property names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility. -->
+	<rule ref="PSR2.Classes.PropertyDeclaration"/>
+
+	<!-- MUST NOT use unused private elements -->
+	<rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
+
+	<rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+
+	<!-- 4.3 Methods -->
+
+	<!-- Visibility MUST be declared on all methods. -->
+	<rule ref="Squiz.Scope.MethodScope"/>
+
+	<!-- Method names MUST NOT be declared with a space after the method name. The opening brace MUST go on its own line, and the closing brace MUST go on the next line following the body. There MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. -->
+	<rule ref="Squiz.Functions.FunctionDeclaration"/>
+	<rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
+
+	<!-- 4.4 Method Arguments -->
+
+	<!-- In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma. -->
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+		<properties>
+			<property name="equalsSpacing" value="1"/>
+		</properties>
+	</rule>
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterHint"/>
+
+	<!-- Method arguments with default values MUST go at the end of the argument list. -->
+	<rule ref="PEAR.Functions.ValidDefaultValue"/>
+
+	<!-- 4.5 abstract, final, and static -->
+
+	<!-- When present, the abstract and final declarations MUST precede the visibility declaration.
+         When present, the static declaration MUST come after the visibility declaration. -->
+	<rule ref="PSR2.Methods.MethodDeclaration"/>
+
+	<!-- 4.6 Method and Function Calls -->
+
+	<!-- When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis, there MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.
+    Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. -->
+	<rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+
+	<!-- 5. Control Structures -->
+
+	<!-- The general style rules for control structures are as follows:
+    There MUST be one space after the control structure keyword
+    There MUST be one space between the closing parenthesis and the opening brace
+    The structure body MUST be indented once
+    The closing brace MUST be on the next line after the body -->
+	<rule ref="Squiz.ControlStructures.ControlSignature"/>
+	<rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
+	<rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
+	<rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
+	<rule ref="PSR2.ControlStructures.ControlStructureSpacing">
+		<exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/><!-- we want to put first expression of multiline condition on next line -->
+	</rule>
+
+	<!-- The body of each structure MUST be enclosed by braces. This standardizes how the structures look, and reduces the likelihood of introducing errors as new lines get added to the body. -->
+	<rule ref="Generic.ControlStructures.InlineControlStructure"/>
+
+	<!-- 5.1. if, elseif, else -->
+
+	<!-- The keyword elseif SHOULD be used instead of else if so that all control keywords look like single words. -->
+	<rule ref="PSR2.ControlStructures.ElseIfDeclaration"/>
+
+	<!-- 5.2. switch, case -->
+
+	<!-- The case statement MUST be indented once from switch, and the break keyword (or other terminating keyword) MUST be indented at the same level as the case body. There MUST be a comment such as // no break when fall-through is intentional in a non-empty case body. -->
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration">
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.caseIndent"/><!-- checked by more generic Generic.WhiteSpace.ScopeIndent.Incorrect -->
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.defaultIndent"/><!-- checked by more generic Generic.WhiteSpace.ScopeIndent.Incorrect -->
+	</rule>
+
+	<!-- 5.3 TypeHints -->
+
+	<!-- ? -->
 	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
 		<properties>
 			<property name="newlinesCountBetweenOpenTagAndDeclare" value="0"/>
 		</properties>
 	</rule>
+
+	<!-- MUST use shorthand scalar typehint (integer -> int, ...) -->
+	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
+
+	<!-- ? -->
+	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+
+	<!-- TypeHints MUST be valid -->
 	<rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
 		<properties>
 			<property name="usefulAnnotations" type="array" value="
@@ -27,34 +829,30 @@
 			"/>
 			<property name="enableObjectTypeHint" value="false"/>
 		</properties>
-		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification"/>
-		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
+		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification"/><!-- this is not working for generics syntax (https://github.com/slevomat/coding-standard/issues/522) -->
+		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/><!-- this is not working for generics syntax (https://github.com/slevomat/coding-standard/issues/522) -->
 	</rule>
-	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
-	<rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
-	<rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator"/>
-	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
-		<properties>
-			<property name="rootNamespaces" type="array" value="src=>PHPStan,tests/PHPStan=>PHPStan"/>
-		</properties>
-	</rule>
-	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
-	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
-	<rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
+
+	<!-- Check the syntax -->
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
+
+	<!-- MUST NOT use @var for constant (type is always clear) -->
+	<rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
+
+	<!-- MUST use null type hint on last position in @var, @param and @return annotations -->
 	<rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
-	<rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
-	<rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing"/>
-	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
-	<rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
-	<!--<rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>-->
-	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
-	<rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
-	<rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
-	<rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+
+	<!-- 5.4 Exceptions -->
+
+	<!-- MUST NOT contains any unreachable catch blocks -->
+	<rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
+
+	<!-- MUST use Throwable instead of Exception -->
+	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
+
+	<!-- 7. Ignore -->
+
+	<!-- phpstan: project specific -->
 	<exclude-pattern>tests/*/data</exclude-pattern>
 	<exclude-pattern>tests/*/traits</exclude-pattern>
 	<exclude-pattern>tests/notAutoloaded</exclude-pattern>


### PR DESCRIPTION
A more consistent and reliable code-style, this changes did not introduce some new style, it only sync the existing code - for example:

- "always" no more duplicate empty lines
- "always" use one empty line before "return"-statements 
- "always" use one empty line between phpdoc types (@param, @return)
- "always" use the same order of @param values
- "always" better readability for callback functions (multi-line)
- ...

... so for better merging I did not commit the changed files, because this can be done easily via ```vendor/bin/phing cs-fix``` and this way you can see that no file is touch manually.