### PR TITLE
Use pntl_async_signals

### DIFF
--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -116,12 +116,6 @@ class AnalyseApplication
 		$bytes = memory_get_peak_usage(true);
 		$megabytes = ceil($bytes / 1024 / 1024);
 		file_put_contents($this->memoryLimitFile, sprintf('%d MB', $megabytes));
-
-		if (!function_exists('pcntl_signal_dispatch')) {
-			return;
-		}
-
-		pcntl_signal_dispatch();
 	}
 
 }

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -241,6 +241,7 @@ class CommandHelper
 			return;
 		}
 
+		pcntl_async_signals(true);
 		pcntl_signal(SIGINT, static function () use ($consoleStyle, $memoryLimitFile): void {
 			if (file_exists($memoryLimitFile)) {
 				@unlink($memoryLimitFile);


### PR DESCRIPTION
PHP 7.1 supports pntl_async_signals where you no longer need to call pcntl_signal_dispatch every loop in order to trigger the signal handler.

This means when the user aborts via Ctrl+C or similar PHPStan will now exit immediately, rather than continue to run in the background.

This will resolve #1979 