### PR TITLE
Only inherit phpDoc comments of non-private methods

### DIFF
--- a/src/PhpDoc/PhpDocBlock.php
+++ b/src/PhpDoc/PhpDocBlock.php
@@ -233,6 +233,9 @@ class PhpDocBlock
 			) {
 				return null;
 			}
+			if ($parentReflection->isPrivate()) {
+				return null;
+			}
 			if (
 				!$parentReflection->getDeclaringClass()->isTrait()
 				&& $parentReflection->getDeclaringClass()->getName() !== $classReflection->getName()

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -3576,6 +3576,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array<string>',
 				'$this->returnsStringArray()',
 			],
+			[
+				'mixed',
+				'$this->privateMethodWithPhpDoc()',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/method-phpDocs-inheritdoc.php
+++ b/tests/PHPStan/Analyser/data/method-phpDocs-inheritdoc.php
@@ -61,4 +61,12 @@ class FooInheritDocChild extends Foo
 		}
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	private function privateMethodWithPhpDoc()
+	{
+
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/methodPhpDocs-defined2.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs-defined2.php
@@ -86,4 +86,12 @@ abstract class FooParent extends FooParentParent implements FooInterface
 
 	}
 
+	/**
+	 * @return string[]
+	 */
+	private function privateMethodWithPhpDoc()
+	{
+
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/methodPhpDocs-implicitInheritance.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs-implicitInheritance.php
@@ -63,4 +63,9 @@ class FooPhpDocsImplicitInheritanceChild extends Foo
 
 	}
 
+	private function privateMethodWithPhpDoc()
+	{
+
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/methodPhpDocs-recursiveTrait.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs-recursiveTrait.php
@@ -82,4 +82,9 @@ class FooWithRecursiveTrait extends FooParent
 
 	}
 
+	private function privateMethodWithPhpDoc()
+	{
+
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/methodPhpDocs-trait.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs-trait.php
@@ -75,4 +75,9 @@ class FooWithTrait extends FooParent
 
 	}
 
+	private function privateMethodWithPhpDoc()
+	{
+
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/methodPhpDocs.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs.php
@@ -161,4 +161,9 @@ class Foo extends FooParent
 
 	}
 
+	private function privateMethodWithPhpDoc()
+	{
+
+	}
+
 }


### PR DESCRIPTION
Here's the second PR for #1828.