### PR TITLE
Handle inheritdoc without curly braces

### DIFF
--- a/src/PhpDoc/PhpDocBlock.php
+++ b/src/PhpDoc/PhpDocBlock.php
@@ -129,7 +129,7 @@ class PhpDocBlock
 		if (
 			(
 				$docComment === null
-				|| preg_match('#\{?@inheritdoc\}?#i', $docComment) > 0
+				|| preg_match('#@inheritdoc|{@inheritdoc}#i', $docComment) > 0
 			)
 			&& $broker->hasClass($class)
 		) {

--- a/src/PhpDoc/PhpDocBlock.php
+++ b/src/PhpDoc/PhpDocBlock.php
@@ -129,7 +129,7 @@ class PhpDocBlock
 		if (
 			(
 				$docComment === null
-				|| preg_match('#\{@inheritdoc\}#i', $docComment) > 0
+				|| preg_match('#\{?@inheritdoc\}?#i', $docComment) > 0
 			)
 			&& $broker->hasClass($class)
 		) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1888,10 +1888,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'PropertiesNamespace\Bar',
 				'$this->inheritDocProperty',
 			],
-            [
-                'PropertiesNamespace\Bar',
-                '$this->inheritDocWithoutCurlyBracesProperty',
-            ],
+			[
+				'PropertiesNamespace\Bar',
+				'$this->inheritDocWithoutCurlyBracesProperty',
+			],
 			[
 				'PropertiesNamespace\Bar',
 				'$this->implicitInheritDocProperty',

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1888,6 +1888,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'PropertiesNamespace\Bar',
 				'$this->inheritDocProperty',
 			],
+            [
+                'PropertiesNamespace\Bar',
+                '$this->inheritDocWithoutCurlyBracesProperty',
+            ],
 			[
 				'PropertiesNamespace\Bar',
 				'$this->implicitInheritDocProperty',
@@ -3668,6 +3672,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$this->phpDocVoidParentMethod()',
 			],
 			[
+				'MethodPhpDocsNamespace\Foo',
+				'$this->phpDocWithoutCurlyBracesVoidParentMethod()',
+			],
+			[
 				'array<string>',
 				'$this->returnsStringArray()',
 			],
@@ -3802,6 +3810,34 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		}
 		$this->assertTypes(
 			__DIR__ . '/data/method-phpDocs-inheritdoc.php',
+			$description,
+			$expression
+		);
+	}
+
+	/**
+	 * @dataProvider dataTypeFromFunctionPhpDocs
+	 * @dataProvider dataTypeFromMethodPhpDocs
+	 * @param string $description
+	 * @param string $expression
+	 * @param bool $replaceClass
+	 */
+	public function testTypeFromMethodPhpDocsInheritDocWithoutCurlyBraces(
+		string $description,
+		string $expression,
+		bool $replaceClass = true
+	): void
+	{
+		if ($replaceClass) {
+			$description = str_replace('$this(MethodPhpDocsNamespace\Foo)', '$this(MethodPhpDocsNamespace\FooInheritDocChild)', $description);
+			$description = str_replace('static(MethodPhpDocsNamespace\Foo)', 'static(MethodPhpDocsNamespace\FooInheritDocChild)', $description);
+			$description = str_replace('MethodPhpDocsNamespace\FooParent', 'MethodPhpDocsNamespace\Foo', $description);
+			if ($expression === '$inlineSelf') {
+				$description = 'MethodPhpDocsNamespace\FooInheritDocChild';
+			}
+		}
+		$this->assertTypes(
+			__DIR__ . '/data/method-phpDocs-inheritdoc-without-curly-braces.php',
 			$description,
 			$expression
 		);
@@ -6903,6 +6939,23 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		);
 	}
 
