### PR TITLE
Fix substr() return type

### DIFF
--- a/src/File/RelativePathHelper.php
+++ b/src/File/RelativePathHelper.php
@@ -96,7 +96,7 @@ class RelativePathHelper
 			$this->pathToTrim !== null
 			&& strpos($filename, $this->pathToTrim) === 0
 		) {
-			return ltrim(substr($filename, strlen($this->pathToTrim)), $this->directorySeparator);
+			return ltrim((string) substr($filename, strlen($this->pathToTrim)), $this->directorySeparator);
 		}
 
 		return $filename;

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -80,7 +80,7 @@ class PhpDocNodeResolver
 		$resolved = [];
 
 		foreach ($phpDocNode->getPropertyTagValues() as $tagValue) {
-			$propertyName = substr($tagValue->propertyName, 1);
+			$propertyName = (string) substr($tagValue->propertyName, 1);
 			$propertyType = !isset($resolved[$propertyName])
 				? $this->typeNodeResolver->resolve($tagValue->type, $nameScope)
 				: new MixedType();
@@ -93,7 +93,7 @@ class PhpDocNodeResolver
 		}
 
 		foreach ($phpDocNode->getPropertyReadTagValues() as $tagValue) {
-			$propertyName = substr($tagValue->propertyName, 1);
+			$propertyName = (string) substr($tagValue->propertyName, 1);
 			$propertyType = !isset($resolved[$propertyName])
 				? $this->typeNodeResolver->resolve($tagValue->type, $nameScope)
 				: new MixedType();
@@ -106,7 +106,7 @@ class PhpDocNodeResolver
 		}
 
 		foreach ($phpDocNode->getPropertyWriteTagValues() as $tagValue) {
-			$propertyName = substr($tagValue->propertyName, 1);
+			$propertyName = (string) substr($tagValue->propertyName, 1);
 			$propertyType = !isset($resolved[$propertyName])
 				? $this->typeNodeResolver->resolve($tagValue->type, $nameScope)
 				: new MixedType();
@@ -133,7 +133,7 @@ class PhpDocNodeResolver
 		foreach ($phpDocNode->getMethodTagValues() as $tagValue) {
 			$parameters = [];
 			foreach ($tagValue->parameters as $parameterNode) {
-				$parameterName = substr($parameterNode->parameterName, 1);
+				$parameterName = (string) substr($parameterNode->parameterName, 1);
 				$type = $parameterNode->type !== null ? $this->typeNodeResolver->resolve($parameterNode->type, $nameScope) : new MixedType();
 				if ($parameterNode->defaultValue instanceof ConstExprNullNode) {
 					$type = TypeCombinator::addNull($type);
@@ -167,7 +167,7 @@ class PhpDocNodeResolver
 	{
 		$resolved = [];
 		foreach ($phpDocNode->getParamTagValues() as $tagValue) {
-			$parameterName = substr($tagValue->parameterName, 1);
+			$parameterName = (string) substr($tagValue->parameterName, 1);
 			$parameterType = !isset($resolved[$parameterName])
 				? $this->typeNodeResolver->resolve($tagValue->type, $nameScope)
 				: new MixedType();

--- a/src/Reflection/SignatureMap/SignatureMapParser.php
+++ b/src/Reflection/SignatureMap/SignatureMapParser.php
@@ -56,7 +56,7 @@ class SignatureMapParser
 			$isNullable = false;
 			if (substr($part, 0, 1) === '?') {
 				$isNullable = true;
-				$part = substr($part, 1);
+				$part = (string) substr($part, 1);
 			}
 
 			if ($part === 'OCI-Lob' || $part === 'OCI-Collection') {

--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -11719,7 +11719,7 @@ return [
 'strtr' => ['string', 'str'=>'string', 'from'=>'string', 'to'=>'string'],
 'strtr\'1' => ['string', 'str'=>'string', 'replace_pairs'=>'array'],
 'strval' => ['string', 'var'=>'mixed'],
-'substr' => ['string', 'str'=>'string', 'start'=>'int', 'length='=>'int'],
+'substr' => ['string|false', 'str'=>'string', 'start'=>'int', 'length='=>'int'],
 'substr_compare' => ['int|false', 'main_str'=>'string', 'str'=>'string', 'offset'=>'int', 'length='=>'int', 'case_sensitivity='=>'bool'],
 'substr_count' => ['int', 'haystack'=>'string', 'needle'=>'string', 'offset='=>'int', 'length='=>'int'],
 'substr_replace' => ['string|array', 'str'=>'string|array', 'repl'=>'mixed', 'start'=>'mixed', 'length='=>'mixed'],

--- a/src/Rules/Operators/InvalidBinaryOperationRule.php
+++ b/src/Rules/Operators/InvalidBinaryOperationRule.php
@@ -106,7 +106,7 @@ class InvalidBinaryOperationRule implements \PHPStan\Rules\Rule
 			return [
 				sprintf(
 					'Binary operation "%s" between %s and %s results in an error.',
-					substr(substr($this->printer->prettyPrintExpr($newNode), strlen($leftName) + 2), 0, -(strlen($rightName) + 2)),
+					substr((string) substr($this->printer->prettyPrintExpr($newNode), strlen($leftName) + 2), 0, -(strlen($rightName) + 2)),
 					$scope->getType($left)->describe(VerbosityLevel::value()),
 					$scope->getType($right)->describe(VerbosityLevel::value())
 				),

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -93,7 +93,7 @@ class AnalyserTest extends \PHPStan\Testing\TestCase
 
 		$expectedPath = __DIR__;
 
-		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+		if (strtoupper((string) substr(PHP_OS, 0, 3)) === 'WIN') {
 			$expectedPath = str_replace('\\', '\\\\', $expectedPath);
 		}
 


### PR DESCRIPTION
See https://secure.php.net/substr.

It should be possible to write a dynamic return type extension (and avoid all those `(string)` casts), but I don't have time for that right now..