### PR TITLE
Fix signature for MongoDB\Driver\WriteConcern::__construct

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -6776,7 +6776,7 @@ return [
 'MongoDB\Driver\Server::isPassive' => [''],
 'MongoDB\Driver\Server::isPrimary' => ['bool'],
 'MongoDB\Driver\Server::isSecondary' => ['bool'],
-'MongoDB\Driver\WriteConcern::__construct' => ['void', 'wstring'=>'string', 'wtimeout='=>'int', 'journal='=>'bool', 'fsync='=>'bool'],
+'MongoDB\Driver\WriteConcern::__construct' => ['void', 'w'=>'string|int', 'wtimeout='=>'int', 'journal='=>'bool', 'fsync='=>'bool'],
 'MongoDB\Driver\WriteConcern::getJurnal' => ['bool|null'],
 'MongoDB\Driver\WriteConcern::getW' => ['int|null|string'],
 'MongoDB\Driver\WriteConcern::getWtimeout' => ['int'],


### PR DESCRIPTION
See http://php.net/manual/en/mongodb-driver-writeconcern.construct.php and https://github.com/mongodb/mongo-php-driver/blob/29f00a91043ad94dc75960ce5511e9c2ff63ce46/src/MongoDB/WriteConcern.c#L38..L55 - the first argument is called `w` and accepts a string or integer. Any other options will throw an exception.