### PR TITLE
Add support for retrieving throws annotation descriptions

### DIFF
--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -1763,6 +1763,7 @@ class Scope implements ClassMemberAccessAnswerer
 	 * @param Type[] $phpDocParameterTypes
 	 * @param Type|null $phpDocReturnType
 	 * @param Type|null $throwType
+	 * @param array<array<\PHPStan\Type\Type|string>> $throwDescriptions
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
@@ -1773,6 +1774,7 @@ class Scope implements ClassMemberAccessAnswerer
 		array $phpDocParameterTypes,
 		?Type $phpDocReturnType,
 		?Type $throwType,
+		array $throwDescriptions,
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal
@@ -1792,6 +1794,7 @@ class Scope implements ClassMemberAccessAnswerer
 				$this->getFunctionType($classMethod->returnType, $classMethod->returnType === null, false),
 				$phpDocReturnType,
 				$throwType,
+				$throwDescriptions,
 				$isDeprecated,
 				$isInternal,
 				$isFinal
@@ -1825,6 +1828,7 @@ class Scope implements ClassMemberAccessAnswerer
 	 * @param Type[] $phpDocParameterTypes
 	 * @param Type|null $phpDocReturnType
 	 * @param Type|null $throwType
+	 * @param array<array<\PHPStan\Type\Type|string>> $throwDescriptions
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
@@ -1835,6 +1839,7 @@ class Scope implements ClassMemberAccessAnswerer
 		array $phpDocParameterTypes,
 		?Type $phpDocReturnType,
 		?Type $throwType,
+		array $throwDescriptions,
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal
@@ -1849,6 +1854,7 @@ class Scope implements ClassMemberAccessAnswerer
 				$this->getFunctionType($function->returnType, $function->returnType === null, false),
 				$phpDocReturnType,
 				$throwType,
+				$throwDescriptions,
 				$isDeprecated,
 				$isInternal,
 				$isFinal

--- a/src/PhpDoc/Tag/SingleThrowsTag.php
+++ b/src/PhpDoc/Tag/SingleThrowsTag.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDoc\Tag;
+
+use PHPStan\Type\Type;
+
+class SingleThrowsTag
+{
+
+	/** @var \PHPStan\Type\Type */
+	private $type;
+
+	/** @var string */
+	private $description;
+
+	public function __construct(Type $type, string $description)
+	{
+		$this->type = $type;
+		$this->description = $description;
+	}
+
+	public function getType(): Type
+	{
+		return $this->type;
+	}
+
+	public function getDescription(): string
+	{
+		return $this->description;
+	}
+
+	/**
+	 * @param mixed[] $properties
+	 * @return SingleThrowsTag
+	 */
+	public static function __set_state(array $properties): self
+	{
+		return new self(
+			$properties['type'],
+			$properties['description']
+		);
+	}
+
+}

--- a/src/PhpDoc/Tag/ThrowsTag.php
+++ b/src/PhpDoc/Tag/ThrowsTag.php
@@ -10,14 +10,30 @@ class ThrowsTag
 	/** @var \PHPStan\Type\Type */
 	private $type;
 
