### PR TITLE
SplFileObject::current() can return false

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -11203,7 +11203,7 @@ return [
 'SplFileInfo::setInfoClass' => ['void', 'class_name='=>'string'],
 'SplFileObject::__construct' => ['void', 'filename'=>'string', 'mode='=>'string', 'use_include_path='=>'bool', 'context='=>''],
 'SplFileObject::__toString' => ['string'],
-'SplFileObject::current' => ['string|array'],
+'SplFileObject::current' => ['string|array|false'],
 'SplFileObject::eof' => ['bool'],
 'SplFileObject::fflush' => ['bool'],
 'SplFileObject::fgetc' => ['string|false'],


### PR DESCRIPTION
Hi,

SplFileObject::current() can return false if the pointer is out of bounds.

This is not mentionned in the php.net website, but here's a reproducible code:
https://3v4l.org/6XefC

Thanks