+	/**
+	 * @dataProvider dataInheritDocFromInterface
+	 * @param string $description
+	 * @param string $expression
+	 */
+	public function testInheritDocWithoutCurlyBracesFromInterface(
+		string $description,
+		string $expression
+	): void
+	{
+		$this->assertTypes(
+			__DIR__ . '/data/inheritdoc-without-curly-braces-from-interface.php',
+			$description,
+			$expression
+		);
+	}
+
 	public function dataInheritDocFromInterface2(): array
 	{
 		return [
@@ -6926,6 +6979,24 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		require_once __DIR__ . '/data/inheritdoc-from-interface2-definition.php';
 		$this->assertTypes(
 			__DIR__ . '/data/inheritdoc-from-interface2.php',
+			$description,
+			$expression
+		);
+	}
+
+	/**
+	 * @dataProvider dataInheritDocFromInterface2
+	 * @param string $description
+	 * @param string $expression
+	 */
+	public function testInheritDocWithoutCurlyBracesFromInterface2(
+		string $description,
+		string $expression
+	): void
+	{
+		require_once __DIR__ . '/data/inheritdoc-without-curly-braces-from-interface2-definition.php';
+		$this->assertTypes(
+			__DIR__ . '/data/inheritdoc-without-curly-braces-from-interface2.php',
 			$description,
 			$expression
 		);
@@ -6958,6 +7029,23 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		);
 	}
 
