### PR TITLE
Fix array_fill analysis performance

### DIFF
--- a/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
@@ -6,14 +6,18 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Type;
 
 class ArrayFillFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
+
+	private const MAX_SIZE_USE_CONSTANT_ARRAY = 100;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -26,32 +30,43 @@ class ArrayFillFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunct
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 
-		$valueType = $scope->getType($functionCall->args[2]->value);
 		$startIndexType = $scope->getType($functionCall->args[0]->value);
-		if (!$startIndexType instanceof ConstantIntegerType) {
-			return new ArrayType(new IntegerType(), $valueType);
-		}
-
 		$numberType = $scope->getType($functionCall->args[1]->value);
-		if (!$numberType instanceof ConstantIntegerType) {
-			return new ArrayType(new IntegerType(), $valueType);
-		}
+		$valueType = $scope->getType($functionCall->args[2]->value);
 
-		$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-		$nextIndex = $startIndexType->getValue();
-		for ($i = 0; $i < $numberType->getValue(); $i++) {
-			$arrayBuilder->setOffsetValueType(
-				new ConstantIntegerType($nextIndex),
-				$valueType
-			);
-			if ($nextIndex < 0) {
-				$nextIndex = 0;
-			} else {
-				$nextIndex++;
+		if (
+			$startIndexType instanceof ConstantIntegerType
+			&& $numberType instanceof ConstantIntegerType
+			&& $numberType->getValue() <= static::MAX_SIZE_USE_CONSTANT_ARRAY
+		) {
+			$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
+			$nextIndex = $startIndexType->getValue();
+			for ($i = 0; $i < $numberType->getValue(); $i++) {
+				$arrayBuilder->setOffsetValueType(
+					new ConstantIntegerType($nextIndex),
+					$valueType
+				);
+				if ($nextIndex < 0) {
+					$nextIndex = 0;
+				} else {
+					$nextIndex++;
+				}
 			}
+
+			return $arrayBuilder->getArray();
 		}
 
-		return $arrayBuilder->getArray();
+		if (
+			$numberType instanceof ConstantIntegerType
+			&& $numberType->getValue() > 0
+		) {
+			return new IntersectionType([
+				new ArrayType(new IntegerType(), $valueType),
+				new NonEmptyArrayType(),
+			]);
+		}
+
+		return new ArrayType(new IntegerType(), $valueType);
 	}
 
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4927,11 +4927,15 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array_fill(5, 6, \'banana\')',
 			],
 			[
+				'array<int, \'apple\'>&nonEmpty',
+				'array_fill(0, 101, \'apple\')',
+			],
+			[
 				'array(-2 => \'pear\', 0 => \'pear\', 1 => \'pear\', 2 => \'pear\')',
 				'array_fill(-2, 4, \'pear\')',
 			],
 			[
-				'array<int, stdClass>',
+				'array<int, stdClass>&nonEmpty',
 				'array_fill($integer, 2, new \stdClass())',
 			],
 			[


### PR DESCRIPTION
Attempt to fix issue #1275 

Still learning the project so no idea if this is a decent workaround.

The original issue is caused by PHPStan getting stuck building a ConstantArrayType with all the items generated by the analysed array_fill.

This fix provides a fallback to the generic ArrayType if the array size is larger than (the magic number) 100.