### PR TITLE
Improve replace function return type extension

### DIFF
--- a/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
@@ -68,7 +68,7 @@ class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctionRetur
 		$stringType = new StringType();
 		$arrayType = new ArrayType(new MixedType(), new MixedType());
 
-		$isStringSuperType = $stringType->isSuperTypeOf($subjectArgumentType);
+		$isStringSuperType = $stringType->isSuperTypeOf($subjectArgumentType->toString());
 		$isArraySuperType = $arrayType->isSuperTypeOf($subjectArgumentType);
 		$compareSuperTypes = $isStringSuperType->compareTo($isArraySuperType);
 		if ($compareSuperTypes === $isStringSuperType) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -7328,6 +7328,22 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'string',
 				'str_ireplace(\'.\', \':\', $intOrStringKey)',
 			],
+			[
+				'string',
+				'$expectedString3',
+			],
+			[
+				'array(\'a\' => string, \'b\' => string)',
+				'$expectedArray3',
+			],
+			[
+				'array<string>|string',
+				'$expectedArrayOrString3',
+			],
+			[
+				'(array<string>|string)',
+				'$expectedBenevolentArrayOrString3',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -7344,6 +7344,38 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'(array<string>|string)',
 				'$expectedBenevolentArrayOrString3',
 			],
+			[
+				'string',
+				'$expectedStringFromInt',
+			],
+			[
+				'string',
+				'$expectedStringFromStringConvertible',
+			],
+			[
+				'string|null',
+				'$anotherExpectedStringFromInt',
+			],
+			[
+				'string|null',
+				'$anotherExpectedStringFromStringConvertible',
+			],
+			[
+				'string|null',
+				'$expectedStringFromInt2',
+			],
+			[
+				'string|null',
+				'$expectedStringFromStringConvertible2',
+			],
+			[
+				'string',
+				'$anotherExpectedStringFromInt3',
+			],
+			[
+				'string',
+				'$anotherExpectedStringFromStringConvertible3',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/replaceFunctions.php
+++ b/tests/PHPStan/Analyser/data/replaceFunctions.php
@@ -2,10 +2,18 @@
 
 namespace ReplaceFunctions;
 
+class StringConvertible {
+    public function __toString(): string
+    {
+        return 'foo';
+    }
+}
+
 function ($mixed) {
 
 	$array = ['a' => 'a', 'b' => 'b'];
 	$string = 'str';
+	$int = 123;
 
 	$arrayOrString = [];
 	if (doFoo()) {
@@ -19,19 +27,27 @@ function ($mixed) {
 	$expectedArray = str_replace('aaa', 'bbb', $array);
 	$expectedArrayOrString = str_replace('aaa', 'bbb', $arrayOrString);
 	$expectedBenevolentArrayOrString = str_replace('aaa', 'bbb', $mixed);
+	$expectedStringFromInt = str_replace('aaa', 'bbb', $int);
+	$expectedStringFromStringConvertible = str_replace('aaa', 'bbb', new StringConvertible());
 
 	$anotherExpectedString = preg_replace('aaa', 'bbb', $string);
 	$anotherExpectedArray = preg_replace('aaa', 'bbb', $array);
 	$anotherExpectedArrayOrString = preg_replace('aaa', 'bbb', $arrayOrString);
+	$anotherExpectedStringFromInt = preg_replace('aaa', 'bbb', $int);
+	$anotherExpectedStringFromStringConvertible = preg_replace('aaa', 'bbb', new StringConvertible());
 
 	$expectedString2 = preg_replace_callback('aaa', function () {}, $string);
 	$expectedArray2 = preg_replace_callback('aaa', function () {}, $array);
 	$expectedArrayOrString2 = preg_replace_callback('aaa', function () {}, $arrayOrString);
+	$expectedStringFromInt2 = preg_replace_callback('aaa', function () {}, $int);
+	$expectedStringFromStringConvertible2 = preg_replace_callback('aaa', function () {}, new StringConvertible());
 
 	$expectedString3 = str_ireplace('aaa', 'bbb', $string);
 	$expectedArray3 = str_ireplace('aaa', 'bbb', $array);
 	$expectedArrayOrString3 = str_ireplace('aaa', 'bbb', $arrayOrString);
 	$expectedBenevolentArrayOrString3 = str_ireplace('aaa', 'bbb', $mixed);
+	$anotherExpectedStringFromInt3 = str_ireplace('aaa', 'bbb', $int);
+	$anotherExpectedStringFromStringConvertible3 = str_ireplace('aaa', 'bbb', $int);
 
 	/** @var Foo[] $arr */
 	$arr = doFoo();


### PR DESCRIPTION
The replace functions automatically convert the subject to type `string`, even in `strict_types` mode. Although I agree that it's better to be explicit with types PHPStan should still know that the resulting type will still be a `string` (or `string|null`).

There were also a few missing `assert`s for the executed lines in the **replaceFunctions.php**.