### PR TITLE
Update UTCDateTime construct hinting

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -6699,7 +6699,7 @@ return [
 'MongoDB\BSON\toJSON' => ['string', 'bson'=>'string'],
 'MongoDB\BSON\toPHP' => ['object', 'bson'=>'string', 'typeMap'=>'array'],
 'MongoDB\BSON\Unserializable::bsonUnserialize' => ['', 'data'=>'array'],
-'MongoDB\BSON\UTCDateTime::__construct' => ['void', 'milliseconds='=>'int|float|string|DateTimeInterface'],
+'MongoDB\BSON\UTCDateTime::__construct' => ['void', 'milliseconds='=>'int|DateTimeInterface'],
 'MongoDB\BSON\UTCDateTime::__toString' => ['string'],
 'MongoDB\BSON\UTCDateTime::toDateTime' => ['DateTime'],
 'MongoDB\Driver\BulkWrite::__construct' => ['void', 'ordered='=>'bool'],

--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -6699,7 +6699,7 @@ return [
 'MongoDB\BSON\toJSON' => ['string', 'bson'=>'string'],
 'MongoDB\BSON\toPHP' => ['object', 'bson'=>'string', 'typeMap'=>'array'],
 'MongoDB\BSON\Unserializable::bsonUnserialize' => ['', 'data'=>'array'],
-'MongoDB\BSON\UTCDateTime::__construct' => ['void', 'milliseconds='=>'int'],
+'MongoDB\BSON\UTCDateTime::__construct' => ['void', 'milliseconds='=>'int|float|string|DateTimeInterface'],
 'MongoDB\BSON\UTCDateTime::__toString' => ['string'],
 'MongoDB\BSON\UTCDateTime::toDateTime' => ['DateTime'],
 'MongoDB\Driver\BulkWrite::__construct' => ['void', 'ordered='=>'bool'],


### PR DESCRIPTION
I came into issue where phpstan was throwing error on my `UTCDateTime` object since I initialized it with `DateTimeImmutable` object while this is perfectly acceptable according to the [documentation](https://secure.php.net/manual/en/class.mongodb-bson-utcdatetime.php) . This is possible fix, if not accepted please fix this issue or tell me how I should enhance this (as I'm very new here), and thanks!