-	public function __construct(Type $type)
+	/** @var array<SingleThrowsTag> */
+	private $throwsTags;
+
+	/**
+	 * @param Type $type
+	 * @param array<SingleThrowsTag> $throwsTags
+	 */
+	public function __construct(Type $type, array $throwsTags)
 	{
 		$this->type = $type;
+		$this->throwsTags = $throwsTags;
 	}
 
 	public function getType(): Type
 	{
 		return $this->type;
+	}
+
+	/**
+	 * @return array<SingleThrowsTag>
+	 */
+	public function getThrowsTags(): array
+	{
+		return $this->throwsTags;
 	}
 
 	/**
@@ -27,7 +43,8 @@ class ThrowsTag
 	public static function __set_state(array $properties): self
 	{
 		return new self(
-			$properties['type']
+			$properties['type'],
+			$properties['throwsTags']
 		);
 	}
 

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -65,7 +65,7 @@ class TypeNodeResolver
 
 	public function getCacheKey(): string
 	{
-		$key = 'v50';
+		$key = 'v51';
 		foreach ($this->extensions as $extension) {
 			$key .= sprintf('-%s', $extension->getCacheKey());
 		}

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Reflection\Php;
 use PHPStan\Broker\Broker;
 use PHPStan\PhpDoc\PhpDocBlock;
 use PHPStan\PhpDoc\Tag\ParamTag;
+use PHPStan\PhpDoc\Tag\SingleThrowsTag;
 use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\BrokerAwareExtension;
@@ -320,6 +321,7 @@ class PhpClassReflectionExtension
 		$phpDocParameterTypes = [];
 		$phpDocReturnType = null;
 		$phpDocThrowType = null;
+		$phpDocThrowDescriptions = [];
 		$isDeprecated = false;
 		$isInternal = false;
 		$isFinal = false;
@@ -367,6 +369,15 @@ class PhpClassReflectionExtension
 				$isDeprecated = $resolvedPhpDoc->isDeprecated();
 				$isInternal = $resolvedPhpDoc->isInternal();
 				$isFinal = $resolvedPhpDoc->isFinal();
+
+				$throwsTag = $resolvedPhpDoc->getThrowsTag();
+
+				if ($throwsTag !== null) {
+					$phpDocThrowType = $throwsTag->getType();
+					$phpDocThrowDescriptions = array_map(static function (SingleThrowsTag $tag): array {
+						return [$tag->getType(), $tag->getDescription()];
+					}, $throwsTag->getThrowsTags());
+				}
 			}
 		}
 
@@ -384,6 +395,7 @@ class PhpClassReflectionExtension
 			$phpDocParameterTypes,
 			$phpDocReturnType,
 			$phpDocThrowType,
+			$phpDocThrowDescriptions,
 			$isDeprecated,
 			$isInternal,
 			$isFinal

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -36,6 +36,9 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 	/** @var \PHPStan\Type\Type|null */
 	private $throwType;
 
+	/** @var array<array<\PHPStan\Type\Type|string>> */
+	private $throwDescriptions;
+
 	/** @var bool */
 	private $isDeprecated;
 
@@ -56,6 +59,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 	 * @param Type $realReturnType
 	 * @param Type|null $phpDocReturnType
 	 * @param Type|null $throwType
+	 * @param array<array<\PHPStan\Type\Type|string>> $throwDescriptions
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
@@ -68,6 +72,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 		Type $realReturnType,
 		?Type $phpDocReturnType = null,
 		?Type $throwType = null,
+		array $throwDescriptions = [],
 		bool $isDeprecated = false,
 		bool $isInternal = false,
 		bool $isFinal = false
@@ -80,6 +85,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 		$this->realReturnType = $realReturnType;
 		$this->phpDocReturnType = $phpDocReturnType;
 		$this->throwType = $throwType;
+		$this->throwDescriptions = $throwDescriptions;
 		$this->isDeprecated = $isDeprecated;
 		$this->isInternal = $isInternal;
 		$this->isFinal = $isFinal;
@@ -194,6 +200,14 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 	public function getThrowType(): ?Type
 	{
 		return $this->throwType;
+	}
+
+	/**
+	 * @return array<array<\PHPStan\Type\Type|string>>
+	 */
+	public function getThrowDescriptions(): array
+	{
+		return $this->throwDescriptions;
 	}
 
 }

--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -29,6 +29,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 	 * @param Type $realReturnType
 	 * @param Type|null $phpDocReturnType
 	 * @param Type|null $throwType
+	 * @param array<array<\PHPStan\Type\Type|string>> $throwDescriptions
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
@@ -42,6 +43,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 		Type $realReturnType,
 		?Type $phpDocReturnType,
 		?Type $throwType,
+		array $throwDescriptions,
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal
@@ -55,6 +57,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 			$realReturnType,
 			$phpDocReturnType,
 			$throwType,
