### PR TITLE
Correctly resolve return type including DynamicMethodReturnTypeExtension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"ext-intl": "*",
 		"ext-mysqli": "*",
 		"ext-soap": "*",
+		"ext-zip": "*",
 		"brianium/paratest": "^2.0",
 		"consistence/coding-standard": "^3.5",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -94,7 +94,7 @@ class FunctionCallParametersCheck
 		}
 
 		if (
-			$parametersAcceptor->getReturnType() instanceof VoidType
+			$scope->getType($funcCall) instanceof VoidType
 			&& !$scope->isInFirstLevelStatement()
 			&& !$funcCall instanceof \PhpParser\Node\Expr\New_
 		) {


### PR DESCRIPTION
This will fix situation where method return `void` but it its overwritten in `DynamicMethodReturnTypeExtension`.

Example scenario:
```php
class Foo
{
    public function doSomething(): void
    {

    }
}
```

Custom extension:
```php
final class SampleExtension implements DynamicMethodReturnTypeExtension
{
    public function isMethodSupported(MethodReflection $methodReflection): bool
    {
        return true;
    }

    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
    {
        return new ObjectType(SomethingOtherThanVoid::class);
    }
}
```

Without this fix, you will get error:
```
 ------ ---------------------------------------------------------------------------------- 
  Line   BarSpec.php                                                                       
 ------ ---------------------------------------------------------------------------------- 
  39     Result of method Foo::doSomething() (void) is used.  
 ------ ---------------------------------------------------------------------------------- 
```