### PR TITLE
Fix signature for jddayofweek - 2nd parameter is optional

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -5676,7 +5676,7 @@ return [
 'java_set_ignore_case' => ['void', 'ignore'=>'ignore'],
 'java_throw_exceptions' => ['void', 'throw'=>'throw'],
 'JavaException::getCause' => ['object'],
-'jddayofweek' => ['mixed', 'juliandaycount'=>'int', 'mode'=>'int'],
+'jddayofweek' => ['mixed', 'juliandaycount'=>'int', 'mode='=>'int'],
 'jdmonthname' => ['string', 'juliandaycount'=>'int', 'mode'=>'int'],
 'jdtofrench' => ['string', 'juliandaycount'=>'int'],
 'jdtogregorian' => ['string', 'juliandaycount'=>'int'],


### PR DESCRIPTION
[PHP Documentation](http://php.net/manual/en/function.jddayofweek.php)