### PR TITLE
Fix path normalization of excludes_analyse rules

### DIFF
--- a/src/File/FileExcluder.php
+++ b/src/File/FileExcluder.php
@@ -22,7 +22,14 @@ class FileExcluder
 	)
 	{
 		$this->analyseExcludes = array_map(function (string $exclude) use ($fileHelper): string {
+			$len = strlen($exclude);
+			$trailingDirSeparator = ($len > 0 && in_array($exclude[$len - 1], ['\\', '/'], true));
+
 			$normalized = $fileHelper->normalizePath($exclude);
+
+			if ($trailingDirSeparator) {
+				$normalized .= DIRECTORY_SEPARATOR;
+			}
 
 			if ($this->isFnmatchPattern($normalized)) {
 				return $normalized;

--- a/tests/PHPStan/File/FileExcluderTest.php
+++ b/tests/PHPStan/File/FileExcluderTest.php
@@ -39,7 +39,7 @@ class FileExcluderTest extends \PHPStan\Testing\TestCase
 			],
 			[
 				__DIR__ . '\Foo\data\excluded-file.php',
-				[__DIR__ . '/*/data/*'],
+				[__DIR__ . '/*\/data/*'],
 				true,
 			],
 			[
@@ -96,6 +96,21 @@ class FileExcluderTest extends \PHPStan\Testing\TestCase
 				'c:\Data\data\parse-error.php',
 				['C:/Temp/*'],
 				false,
+			],
+			[
+				'c:\etc\phpstan\dummy-1.php',
+				['c:\etc\phpstan\\'],
+				true,
+			],
+			[
+				'c:\etc\phpstan-test\dummy-2.php',
+				['c:\etc\phpstan\\'],
+				false,
+			],
+			[
+				'c:\etc\phpstan-test\dummy-2.php',
+				['c:\etc\phpstan'],
+				true,
 			],
 		];
 	}
@@ -176,6 +191,21 @@ class FileExcluderTest extends \PHPStan\Testing\TestCase
 				'/home/myname/data/parse-error.php',
 				['/tmp/*'],
 				false,
+			],
+			[
+				'/etc/phpstan/dummy-1.php',
+				['/etc/phpstan/'],
+				true,
+			],
+			[
+				'/etc/phpstan-test/dummy-2.php',
+				['/etc/phpstan/'],
+				false,
+			],
+			[
+				'/etc/phpstan-test/dummy-2.php',
+				['/etc/phpstan'],
+				true,
 			],
 		];
 	}


### PR DESCRIPTION
Fix copy-pasted from https://github.com/phpstan/phpstan/pull/1822
tests from https://github.com/phpstan/phpstan/issues/1821 (fixes #1821)

I also added test for magic wildcard without wildcard - excluding "/phpstan" also excludes "/phpstan-asdf".