+			$throwDescriptions,
 			$isDeprecated,
 			$isInternal,
 			$isFinal

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -62,6 +62,9 @@ class PhpMethodReflection implements MethodReflection, DeprecatableReflection, I
 	/** @var \PHPStan\Type\Type|null */
 	private $phpDocThrowType;
 
+	/** @var array<array<\PHPStan\Type\Type|string>> $phpDocThrowDescriptions */
+	private $phpDocThrowDescriptions;
+
 	/** @var \PHPStan\Reflection\ParameterReflection[]|null */
 	private $parameters;
 
@@ -94,6 +97,7 @@ class PhpMethodReflection implements MethodReflection, DeprecatableReflection, I
 	 * @param \PHPStan\Type\Type[] $phpDocParameterTypes
 	 * @param Type|null $phpDocReturnType
 	 * @param Type|null $phpDocThrowType
+	 * @param array<array<\PHPStan\Type\Type|string>> $phpDocThrowDescriptions
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
@@ -109,6 +113,7 @@ class PhpMethodReflection implements MethodReflection, DeprecatableReflection, I
 		array $phpDocParameterTypes,
 		?Type $phpDocReturnType,
 		?Type $phpDocThrowType,
+		array $phpDocThrowDescriptions,
 		bool $isDeprecated = false,
 		bool $isInternal = false,
 		bool $isFinal = false
@@ -124,6 +129,7 @@ class PhpMethodReflection implements MethodReflection, DeprecatableReflection, I
 		$this->phpDocParameterTypes = $phpDocParameterTypes;
 		$this->phpDocReturnType = $phpDocReturnType;
 		$this->phpDocThrowType = $phpDocThrowType;
+		$this->phpDocThrowDescriptions = $phpDocThrowDescriptions;
 		$this->isDeprecated = $isDeprecated;
 		$this->isInternal = $isInternal;
 		$this->isFinal = $isFinal;
@@ -410,6 +416,14 @@ class PhpMethodReflection implements MethodReflection, DeprecatableReflection, I
 	public function getThrowType(): ?Type
 	{
 		return $this->phpDocThrowType;
+	}
+
+	/**
+	 * @return array<array<\PHPStan\Type\Type|string>>
+	 */
+	public function getThrowDescriptions(): array
+	{
+		return $this->phpDocThrowDescriptions;
 	}
 
 }

--- a/src/Reflection/Php/PhpMethodReflectionFactory.php
+++ b/src/Reflection/Php/PhpMethodReflectionFactory.php
@@ -15,6 +15,7 @@ interface PhpMethodReflectionFactory
 	 * @param \PHPStan\Type\Type[] $phpDocParameterTypes
 	 * @param \PHPStan\Type\Type|null $phpDocReturnType
 	 * @param \PHPStan\Type\Type|null $phpDocThrowType
+	 * @param array<array<\PHPStan\Type\Type|string>> $phpDocThrowDescriptions
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
@@ -27,6 +28,7 @@ interface PhpMethodReflectionFactory
 		array $phpDocParameterTypes,
 		?Type $phpDocReturnType,
 		?Type $phpDocThrowType,
+		array $phpDocThrowDescriptions,
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -104,6 +104,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 			 * @param Type[] $phpDocParameterTypes
 			 * @param Type|null $phpDocReturnType
 			 * @param Type|null $phpDocThrowType
+			 * @param array<array<\PHPStan\Type\Type|string>> $phpDocThrowDescriptions
 			 * @param bool $isDeprecated
 			 * @param bool $isInternal
 			 * @param bool $isFinal
@@ -116,6 +117,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 				array $phpDocParameterTypes,
 				?Type $phpDocReturnType,
 				?Type $phpDocThrowType,
+				array $phpDocThrowDescriptions,
 				bool $isDeprecated,
 				bool $isInternal,
 				bool $isFinal
@@ -132,6 +134,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 					$phpDocParameterTypes,
 					$phpDocReturnType,
 					$phpDocThrowType,