+	/**
+	 * @dataProvider dataInheritDocFromTrait
+	 * @param string $description
+	 * @param string $expression
+	 */
+	public function testInheritDocWithoutCurlyBracesFromTrait(
+		string $description,
+		string $expression
+	): void
+	{
+		$this->assertTypes(
+			__DIR__ . '/data/inheritdoc-without-curly-braces-from-trait.php',
+			$description,
+			$expression
+		);
+	}
+
 	public function dataInheritDocFromTrait2(): array
 	{
 		return [
@@ -6982,6 +7070,25 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		require_once __DIR__ . '/data/inheritdoc-from-trait2-definition2.php';
 		$this->assertTypes(
 			__DIR__ . '/data/inheritdoc-from-trait2.php',
+			$description,
+			$expression
+		);
+	}
+
+	/**
+	 * @dataProvider dataInheritDocFromTrait2
+	 * @param string $description
+	 * @param string $expression
+	 */
+	public function testInheritDocWithoutCurlyBracesFromTrait2(
+		string $description,
+		string $expression
+	): void
+	{
+		require_once __DIR__ . '/data/inheritdoc-without-curly-braces-from-trait2-definition.php';
+		require_once __DIR__ . '/data/inheritdoc-without-curly-braces-from-trait2-definition2.php';
+		$this->assertTypes(
+			__DIR__ . '/data/inheritdoc-without-curly-braces-from-trait2.php',
 			$description,
 			$expression
 		);

--- a/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-interface.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-interface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace InheritDocWithoutCurlyBracesFromInterface;
+
+class Foo extends FooParent implements FooInterface
+{
+
+	/**
+	 * @inheritdoc
+	 */
+	public function doFoo($string)
+	{
+		die;
+	}
+
+}
+
+abstract class FooParent
+{
+
+}
+
+interface FooInterface
+{
+
+	/**
+	 * @param string $string
+	 */
+	public function doFoo($string);
+
+}

--- a/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-interface2-definition.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-interface2-definition.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace InheritDocWithoutCurlyBracesFromInterface2;
+
+interface FooInterface extends BarInterface
+{
+}
+
+interface BarInterface
+{
+
+	/**
+	 * @param int $int
+	 */
+	public function doBar($int);
+
+}

--- a/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-interface2.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-interface2.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace InheritDocWithoutCurlyBracesFromInterface2;
+
+class Foo implements FooInterface
+{
+
+	/**
+	 * @inheritdoc
+	 */
+	public function doBar($int)
+	{
+		die;
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-trait.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-trait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace InheritDocWithoutCurlyBracesFromTrait;
+
+class Foo implements FooInterface
+{
+	use FooTrait;
+}
+
+trait FooTrait
+{
+
+	/**
+	 * @inheritdoc
+	 */
+	public function doFoo($string)
+	{
+		die;
+	}
+
+}
+
+interface FooInterface
+{
+
+	/**
+	 * @param string $string
+	 */
+	public function doFoo($string);
+
+}

--- a/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-trait2-definition.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-trait2-definition.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace InheritDocWithoutCurlyBracesFromTrait2;
+
+trait FooTrait
+{
+
+	/**
+	 * @param string $string
+	 */
+	public function doFoo($string)
+	{
+		die;
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-trait2-definition2.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-trait2-definition2.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace InheritDocWithoutCurlyBracesFromTrait2;
+
+class FooParent
+{
+	use FooTrait;
+}

--- a/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-trait2.php
+++ b/tests/PHPStan/Analyser/data/inheritdoc-without-curly-braces-from-trait2.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace InheritDocWithoutCurlyBracesFromTrait2;
+
+class Foo extends FooParent
+{
+
+	/**
+	 * @inheritdoc
+	 */
+	public function doFoo($string)
+	{
+		die;
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/method-phpDocs-inheritdoc-without-curly-braces.php
+++ b/tests/PHPStan/Analyser/data/method-phpDocs-inheritdoc-without-curly-braces.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MethodPhpDocsNamespace;
+
+use SomeNamespace\Amet as Dolor;
+use SomeNamespace\Consecteur;
+
+class FooInheritDocChild extends Foo
+{
+
+	/**
+	 * @inheritdoc
+	 */
+	public function doFoo(
+		$mixedParameter,
+		$unionTypeParameter,
+		$anotherMixedParameter,
+		$yetAnotherMixedParameter,
+		$integerParameter,
+		$anotherIntegerParameter,
+		$arrayParameterOne,
+		$arrayParameterOther,
+		$objectRelative,
+		$objectFullyQualified,
+		$objectUsed,
+		$nullableInteger,
+		$nullableObject,
+		$anotherNullableObject = null,
+		$selfType,
+		$staticType,
+		$nullType,
+		$barObject,
+		Bar $conflictedObject,
+		Bar $moreSpecifiedObject,
+		$resource,
+		$yetAnotherAnotherMixedParameter,
+		$yetAnotherAnotherAnotherMixedParameter,
+		$yetAnotherAnotherAnotherAnotherMixedParameter,
+		$voidParameter,
+		$useWithoutAlias,
+		$true,
+		$false,
+		bool $boolTrue,
+		bool $boolFalse,
+		bool $trueBoolean,
+		$parameterWithDefaultValueFalse = false,
+		$objectWithoutNativeTypehint,
+		object $objectWithNativeTypehint
+	)
+	{
+		$parent = new FooParent();
+		$differentInstance = new Foo();
+
+		/** @var self $inlineSelf */
+		$inlineSelf = doFoo();
+
+		/** @var Bar $inlineBar */
+		$inlineBar = doFoo();
+		foreach ($moreSpecifiedObject->doFluentUnionIterable() as $fluentUnionIterableBaz) {
+			die;
+		}
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	private function privateMethodWithPhpDoc()
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/methodPhpDocs-defined2.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs-defined2.php
@@ -25,6 +25,14 @@ class FooParentParent
 
 	}
 
+	/**
+	 * @return void
+	 */
+	public function phpDocWithoutCurlyBracesVoidParentMethod()
+	{
+
+	}
+
 }
 
 abstract class FooParent extends FooParentParent implements FooInterface
@@ -82,6 +90,14 @@ abstract class FooParent extends FooParentParent implements FooInterface
 	 * {@inheritDoc}
 	 */
 	public function phpDocVoidParentMethod()
+	{
+
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function phpDocWithoutCurlyBracesVoidParentMethod()
 	{
 
 	}

--- a/tests/PHPStan/Analyser/data/methodPhpDocs-recursiveTrait.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs-recursiveTrait.php
@@ -74,6 +74,11 @@ class FooWithRecursiveTrait extends FooParent
 
 	}
 
+	public function phpDocWithoutCurlyBracesVoidParentMethod(): self
+	{
+
+	}
+
 	/**
 	 * @return string[]
 	 */

--- a/tests/PHPStan/Analyser/data/methodPhpDocs-trait.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs-trait.php
@@ -67,6 +67,11 @@ class FooWithTrait extends FooParent
 
 	}
 
+	public function phpDocWithoutCurlyBracesVoidParentMethod(): self
+	{
+
+	}
+
 	/**
 	 * @return string[]
 	 */

--- a/tests/PHPStan/Analyser/data/methodPhpDocs.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs.php
@@ -153,6 +153,11 @@ class Foo extends FooParent
 
 	}
 
+	public function phpDocWithoutCurlyBracesVoidParentMethod(): self
+	{
+
+	}
+
 	/**
 	 * @return string[]
 	 */

--- a/tests/PHPStan/Analyser/data/properties-defined.php
+++ b/tests/PHPStan/Analyser/data/properties-defined.php
@@ -25,6 +25,11 @@ class Bar extends DOMDocument
 	/**
 	 * @var self
 	 */
+	protected $inheritDocWithoutCurlyBracesProperty;
+
+	/**
+	 * @var self
+	 */
 	protected $implicitInheritDocProperty;
 
 	public function doBar(): Self

--- a/tests/PHPStan/Analyser/data/properties.php
+++ b/tests/PHPStan/Analyser/data/properties.php
@@ -125,6 +125,11 @@ abstract class Foo extends Bar
 	 */
 	protected $inheritDocProperty;
 
+	/**
+	 * @inheritDoc
+	 */
+	protected $inheritDocWithoutCurlyBracesProperty;
+
 	protected $implicitInheritDocProperty;
 
 	public function doFoo()

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -808,6 +808,23 @@ class CallMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 		]);
 	}
 
+	public function testCallMethodWithInheritDocWithoutBraces(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/calling-method-with-inheritdoc-without-curly-braces.php'], [
+			[
+				'Parameter #1 $i of method MethodWithInheritDoc\Baz::doFoo() expects int, string given.',
+				65,
+			],
+			[
+				'Parameter #1 $str of method MethodWithInheritDoc\Foo::doBar() expects string, int given.',
+				67,
+			],
+		]);
+	}
+
 	public function testCallMethodWithPhpDocsImplicitInheritance(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -808,18 +808,18 @@ class CallMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 		]);
 	}
 
