### PR TITLE
If phpstan crashed, it is not every time due to memory

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -148,11 +148,14 @@ class CommandHelper
 			if ($memoryLimitFileContents === false) {
 				throw new \PHPStan\ShouldNotHappenException();
 			}
-			$errorOutput->writeln('PHPStan crashed in the previous run probably because of excessive memory consumption.');
-			$errorOutput->writeln(sprintf('It consumed around %s of memory.', $memoryLimitFileContents));
+			$errorOutput->writeln('PHPStan crashed in the previous run. It may be because:');
+			$errorOutput->writeln('  - there was a fatal error while parsing:');
+			$errorOutput->writeln('    ex: a class is in the wrong namespace, or there is a linting error in one of you files.');
+			$errorOutput->writeln('  - an excessive memory consumption:');
+			$errorOutput->writeln(sprintf('    (It consumed around %s of memory.)', $memoryLimitFileContents));
 			$errorOutput->writeln('');
 			$errorOutput->writeln('');
-			$errorOutput->writeln('To avoid this issue, allow to use more memory with the --memory-limit option.');
+			$errorOutput->writeln('If the issue is related to memory consumtion, allow to use more memory with the --memory-limit option.');
 			@unlink($memoryLimitFile);
 		}
 

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -155,7 +155,7 @@ class CommandHelper
 			$errorOutput->writeln(sprintf('    (It consumed around %s of memory.)', $memoryLimitFileContents));
 			$errorOutput->writeln('');
 			$errorOutput->writeln('');
-			$errorOutput->writeln('If the issue is related to memory consumtion, allow to use more memory with the --memory-limit option.');
+			$errorOutput->writeln('If the issue is related to memory consumption, allow to use more memory with the --memory-limit option.');
 			@unlink($memoryLimitFile);
 		}
 


### PR DESCRIPTION
In fact, I encouter this "wrong" error message every time I made an error in one of my PHP file, but even in a big project (the phpstan progressbar show 665 files), it consumes "only"  ~210M