+					$phpDocThrowDescriptions,
 					$isDeprecated,
 					$isInternal,
 					$isFinal

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-throws.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-throws.php
@@ -8,7 +8,8 @@ function withoutThrows()
 }
 
 /**
- * @throws \RuntimeException
+ * @throws \RuntimeException Function description 1.
+ * @throws \RuntimeException Function description 2.
  */
 function throwsRuntime()
 {
@@ -24,7 +25,8 @@ class Foo
 	}
 
 	/**
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException Class instance method description 1.
+	 * @throws \RuntimeException Class instance method description 2.
 	 */
 	public function throwsRuntime()
 	{
@@ -32,7 +34,7 @@ class Foo
 	}
 
 	/**
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException Class static method description.
 	 */
 	public static function staticThrowsRuntime()
 	{
@@ -47,12 +49,13 @@ interface FooInterface
 	public function withoutThrows();
 
 	/**
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException Interface instance method description.
 	 */
 	public function throwsRuntime();
 
 	/**
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException Interface static method description 1.
+	 * @throws \RuntimeException Interface static method description 2.
 	 */
 	public static function staticThrowsRuntime();
 
@@ -67,7 +70,8 @@ trait FooTrait
 	}
 
 	/**
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException Trait instance method description 1.
+	 * @throws \RuntimeException Trait instance method description 2.
 	 */
 	public function throwsRuntime()
 	{
@@ -75,7 +79,7 @@ trait FooTrait
 	}
 
 	/**
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException Trait static method description.
 	 */
 	public static function staticThrowsRuntime()
 	{

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -2,6 +2,8 @@
 
 namespace PHPStan\Type;
 
+use PHPStan\PhpDoc\Tag\SingleThrowsTag;
+
 class FileTypeMapperTest extends \PHPStan\Testing\TestCase
 {
 
@@ -142,6 +144,26 @@ class FileTypeMapperTest extends \PHPStan\Testing\TestCase
 			'LogicException|RuntimeException',
 			$resolved->getThrowsTag()->getType()->describe(VerbosityLevel::precise())
 		);
+
+		$resolved = $fileTypeMapper->getResolvedPhpDoc($realpath, \ThrowsPhpDocs\Foo::class, null, '/**
+ * @throws RuntimeException Runtime description
+ * @throws LogicException Logic description
+ */');
+
+		$this->assertNotNull($resolved->getThrowsTag());
+		$this->assertSame(
+			'LogicException|RuntimeException',
+			$resolved->getThrowsTag()->getType()->describe(VerbosityLevel::precise())
+		);
+
+		$descriptions = array_map(static function (SingleThrowsTag $singleThrowsTag): string {
+			return $singleThrowsTag->getDescription();
+		}, $resolved->getThrowsTag()->getThrowsTags());
+
+		$this->assertCount(2, $descriptions);
+
+		$this->assertContains('Runtime description', $descriptions);
+		$this->assertContains('Logic description', $descriptions);
 	}
 
 	public function testFileWithCyclicPhpDocs(): void

--- a/tests/PHPStan/Type/data/throws-phpdocs.php
+++ b/tests/PHPStan/Type/data/throws-phpdocs.php
@@ -22,4 +22,10 @@ interface Foo
 	 * @throws LogicException
 	 */
 	public function throwRuntimeAndLogicException2();
+
+	/**
+	 * @throws RuntimeException Runtime description
+	 * @throws LogicException Logic description
+	 */
+	public function throwRuntimeAndLogicExceptionDescriptive();
 }


### PR DESCRIPTION
This PR adds support for retrieving throws annotations descriptions as suggested in https://github.com/phpstan/phpstan/issues/1868#issuecomment-460052717.

@ondrejmirtes I was wondering if we should add a new reflection interface to make easy to obtain the description in rules (perhaps `ThrowableReflectionWithPhpDocs`?). What do you suggest?