### PR TITLE
Fix NonEmptyArrayType in TypeUtils::getArrays

### DIFF
--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type;
 
 use PHPStan\Type\Accessory\HasPropertyType;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 
@@ -132,6 +133,10 @@ class TypeUtils
 		if ($type instanceof UnionType) {
 			$matchingTypes = [];
 			foreach ($type->getTypes() as $innerType) {
+				if ($typeClass === ArrayType::class && $innerType instanceof NonEmptyArrayType) {
+					continue;
+				}
+
 				if (!$innerType instanceof $typeClass) {
 					if ($stopOnUnmatched) {
 						return [];
@@ -149,6 +154,10 @@ class TypeUtils
 		if ($inspectIntersections && $type instanceof IntersectionType) {
 			$matchingTypes = [];
 			foreach ($type->getTypes() as $innerType) {
+				if ($typeClass === ArrayType::class && $innerType instanceof NonEmptyArrayType) {
+					continue;
+				}
+
 				if (!$innerType instanceof $typeClass) {
 					if ($stopOnUnmatched) {
 						return [];

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -2,8 +2,8 @@
 
 namespace PHPStan\Type;
 
+use PHPStan\Type\Accessory\AccessoryType;
 use PHPStan\Type\Accessory\HasPropertyType;
-use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 
@@ -133,7 +133,7 @@ class TypeUtils
 		if ($type instanceof UnionType) {
 			$matchingTypes = [];
 			foreach ($type->getTypes() as $innerType) {
-				if ($typeClass === ArrayType::class && $innerType instanceof NonEmptyArrayType) {
+				if ($typeClass === ArrayType::class && $innerType instanceof AccessoryType) {
 					continue;
 				}
 
@@ -154,7 +154,7 @@ class TypeUtils
 		if ($inspectIntersections && $type instanceof IntersectionType) {
 			$matchingTypes = [];
 			foreach ($type->getTypes() as $innerType) {
-				if ($typeClass === ArrayType::class && $innerType instanceof NonEmptyArrayType) {
+				if ($typeClass === ArrayType::class && $innerType instanceof AccessoryType) {
 					continue;
 				}
 

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 
@@ -86,6 +87,22 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 					]),
 				]),
 				TrinaryLogic::createYes(),
+			],
+			[
+				new ArrayType(new IntegerType(), new IntegerType()),
+				new IntersectionType([
+					new ArrayType(new MixedType(), new MixedType()),
+					new NonEmptyArrayType(),
+				]),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new ArrayType(new IntegerType(), new IntegerType()),
+				new IntersectionType([
+					new ArrayType(new IntegerType(), new StringType()),
+					new NonEmptyArrayType(),
+				]),
+				TrinaryLogic::createNo(),
 			],
 		];
 	}

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Accessory\HasOffsetType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -93,6 +94,7 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 				new IntersectionType([
 					new ArrayType(new MixedType(), new MixedType()),
 					new NonEmptyArrayType(),
+					new HasOffsetType(new IntegerType()),
 				]),
 				TrinaryLogic::createYes(),
 			],


### PR DESCRIPTION
Issue https://github.com/phpstan/phpstan/issues/2039

The problem was 

```
	public static function getArrays(Type $type): array
	{
		return self::map(ArrayType::class, $type, true);
	}
```
and
```

				if (!$innerType instanceof $typeClass) {
					if ($stopOnUnmatched) {
						return [];
					}

					continue;
				}
```

NonEmptyArrayType was not an instance of ArrayType, so the return value always be []

I added code to skip typeClass check in that case.
```
				if ($typeClass === ArrayType::class && $innerType instanceof NonEmptyArrayType) {
					continue;
				}
```