### PR TITLE
Added possibility to override rule error file

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -5,6 +5,7 @@ namespace PHPStan\Analyser;
 use Nette\Utils\Json;
 use PHPStan\File\FileHelper;
 use PHPStan\Parser\Parser;
+use PHPStan\Rules\FileRuleError;
 use PHPStan\Rules\LineRuleError;
 use PHPStan\Rules\Registry;
 
@@ -164,6 +165,7 @@ class Analyser
 
 								foreach ($ruleErrors as $ruleError) {
 									$line = $node->getLine();
+									$fileName = $scope->getFileDescription();
 									if (is_string($ruleError)) {
 										$message = $ruleError;
 									} else {
@@ -174,8 +176,14 @@ class Analyser
 										) {
 											$line = $ruleError->getLine();
 										}
+										if (
+											$ruleError instanceof FileRuleError
+											&& $ruleError->getFile() !== ''
+										) {
+											$fileName = $ruleError->getFile();
+										}
 									}
-									$fileErrors[] = new Error($message, $scope->getFileDescription(), $line);
+									$fileErrors[] = new Error($message, $fileName, $line);
 								}
 							}
 

--- a/src/Rules/FileRuleError.php
+++ b/src/Rules/FileRuleError.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules;
+
+interface FileRuleError extends RuleError
+{
+
+	public function getFile(): string;
+
+}

--- a/src/Rules/RuleErrorBuilder.php
+++ b/src/Rules/RuleErrorBuilder.php
@@ -3,7 +3,9 @@
 namespace PHPStan\Rules;
 
 use PHPStan\Rules\RuleErrors\RuleErrorWithMessage;
+use PHPStan\Rules\RuleErrors\RuleErrorWithMessageAndFile;
 use PHPStan\Rules\RuleErrors\RuleErrorWithMessageAndLine;
+use PHPStan\Rules\RuleErrors\RuleErrorWithMessageAndLineAndFile;
 
 class RuleErrorBuilder
 {
@@ -13,6 +15,9 @@ class RuleErrorBuilder
 
 	/** @var int|null */
 	private $line;
+
+	/** @var string|null */
+	private $file;
 
 	private function __construct()
 	{
@@ -33,10 +38,23 @@ class RuleErrorBuilder
 		return $this;
 	}
 
+	public function file(string $file): self
+	{
+		$this->file = $file;
+
+		return $this;
+	}
+
 	public function build(): RuleError
 	{
-		if ($this->line !== null) {
+		if ($this->line !== null && $this->file !== null) {
+			return new RuleErrorWithMessageAndLineAndFile($this->message, $this->line, $this->file);
+		}
+		if ($this->line !== null && $this->file === null) {
 			return new RuleErrorWithMessageAndLine($this->message, $this->line);
+		}
+		if ($this->line === null && $this->file !== null) {
+			return new RuleErrorWithMessageAndFile($this->message, $this->file);
 		}
 
 		return new RuleErrorWithMessage($this->message);

--- a/src/Rules/RuleErrors/RuleErrorWithMessageAndFile.php
+++ b/src/Rules/RuleErrors/RuleErrorWithMessageAndFile.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\RuleErrors;
+
+use PHPStan\Rules\FileRuleError;
+
+class RuleErrorWithMessageAndFile implements FileRuleError
+{
+
+	/** @var string */
+	private $message;
+
+	/** @var string */
+	private $file;
+
+	public function __construct(string $message, string $file)
+	{
+		$this->message = $message;
+		$this->file = $file;
+	}
+
+	public function getMessage(): string
+	{
+		return $this->message;
+	}
+
+	public function getFile(): string
+	{
+		return $this->file;
+	}
+
+}

--- a/src/Rules/RuleErrors/RuleErrorWithMessageAndLineAndFile.php
+++ b/src/Rules/RuleErrors/RuleErrorWithMessageAndLineAndFile.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\RuleErrors;
+
+use PHPStan\Rules\FileRuleError;
+use PHPStan\Rules\LineRuleError;
+
+class RuleErrorWithMessageAndLineAndFile implements LineRuleError, FileRuleError
+{
+
+	/** @var string */
+	private $message;
+
+	/** @var int */
+	private $line;
+
+	/** @var string */
+	private $file;
+
+	public function __construct(string $message, int $line, string $file)
+	{
+		$this->message = $message;
+		$this->line = $line;
+		$this->file = $file;
+	}
+
+	public function getMessage(): string
+	{
+		return $this->message;
+	}
+
+	public function getLine(): int
+	{
+		return $this->line;
+	}
+
+	public function getFile(): string
+	{
+		return $this->file;
+	}
+
+}

--- a/tests/PHPStan/Rules/RuleErrorBuilderTest.php
+++ b/tests/PHPStan/Rules/RuleErrorBuilderTest.php
@@ -24,4 +24,26 @@ class RuleErrorBuilderTest extends TestCase
 		$this->assertSame(25, $ruleError->getLine());
 	}
 
+	public function testMessageAndFileAndBuild(): void
+	{
+		$builder = RuleErrorBuilder::message('Foo')->file('Bar.php');
+		$ruleError = $builder->build();
+		$this->assertSame('Foo', $ruleError->getMessage());
+
+		$this->assertInstanceOf(FileRuleError::class, $ruleError);
+		$this->assertSame('Bar.php', $ruleError->getFile());
+	}
+
+	public function testMessageAndLineAndFileAndBuild(): void
+	{
+		$builder = RuleErrorBuilder::message('Foo')->line(25)->file('Bar.php');
+		$ruleError = $builder->build();
+		$this->assertSame('Foo', $ruleError->getMessage());
+
+		$this->assertInstanceOf(LineRuleError::class, $ruleError);
+		$this->assertInstanceOf(FileRuleError::class, $ruleError);
+		$this->assertSame(25, $ruleError->getLine());
+		$this->assertSame('Bar.php', $ruleError->getFile());
+	}
+
 }


### PR DESCRIPTION
Adding more interfaces like this could lead to a combinatorial explosion, I know, but at least these three properties (message, line, file) should be covered. Plus I need it in my project.. 😊

Other option would be to maybe change the `PHPStan\Analyser\Error` interface and pass the `RuleError` in it, and let error formatter do all the work instead of the analyser. But that is a much bigger task that I didn't want to start without further discussion.