### PR TITLE
Revert "null is also scalar"

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -65,7 +65,7 @@ class TypeNodeResolver
 
 	public function getCacheKey(): string
 	{
-		$key = 'v51';
+		$key = 'v50';
 		foreach ($this->extensions as $extension) {
 			$key .= sprintf('-%s', $extension->getCacheKey());
 		}
@@ -146,7 +146,6 @@ class TypeNodeResolver
 					new FloatType(),
 					new StringType(),
 					new BooleanType(),
-					new NullType(),
 				]);
 
 			case 'number':


### PR DESCRIPTION
This reverts commit c7ab8fb08273165ae7d3309b85bae256bce68bf7.

Null is not scalar as per PHP's definition, as pointed out by @voku in c7ab8fb08273165ae7d3309b85bae256bce68bf7.

https://www.php.net/manual/en/function.is-scalar.php
> Note:
> is_scalar() does not consider NULL to be scalar.
