### PR TITLE
InvalidThrowsPhpDocValueRule: allow `@throws void` phpDoc

### DIFF
--- a/src/Rules/PhpDoc/InvalidThrowsPhpDocValueRule.php
+++ b/src/Rules/PhpDoc/InvalidThrowsPhpDocValueRule.php
@@ -49,7 +49,7 @@ class InvalidThrowsPhpDocValueRule implements \PHPStan\Rules\Rule
 		}
 
 		$phpDocThrowsType = $resolvedPhpDoc->getThrowsTag()->getType();
-		if ((new VoidType())->accepts($phpDocThrowsType, $scope->isDeclareStrictTypes())->yes()) {
+		if ((new VoidType())->isSuperTypeOf($phpDocThrowsType)->yes()) {
 			return [];
 		}
 

--- a/src/Rules/PhpDoc/InvalidThrowsPhpDocValueRule.php
+++ b/src/Rules/PhpDoc/InvalidThrowsPhpDocValueRule.php
@@ -7,6 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
+use PHPStan\Type\VoidType;
 
 class InvalidThrowsPhpDocValueRule implements \PHPStan\Rules\Rule
 {
@@ -48,6 +49,9 @@ class InvalidThrowsPhpDocValueRule implements \PHPStan\Rules\Rule
 		}
 
 		$phpDocThrowsType = $resolvedPhpDoc->getThrowsTag()->getType();
+		if ((new VoidType())->accepts($phpDocThrowsType, $scope->isDeclareStrictTypes())->yes()) {
+			return [];
+		}
 
 		$isThrowsSuperType = (new ObjectType(\Throwable::class))->isSuperTypeOf($phpDocThrowsType);
 		if ($isThrowsSuperType->yes()) {

--- a/tests/PHPStan/Rules/PhpDoc/InvalidThrowsPhpDocValueRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidThrowsPhpDocValueRuleTest.php
@@ -37,6 +37,14 @@ class InvalidThrowsPhpDocValueRuleTest extends \PHPStan\Testing\RuleTestCase
 				'PHPDoc tag @throws with type DateTimeImmutable&IteratorAggregate is not subtype of Throwable',
 				82,
 			],
+			[
+				'PHPDoc tag @throws with type Throwable|void is not subtype of Throwable',
+				96,
+			],
+			[
+				'PHPDoc tag @throws with type stdClass|void is not subtype of Throwable',
+				103,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-throws.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-throws.php
@@ -82,3 +82,10 @@ function notThrowableInUnionThrows()
 function notThrowableInIntersectThrows()
 {
 }
+
+/**
+ * @throws void
+ */
+function voidThrows()
+{
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-throws.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-throws.php
@@ -89,3 +89,17 @@ function notThrowableInIntersectThrows()
 function voidThrows()
 {
 }
+
+/**
+ * @throws \Throwable|void
+ */
+function voidUnionThrows()
+{
+}
+
+/**
+ * @throws \stdClass|void
+ */
+function voidUnionWithNotThrowableThrows()
+{
+}


### PR DESCRIPTION
Sometimes I need to say my method is throwing nothing (`@throws void`). Because of since v0.11.x phpDoc is inherited from the parent if phpDoc is not present, there is no way how to say my implementation is not throwing anything.

Example (https://phpstan.org/r/65a8eada-13c9-4f91-a53e-4405dc695acb):

```php
<?php declare(strict_types = 1);

interface Foo
{

	/**
	 * @throws \RuntimeException
	 */
	public function sayHello(string $message): void;

}

class Bar implements Foo
{

	public function sayHello(string $message): void
	{
		echo $message;
	}

}

class Baz implements Foo
{

	/**
	 * @throws void
	 */
	public function sayHello(string $message): void
	{
		echo $message;
	}

}
``` 
```
+----------------------------------------------------------------------+
| Line | test.php                                                      |
+----------------------------------------------------------------------+
| 29   | PHPDoc tag @throws with type void is not subtype of Throwable |
+----------------------------------------------------------------------+
```

Why I need it? Try to use [`pepakriz/phpstan-exception-rules`](https://github.com/pepakriz/phpstan-exception-rules). There is a rule which detects unused `@throws` annotations and it leads to en error on `Bar` method implementation - because there is no `RuntimeException` in implementation.