-	public function testCallMethodWithInheritDocWithoutBraces(): void
+	public function testCallMethodWithInheritDocWithoutCurlyBraces(): void
 	{
 		$this->checkThisOnly = false;
 		$this->checkNullables = true;
 		$this->checkUnionTypes = true;
 		$this->analyse([__DIR__ . '/data/calling-method-with-inheritdoc-without-curly-braces.php'], [
 			[
-				'Parameter #1 $i of method MethodWithInheritDoc\Baz::doFoo() expects int, string given.',
+				'Parameter #1 $i of method MethodWithInheritDocWithoutCurlyBraces\Baz::doFoo() expects int, string given.',
 				65,
 			],
 			[
-				'Parameter #1 $str of method MethodWithInheritDoc\Foo::doBar() expects string, int given.',
+				'Parameter #1 $str of method MethodWithInheritDocWithoutCurlyBraces\Foo::doBar() expects string, int given.',
 				67,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/data/calling-method-with-inheritdoc-without-curly-braces.php
+++ b/tests/PHPStan/Rules/Methods/data/calling-method-with-inheritdoc-without-curly-braces.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MethodWithInheritDocWithoutCurlyBraces;
+
+interface FooInterface
+{
+
+	/**
+	 * @param string $str
+	 */
+	public function doBar($str);
+
+}
+
+class Foo implements FooInterface
+{
+
+	/**
+	 * @param int $i
+	 */
+	public function doFoo($i)
+	{
+
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function doBar($str)
+	{
+
+	}
+
+}
+
+class Bar extends Foo
+{
+
+	/**
+	 * @inheritDoc
+	 */
+	public function doFoo($i)
+	{
+
+	}
+
+}
+
+class Baz extends Bar
+{
+
+	/**
+	 * @inheritDoc
+	 */
+	public function doFoo($i)
+	{
+
+	}
+
+}
+
+function () {
+	$baz = new Baz();
+	$baz->doFoo(1);
+	$baz->doFoo('1');
+	$baz->doBar('1');
+	$baz->doBar(1);
+};


### PR DESCRIPTION
`PhpDocBlock` now handles `@inheritdoc` along with `{@inheritdoc}`.

This resolves https://github.com/phpstan/phpstan/issues/1332

Let me know if this change is acceptable.