### PR TITLE
Add the failure return type for shmop_open()

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -10108,7 +10108,7 @@ return [
 'shm_remove_var' => ['bool', 'shm_identifier'=>'resource', 'variable_key'=>'int'],
 'shmop_close' => ['void', 'shmid'=>'resource'],
 'shmop_delete' => ['bool', 'shmid'=>'resource'],
-'shmop_open' => ['resource', 'key'=>'int', 'flags'=>'string', 'mode'=>'int', 'size'=>'int'],
+'shmop_open' => ['resource|false', 'key'=>'int', 'flags'=>'string', 'mode'=>'int', 'size'=>'int'],
 'shmop_read' => ['string', 'shmid'=>'resource', 'start'=>'int', 'count'=>'int'],
 'shmop_size' => ['int', 'shmid'=>'resource'],
 'shmop_write' => ['int', 'shmid'=>'resource', 'data'=>'string', 'offset'=>'int'],


### PR DESCRIPTION
[shmop_open()](http://php.net/manual/en/function.shmop-open.php) returns false in the event of an error.