### PR TITLE
Add missing parameter to MongoDB ReadPreference

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -6755,7 +6755,7 @@ return [
 'MongoDB\Driver\ReadConcern::__construct' => ['void', 'level='=>'string'],
 'MongoDB\Driver\ReadConcern::bsonSerialize' => ['object'],
 'MongoDB\Driver\ReadConcern::getLevel' => ['null|string'],
-'MongoDB\Driver\ReadPreference::__construct' => ['void', 'readPreference'=>'string', 'tagSets='=>'array'],
+'MongoDB\Driver\ReadPreference::__construct' => ['void', 'readPreference'=>'string', 'tagSets='=>'array', 'options='=>'array'],
 'MongoDB\Driver\ReadPreference::bsonSerialize' => ['object'],
 'MongoDB\Driver\ReadPreference::getMode' => ['int'],
 'MongoDB\Driver\ReadPreference::getTagSets' => ['array'],


### PR DESCRIPTION
Adds the missing `$options` parameter to `MongoDB\Driver\ReadPreference::__construct` signature.

This parameter has existed since 1.2.0 version of the extension, see: https://www.php.net/manual/en/mongodb-driver-readpreference.construct.php