### PR TITLE
documentElement can be null

### DIFF
--- a/src/Reflection/PhpDefect/PhpDefectClassReflectionExtension.php
+++ b/src/Reflection/PhpDefect/PhpDefectClassReflectionExtension.php
@@ -53,7 +53,7 @@ class PhpDefectClassReflectionExtension implements PropertiesClassReflectionExte
 			'actualEncoding' => 'string',
 			'config' => 'DOMConfiguration',
 			'doctype' => 'DOMDocumentType',
-			'documentElement' => 'DOMElement',
+			'documentElement' => 'DOMElement|null',
 			'documentURI' => 'string',
 			'encoding' => 'string',
 			'formatOutput' => 'bool',

--- a/tests/PHPStan/Reflection/PhpDefect/PhpDefectClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/PhpDefect/PhpDefectClassReflectionExtensionTest.php
@@ -201,7 +201,7 @@ class PhpDefectClassReflectionExtensionTest extends \PHPStan\Testing\TestCase
 					'actualEncoding' => 'string',
 					'config' => \DOMConfiguration::class,
 					'doctype' => \DOMDocumentType::class,
-					'documentElement' => \DOMElement::class,
+					'documentElement' => 'DOMElement|null',
 					'documentURI' => 'string',
 					'encoding' => 'string',
 					'formatOutput' => 'bool',


### PR DESCRIPTION
By default `documentElement` is null when creating a new `DOMDocument`. See https://3v4l.org/HXsGV.