### PR TITLE
Allow annotations to override properties set in PhpDefectClassReflectionExtension

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -218,7 +218,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 		$broker = new Broker(
 			[
 				$phpExtension,
-				new PhpDefectClassReflectionExtension(self::getContainer()->getByType(TypeStringResolver::class)),
+				new PhpDefectClassReflectionExtension(self::getContainer()->getByType(TypeStringResolver::class), $annotationsPropertiesClassReflectionExtension),
 				new UniversalObjectCratesClassReflectionExtension([\stdClass::class]),
 				$annotationsPropertiesClassReflectionExtension,
 			],

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1876,6 +1876,18 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'PropertiesNamespace\Bar',
 				'$this->implicitInheritDocProperty',
 			],
+			[
+				'int',
+				'$this->readOnlyProperty',
+			],
+			[
+				'string',
+				'$this->overriddenReadOnlyProperty',
+			],
+			[
+				'string',
+				'$this->documentElement',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/properties-defined.php
+++ b/tests/PHPStan/Analyser/data/properties-defined.php
@@ -2,9 +2,14 @@
 
 namespace PropertiesNamespace;
 
+use DOMDocument;
 use SomeNamespace\Sit as Dolor;
 
-class Bar
+/**
+ * @property-read int $readOnlyProperty
+ * @property-read int $overriddenReadOnlyProperty
+ */
+class Bar extends DOMDocument
 {
 
 	/**

--- a/tests/PHPStan/Analyser/data/properties.php
+++ b/tests/PHPStan/Analyser/data/properties.php
@@ -5,6 +5,10 @@ namespace PropertiesNamespace;
 use SomeNamespace\Amet as Dolor;
 use SomeGroupNamespace\{One, Two as Too, Three};
 
+/**
+ * @property-read string $overriddenReadOnlyProperty
+ * @property-read string $documentElement
+ */
 abstract class Foo extends Bar
 {
 


### PR DESCRIPTION
Hopefully now the correct fix for #1537.

The replicates https://github.com/phpstan/phpstan/commit/a7421ce953ea8b78f8c955dbcd5d7237b214fc47 in  `PhpDefectClassReflectionExtension`.

(Applies to 0.10 too, is that receiving bug fixes?)