### PR TITLE
Added `isAbstract()` method to MethodReflection

### DIFF
--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -82,6 +82,11 @@ class AnnotationMethodReflection implements MethodReflection
 		return true;
 	}
 
+	public function isAbstract(): bool
+	{
+		return false;
+	}
+
 	public function getName(): string
 	{
 		return $this->name;

--- a/src/Reflection/Dummy/DummyMethodReflection.php
+++ b/src/Reflection/Dummy/DummyMethodReflection.php
@@ -41,6 +41,11 @@ class DummyMethodReflection implements MethodReflection
 		return true;
 	}
 
+	public function isAbstract(): bool
+	{
+		return false;
+	}
+
 	public function getName(): string
 	{
 		return $this->name;

--- a/src/Reflection/MethodReflection.php
+++ b/src/Reflection/MethodReflection.php
@@ -14,4 +14,6 @@ interface MethodReflection extends ClassMemberReflection
 	 */
 	public function getVariants(): array;
 
+	public function isAbstract(): bool;
+
 }

--- a/src/Reflection/Native/NativeMethodReflection.php
+++ b/src/Reflection/Native/NativeMethodReflection.php
@@ -66,6 +66,11 @@ class NativeMethodReflection implements MethodReflection, DeprecatableReflection
 		return $this->reflection->isPublic();
 	}
 
+	public function isAbstract(): bool
+	{
+		return $this->reflection->isAbstract();
+	}
+
 	public function getPrototype(): ClassMemberReflection
 	{
 		try {

--- a/src/Reflection/Php/BuiltinMethodReflection.php
+++ b/src/Reflection/Php/BuiltinMethodReflection.php
@@ -35,6 +35,8 @@ interface BuiltinMethodReflection
 
 	public function isPublic(): bool;
 
+	public function isAbstract(): bool;
+
 	public function getPrototype(): self;
 
 	public function isDeprecated(): bool;

--- a/src/Reflection/Php/FakeBuiltinMethodReflection.php
+++ b/src/Reflection/Php/FakeBuiltinMethodReflection.php
@@ -77,6 +77,11 @@ class FakeBuiltinMethodReflection implements BuiltinMethodReflection
 		return true;
 	}
 
+	public function isAbstract(): bool
+	{
+		return false;
+	}
+
 	public function getPrototype(): BuiltinMethodReflection
 	{
 		throw new \ReflectionException();

--- a/src/Reflection/Php/NativeBuiltinMethodReflection.php
+++ b/src/Reflection/Php/NativeBuiltinMethodReflection.php
@@ -70,6 +70,11 @@ class NativeBuiltinMethodReflection implements BuiltinMethodReflection
 		return $this->reflection->isPublic();
 	}
 
+	public function isAbstract(): bool
+	{
+		return $this->reflection->isAbstract();
+	}
+
 	public function getPrototype(): BuiltinMethodReflection
 	{
 		return new self($this->reflection->getPrototype());

--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -94,6 +94,11 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 		return $this->getClassMethod()->isPublic();
 	}
 
+	public function isAbstract(): bool
+	{
+		return $this->getClassMethod()->isAbstract();
+	}
+
 	protected function getReturnType(): Type
 	{
 		$name = strtolower($this->getName());

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -325,6 +325,11 @@ class PhpMethodReflection implements MethodReflection, DeprecatableReflection, I
 		return $this->reflection->isPublic();
 	}
 
+	public function isAbstract(): bool
+	{
+		return $this->reflection->isAbstract();
+	}
+
 	private function getReturnType(): Type
 	{
 		if ($this->returnType === null) {

--- a/src/Rules/Missing/MissingReturnRule.php
+++ b/src/Rules/Missing/MissingReturnRule.php
@@ -64,6 +64,10 @@ class MissingReturnRule implements Rule
 		} elseif ($scopeFunction !== null) {
 			$returnType = ParametersAcceptorSelector::selectSingle($scopeFunction->getVariants())->getReturnType();
 			if ($scopeFunction instanceof MethodReflection) {
+				if ($scopeFunction->isAbstract()) {
+					return [];
+				}
+
 				$description = sprintf('Method %s::%s()', $scopeFunction->getDeclaringClass()->getDisplayName(), $scopeFunction->getName());
 			} else {
 				$description = sprintf('Function %s()', $scopeFunction->getName());


### PR DESCRIPTION
Sometimes I need to ignore method analysis of abstract methods in my custom rules. Now the only way how to detect it is to use native reflection like `$classReflection->getNativeReflection()->getMethod($name)->isAbstract()` but it's not nice.