### PR TITLE
#1974 allow first parameter of DOMDocument::saveXML to be null

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -1928,7 +1928,7 @@ return [
 'DOMDocument::save' => ['int', 'filename'=>'string', 'options='=>'int'],
 'DOMDocument::saveHTML' => ['string|false', 'node='=>'?DOMNode'],
 'DOMDocument::saveHTMLFile' => ['int', 'filename'=>'string'],
-'DOMDocument::saveXML' => ['string', 'node='=>'DOMNode', 'options='=>'int'],
+'DOMDocument::saveXML' => ['string', 'node='=>'?DOMNode', 'options='=>'int'],
 'DOMDocument::schemaValidate' => ['bool', 'filename'=>'string', 'flags='=>'int'],
 'DOMDocument::schemaValidateSource' => ['bool', 'source'=>'string', 'flags='=>'int'],
 'DOMDocument::validate' => ['bool'],


### PR DESCRIPTION
Closes #1974.