### PR TITLE
Added ability to suppress unmatched specific ignore error

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -235,7 +235,13 @@ class Analyser
 			file_put_contents($this->benchmarkFile, Json::encode($this->benchmarkData, Json::PRETTY));
 		}
 
-		$unmatchedIgnoredErrors = $this->ignoreErrors;
+		$unmatchedIgnoredErrors = array_values(array_filter($this->ignoreErrors, static function ($ignoreError): bool {
+			if (!is_array($ignoreError) || !isset($ignoreError['reportUnmatched'])) {
+				return true;
+			}
+
+			return $ignoreError['reportUnmatched'];
+		}));
 		$addErrors = [];
 		$errors = array_values(array_filter($errors, function (Error $error) use (&$unmatchedIgnoredErrors, &$addErrors): bool {
 			foreach ($this->ignoreErrors as $i => $ignore) {

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -127,6 +127,33 @@ class AnalyserTest extends \PHPStan\Testing\TestCase
 		$this->assertSame('No ending delimiter \'#\' found in pattern: #Fail\.', $result[1]);
 	}
 
+	public function testIgnoredErrorMessageUnmatchedIgnored(): void
+	{
+		$ignoreErrors = [
+			[
+				'message' => '#Fail\.#',
+				'path' => __DIR__ . '/data/not-existent-path.php',
+				'reportUnmatched' => true,
+			],
+		];
+		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/empty/empty.php', false);
+		$this->assertCount(1, $result);
+		$this->assertSame('Ignored error pattern #Fail\.# in path ' . __DIR__ . '/data/not-existent-path.php was not matched in reported errors.', $result[0]);
+	}
+
+	public function testIgnoredErrorMessageReportUnmatched(): void
+	{
+		$ignoreErrors = [
+			[
+				'message' => '#Fail\.#',
+				'path' => __DIR__ . '/data/not-existent-path.php',
+				'reportUnmatched' => false,
+			],
+		];
+		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/empty/empty.php', false);
+		$this->assertSame([], $result);
+	}
+
 	public function testReportMultipleParserErrorsAtOnce(): void
 	{
 		$result = $this->runAnalyser([], false, __DIR__ . '/data/multipleParseErrors.php', false);


### PR DESCRIPTION
Some ignore errors are environment specific, so on other environment than CI phpstan complains on unmatched ignore errors. Also this covers different major versions installed (eg. deps=low, deps=high; or when you support both php5 and php7).
If you do not want to suppress all unmatched ignore errors, this might become handy.

Usage:
```yaml
parameters:
    ignoreErrors:
        -
             message: '~^Constant PHP_WINDOWS_VERSION_MAJOR not found\.$~'
             path: '%currentWorkingDirectory%/src/File.php'
             reportUnmatched: false   # false for suppress, true (default) for report unmatched
        -
             message: '~^Instantiated class Symfony\\Component\\Console\\Terminal not found\.$~'
             path: '%currentWorkingDirectory%/src/File.php'
             reportUnmatched: false   # false for suppress, true (default) for report unmatched
```