### PR TITLE
Update symfony versions from Tilde to Caret

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 		"nette/utils": "^2.4.5 || ^3.0",
 		"nikic/php-parser": "^4.0.2",
 		"phpstan/phpdoc-parser": "^0.3",
-		"symfony/console": "~3.2 || ~4.0",
-		"symfony/finder": "~3.2 || ~4.0"
+		"symfony/console": "^3.2 || ^4.0",
+		"symfony/finder": "^3.2 || ^4.0"
 	},
 	"conflict": {
 		"symfony/console": "3.4.16 || 4.1.5"


### PR DESCRIPTION
Does not limit the version to 3.2.*  / 4.0.* Releases...