### PR TITLE
Add proper return type for array_shift

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -299,7 +299,7 @@ return [
 'array_replace_recursive' => ['array', 'arr1'=>'array', 'arr2'=>'array', '...args='=>'array'],
 'array_reverse' => ['array', 'input'=>'array', 'preserve='=>'bool'],
 'array_search' => ['int|string|false', 'needle'=>'mixed', 'haystack'=>'array', 'strict='=>'bool'],
-'array_shift' => ['mixed', '&rw_stack'=>'array'],
+'array_shift' => ['mixed|null', '&rw_stack'=>'array'],
 'array_slice' => ['array', 'input'=>'array', 'offset'=>'int', 'length='=>'?int', 'preserve_keys='=>'bool'],
 'array_splice' => ['array', '&rw_input'=>'array', 'offset'=>'int', 'length='=>'int', 'replacement='=>'array|string'],
 'array_sum' => ['int|float', 'input'=>'array'],

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4808,7 +4808,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array_pop($stdClassesWithIsset)',
 			],
 			[
-				'\'foo\'',
+				'\'foo\'|null',
 				'array_shift($stringKeys)',
 			],
 			[


### PR DESCRIPTION
> Returns the shifted value, or NULL if array is empty or is not an array.

http://php.net/manual/en/function.array-shift.php

(CI fails for me on 
```  Problem 1
    - phpstan/phpstan-strict-rules 0.11 requires phpstan/phpstan ^0.11 -> satisfiable by phpstan/phpstan[0.11, 0.11.1, 0.11.x-dev].
    - phpstan/phpstan-strict-rules 0.11.x-dev requires phpstan/phpstan ^0.11 -> satisfiable by phpstan/phpstan[0.11, 0.11.1, 0.11.x-dev].
    - Can only install one of: phpstan/phpstan[0.11, dev-db60771437de972565bc9263bcf0cc9081a2e14a].
    - Can only install one of: phpstan/phpstan[0.11.1, dev-db60771437de972565bc9263bcf0cc9081a2e14a].
    - Can only install one of: phpstan/phpstan[0.11.x-dev, dev-db60771437de972565bc9263bcf0cc9081a2e14a].
    - Installation request for phpstan/phpstan dev-db60771437de972565bc9263bcf0cc9081a2e14a -> satisfiable by phpstan/phpstan[dev-db60771437de972565bc9263bcf0cc9081a2e14a].
    - Installation request for phpstan/phpstan-strict-rules ^0.11 -> satisfiable by phpstan/phpstan-strict-rules[0.11, 0.11.x-dev].
```
not sure why)