### PR TITLE
Fix: phpredis >=4.0.0 exists method returns int

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9216,7 +9216,7 @@ return [
 'Redis::evaluate' => ['mixed', 'script'=>'string', 'args='=>'array', 'numKeys='=>'int'],
 'Redis::evaluateSha' => ['', 'scriptSha'=>'string', 'args='=>'array', 'numKeys='=>'int'],
 'Redis::exec' => ['array'],
-'Redis::exists' => ['bool', 'key'=>'string'],
+'Redis::exists' => ['bool|int', 'key'=>'string'],
 'Redis::expire' => ['bool', 'key'=>'string', 'ttl'=>'int'],
 'Redis::expireAt' => ['bool', 'key'=>'string', 'expiry'=>'int'],
 'Redis::flushAll' => ['bool'],


### PR DESCRIPTION
`phpredis` >= 4.0.0 exists method returns `int`.
Docs: https://github.com/phpredis/phpredis#exists

Now I get error on level 4.