### PR TITLE
PoC: Analysis-based testing

### DIFF
--- a/src/Testing/AnalysisBased/TestBuilder.php
+++ b/src/Testing/AnalysisBased/TestBuilder.php
@@ -1,0 +1,541 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Testing\AnalysisBased;
+
+use PhpParser\PrettyPrinter\Standard;
+use PHPStan\Analyser\Analyser;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\ScopeFactory;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierFactory;
+use PHPStan\Broker\AnonymousClassNameHelper;
+use PHPStan\Broker\Broker;
+use PHPStan\Broker\BrokerFactory;
+use PHPStan\Cache\Cache;
+use PHPStan\Cache\MemoryCacheStorage;
+use PHPStan\DependencyInjection\Container;
+use PHPStan\File\FileHelper;
+use PHPStan\File\FuzzyRelativePathHelper;
+use PHPStan\File\RelativePathHelper;
+use PHPStan\Parser\FunctionCallStatementFinder;
+use PHPStan\Parser\Parser;
+use PHPStan\PhpDoc\PhpDocStringResolver;
+use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
+use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionReflectionFactory;
+use PHPStan\Reflection\Php\PhpClassReflectionExtension;
+use PHPStan\Reflection\Php\PhpFunctionReflection;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
+use PHPStan\Reflection\Php\UniversalObjectCratesClassReflectionExtension;
+use PHPStan\Reflection\PhpDefect\PhpDefectClassReflectionExtension;
+use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
+use PHPStan\Rules\Registry;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\TestCase;
+use PHPStan\Type\FileTypeMapper;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
+use PHPStan\Type\Type;
+use PHPUnit\Framework\Assert;
+
+class TestBuilder
+{
+
+	/** @var \PHPStan\Analyser\Analyser|null */
+	private $analyser;
+
+	/** @var UtilsRule */
+	private $utilsRule;
+
+	/** @var Rule[] */
+	private $rules = [];
+
+	/** @var MethodTypeSpecifyingExtension[] */
+	private $methodTypeSpecifyingExtensions = [];
+
+	/** @var StaticMethodTypeSpecifyingExtension[] */
+	private $staticMethodTypeSpecifyingExtensions = [];
+
+	/** @var TypeNodeResolverExtension[] */
+	private $typeNodeResolverExtensions = [];
+
+	/** @var \PHPStan\Type\DynamicMethodReturnTypeExtension[] */
+	private $dynamicMethodReturnTypeExtensions = [];
+
+	/** @var \PHPStan\Type\DynamicStaticMethodReturnTypeExtension[] */
+	private $dynamicStaticMethodReturnTypeExtensions = [];
+
+	/** @var \PHPStan\Type\DynamicFunctionReturnTypeExtension[] */
+	private $dynamicFunctionReturnTypeExtensions = [];
+
+	/** @var bool */
+	private $shouldPolluteScopeWithLoopInitialAssignments = false;
+
+	/** @var bool */
+	private $shouldPolluteCatchScopeWithTryAssignments = false;
+
+	/** @var bool */
+	private $shouldPolluteScopeWithAlwaysIterableForeach = true;
+
+	/** @var Cache */
+	private $cache;
+
+	public function __construct(Cache $cache)
+	{
+		$this->utilsRule = new UtilsRule();
+		$this->cache = $cache;
+	}
+
+	/**
+	 * @param Rule[] $rules
+	 */
+	public function setRules(array $rules): self
+	{
+		$this->rules = $rules;
+
+		return $this;
+	}
+
+	/**
+	 * @param MethodTypeSpecifyingExtension[] $methodTypeSpecifyingExtensions
+	 */
+	public function setMethodTypeSpecifyingExtensions(array $methodTypeSpecifyingExtensions): self
+	{
+		$this->methodTypeSpecifyingExtensions = $methodTypeSpecifyingExtensions;
+
+		return $this;
+	}
+
+	/**
+	 * @param StaticMethodTypeSpecifyingExtension[] $staticMethodTypeSpecifyingExtensions
+	 */
+	public function setStaticMethodTypeSpecifyingExtensions(array $staticMethodTypeSpecifyingExtensions): self
+	{
+		$this->staticMethodTypeSpecifyingExtensions = $staticMethodTypeSpecifyingExtensions;
+
+		return $this;
+	}
+
+	/**
+	 * @param TypeNodeResolverExtension[] $typeNodeResolverExtensions
+	 */
+	public function setTypeNodeResolverExtensions(array $typeNodeResolverExtensions): self
+	{
+		$this->typeNodeResolverExtensions = $typeNodeResolverExtensions;
+
+		return $this;
+	}
+
+	/**
+	 * @param \PHPStan\Type\DynamicMethodReturnTypeExtension[] $dynamicMethodReturnTypeExtensions
+	 */
+	public function setDynamicMethodReturnTypeExtensions(array $dynamicMethodReturnTypeExtensions): self
+	{
+		$this->dynamicMethodReturnTypeExtensions = $dynamicMethodReturnTypeExtensions;
+
+		return $this;
+	}
+
+	/**
+	 * @param \PHPStan\Type\DynamicStaticMethodReturnTypeExtension[] $dynamicStaticMethodReturnTypeExtensions
+	 */
+	public function setDynamicStaticMethodReturnTypeExtensions(array $dynamicStaticMethodReturnTypeExtensions): self
+	{
+		$this->dynamicStaticMethodReturnTypeExtensions = $dynamicStaticMethodReturnTypeExtensions;
+
+		return $this;
+	}
+
+	/**
+	 * @param \PHPStan\Type\DynamicFunctionReturnTypeExtension[] $dynamicFunctionReturnTypeExtensions
+	 */
+	public function setDynamicFunctionReturnTypeExtensions(array $dynamicFunctionReturnTypeExtensions): self
+	{
+		$this->dynamicFunctionReturnTypeExtensions = $dynamicFunctionReturnTypeExtensions;
+
+		return $this;
+	}
+
+	public function setShouldPolluteScopeWithLoopInitialAssignments(bool $shouldPolluteScopeWithLoopInitialAssignments): self
+	{
+		$this->shouldPolluteScopeWithLoopInitialAssignments = $shouldPolluteScopeWithLoopInitialAssignments;
+
+		return $this;
+	}
+
+	public function setShouldPolluteCatchScopeWithTryAssignments(bool $shouldPolluteCatchScopeWithTryAssignments): self
+	{
+		$this->shouldPolluteCatchScopeWithTryAssignments = $shouldPolluteCatchScopeWithTryAssignments;
+
+		return $this;
+	}
+
+	public function setShouldPolluteScopeWithAlwaysIterableForeach(bool $shouldPolluteScopeWithAlwaysIterableForeach): self
+	{
+		$this->shouldPolluteScopeWithAlwaysIterableForeach = $shouldPolluteScopeWithAlwaysIterableForeach;
+
+		return $this;
+	}
+
+	public function checkFile(string $file): self
+	{
+		$file = $this->getFileHelper()->normalizePath($file);
+		$actualErrors = $this->getAnalyser()->analyse([$file], false);
+
+		$strictlyTypedSprintf = static function (int $line, string $message): string {
+			return sprintf('%02d: %s', $line, $message);
+		};
+
+		$expectedErrors = $this->utilsRule->getExpectedErrors();
+		$expectedErrors = array_map(
+			static function (array $error) use ($strictlyTypedSprintf): string {
+				if (!isset($error[0])) {
+					throw new \InvalidArgumentException('Missing expected error message.');
+				}
+				if (!isset($error[1])) {
+					throw new \InvalidArgumentException('Missing expected file line.');
+				}
+				return $strictlyTypedSprintf($error[1], $error[0]);
+			},
+			$expectedErrors
+		);
+
+		$actualErrors = array_map(
+			static function (Error $error) use ($strictlyTypedSprintf): string {
+				return $strictlyTypedSprintf((int) $error->getLine(), $error->getMessage());
+			},
+			$actualErrors
+		);
+
+		$errorMessages = [];
+		foreach (array_diff($expectedErrors, $actualErrors) as $error) {
+			$errorParts = explode(':', $error, 2);
+			$errorMessages[] = $this->prepareCodeSnippet('Expected error did not occur: ' . ltrim($errorParts[1]), $file, (int) $errorParts[0]);
+		}
+
+		foreach (array_diff($actualErrors, $expectedErrors) as $error) {
+			$errorParts = explode(':', $error, 2);
+			$errorMessages[] = $this->prepareCodeSnippet('Unexpected error: ' . ltrim($errorParts[1]), $file, (int) $errorParts[0]);
+		}
+
+		Assert::assertCount(0, $errorMessages, implode("\n", $errorMessages));
+
+		return $this;
+	}
+
+	private function getParser(): \PHPStan\Parser\Parser
+	{
+		/** @var \PHPStan\Parser\Parser $parser */
+		$parser = TestCase::getContainer()->getService('directParser');
+		return $parser;
+	}
+
+	private function createBroker(): Broker
+	{
+		$functionCallStatementFinder = new FunctionCallStatementFinder();
+		$parser = $this->getParser();
+		$cache = new Cache(new MemoryCacheStorage());
+		$methodReflectionFactory = new class($parser, $functionCallStatementFinder, $cache) implements PhpMethodReflectionFactory {
+
+			/** @var \PHPStan\Parser\Parser */
+			private $parser;
+
+			/** @var \PHPStan\Parser\FunctionCallStatementFinder */
+			private $functionCallStatementFinder;
+
+			/** @var \PHPStan\Cache\Cache */
+			private $cache;
+
+			/** @var \PHPStan\Broker\Broker */
+			public $broker;
+
+			public function __construct(
+				Parser $parser,
+				FunctionCallStatementFinder $functionCallStatementFinder,
+				Cache $cache
+			)
+			{
+				$this->parser = $parser;
+				$this->functionCallStatementFinder = $functionCallStatementFinder;
+				$this->cache = $cache;
+			}
+
+			/**
+			 * @param ClassReflection $declaringClass
+			 * @param ClassReflection|null $declaringTrait
+			 * @param \PHPStan\Reflection\Php\BuiltinMethodReflection $reflection
+			 * @param Type[] $phpDocParameterTypes
+			 * @param Type|null $phpDocReturnType
+			 * @param Type|null $phpDocThrowType
+			 * @param bool $isDeprecated
+			 * @param bool $isInternal
+			 * @param bool $isFinal
+			 * @return PhpMethodReflection
+			 */
+			public function create(
+				ClassReflection $declaringClass,
+				?ClassReflection $declaringTrait,
+				\PHPStan\Reflection\Php\BuiltinMethodReflection $reflection,
+				array $phpDocParameterTypes,
+				?Type $phpDocReturnType,
+				?Type $phpDocThrowType,
+				bool $isDeprecated,
+				bool $isInternal,
+				bool $isFinal
+			): PhpMethodReflection
+			{
+				return new PhpMethodReflection(
+					$declaringClass,
+					$declaringTrait,
+					$reflection,
+					$this->broker,
+					$this->parser,
+					$this->functionCallStatementFinder,
+					$this->cache,
+					$phpDocParameterTypes,
+					$phpDocReturnType,
+					$phpDocThrowType,
+					$isDeprecated,
+					$isInternal,
+					$isFinal
+				);
+			}
+
+		};
+		$phpDocStringResolver = TestCase::getContainer()->getByType(PhpDocStringResolver::class);
+		$currentWorkingDirectory = $this->getCurrentWorkingDirectory();
+		$relativePathHelper = new FuzzyRelativePathHelper($this->getCurrentWorkingDirectory(), DIRECTORY_SEPARATOR, []);
+		$fileTypeMapper = new FileTypeMapper($parser, $phpDocStringResolver, $cache, new AnonymousClassNameHelper(new FileHelper($currentWorkingDirectory), $relativePathHelper), TestCase::getContainer()->getByType(\PHPStan\PhpDoc\TypeNodeResolver::class));
+		$annotationsMethodsClassReflectionExtension = new AnnotationsMethodsClassReflectionExtension($fileTypeMapper);
+		$annotationsPropertiesClassReflectionExtension = new AnnotationsPropertiesClassReflectionExtension($fileTypeMapper);
+		$signatureMapProvider = TestCase::getContainer()->getByType(SignatureMapProvider::class);
+		$phpExtension = new PhpClassReflectionExtension($methodReflectionFactory, $fileTypeMapper, $annotationsMethodsClassReflectionExtension, $annotationsPropertiesClassReflectionExtension, $signatureMapProvider);
+		$functionReflectionFactory = new class($this->getParser(), $functionCallStatementFinder, $cache) implements FunctionReflectionFactory {
+
+			/** @var \PHPStan\Parser\Parser */
+			private $parser;
+
+			/** @var \PHPStan\Parser\FunctionCallStatementFinder */
+			private $functionCallStatementFinder;
+
+			/** @var \PHPStan\Cache\Cache */
+			private $cache;
+
+			public function __construct(
+				Parser $parser,
+				FunctionCallStatementFinder $functionCallStatementFinder,
+				Cache $cache
+			)
+			{
+				$this->parser = $parser;
+				$this->functionCallStatementFinder = $functionCallStatementFinder;
+				$this->cache = $cache;
+			}
+
+			/**
+			 * @param \ReflectionFunction $function
+			 * @param Type[] $phpDocParameterTypes
+			 * @param Type|null $phpDocReturnType
+			 * @param Type|null $phpDocThrowType
+			 * @param bool $isDeprecated
+			 * @param bool $isInternal
+			 * @param bool $isFinal
+			 * @param string|false $filename
+			 * @return PhpFunctionReflection
+			 */
+			public function create(
+				\ReflectionFunction $function,
+				array $phpDocParameterTypes,
+				?Type $phpDocReturnType,
+				?Type $phpDocThrowType,
+				bool $isDeprecated,
+				bool $isInternal,
+				bool $isFinal,
+				$filename
+			): PhpFunctionReflection
+			{
+				return new PhpFunctionReflection(
+					$function,
+					$this->parser,
+					$this->functionCallStatementFinder,
+					$this->cache,
+					$phpDocParameterTypes,
+					$phpDocReturnType,
+					$phpDocThrowType,
+					$isDeprecated,
+					$isInternal,
+					$isFinal,
+					$filename
+				);
+			}
+
+		};
+
+		$tagToService = static function (array $tags) {
+			return array_map(static function (string $serviceName) {
+				return TestCase::getContainer()->getService($serviceName);
+			}, array_keys($tags));
+		};
+
+		$currentWorkingDirectory = $this->getCurrentWorkingDirectory();
+		$anonymousClassNameHelper = new AnonymousClassNameHelper(new FileHelper($currentWorkingDirectory), $relativePathHelper);
+		$broker = new Broker(
+			[
+				$phpExtension,
+				new PhpDefectClassReflectionExtension(TestCase::getContainer()->getByType(TypeStringResolver::class), $annotationsPropertiesClassReflectionExtension),
+				new UniversalObjectCratesClassReflectionExtension([\stdClass::class]),
+				$annotationsPropertiesClassReflectionExtension,
+			],
+			[
+				$phpExtension,
+				$annotationsMethodsClassReflectionExtension,
+			],
+			$this->dynamicMethodReturnTypeExtensions,
+			$this->dynamicStaticMethodReturnTypeExtensions,
+			array_merge(
+				$tagToService(TestCase::getContainer()->findByTag(BrokerFactory::DYNAMIC_FUNCTION_RETURN_TYPE_EXTENSION_TAG)),
+				$this->dynamicFunctionReturnTypeExtensions
+			),
+			$functionReflectionFactory,
+			new FileTypeMapper($this->getParser(), $phpDocStringResolver, $cache, $anonymousClassNameHelper, TestCase::getContainer()->getByType(\PHPStan\PhpDoc\TypeNodeResolver::class)),
+			$signatureMapProvider,
+			TestCase::getContainer()->getByType(Standard::class),
+			$anonymousClassNameHelper,
+			TestCase::getContainer()->getByType(Parser::class),
+			$relativePathHelper,
+			TestCase::getContainer()->parameters['universalObjectCratesClasses']
+		);
+		$methodReflectionFactory->broker = $broker;
+
+		return $broker;
+	}
+
+	private function prepareCodeSnippet(string $error, string $file, int $line): string
+	{
+		$fileData = file_get_contents($file);
+		if ($fileData === false) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
+		$fileContent = explode("\n", $fileData);
+		$snippetStart = max(0, $line - 3);
+		$fileContent = array_slice($fileContent, $snippetStart, min(count($fileContent) - $snippetStart, 4));
+		$snippetLine = $line - $snippetStart - 1;
+
+		$fileContent[$snippetLine] = "\033[1m" . $fileContent[$snippetLine] . "\033[0m";
+		foreach ($fileContent as $key => $row) {
+			$fileContent[$key] = sprintf('| %4d | %s', $snippetStart + $key + 1, $row);
+		}
+
+		return sprintf("%s\nFile %s:%d\n\n| …\n%s\n| …\n\n", $error, $file, $line, implode("\n", $fileContent));
+	}
+
+	private function getAnalyser(): Analyser
+	{
+		if ($this->analyser === null) {
+			$registry = new Registry(array_merge($this->rules, [$this->utilsRule]));
+			$broker = $this->createBroker();
+			$printer = new \PhpParser\PrettyPrinter\Standard();
+			$fileHelper = $this->getFileHelper();
+			$typeSpecifier = $this->createTypeSpecifier(
+				$printer,
+				$broker,
+				$this->methodTypeSpecifyingExtensions,
+				$this->staticMethodTypeSpecifyingExtensions
+			);
+			$currentWorkingDirectory = $this->getCurrentWorkingDirectory();
+			$this->analyser = new Analyser(
+				$this->createScopeFactory($broker, $typeSpecifier),
+				$this->getParser(),
+				$registry,
+				new NodeScopeResolver(
+					$broker,
+					$this->getParser(),
+					new FileTypeMapper($this->getParser(), TestCase::getContainer()->getByType(PhpDocStringResolver::class), $this->cache, new AnonymousClassNameHelper(new FileHelper($currentWorkingDirectory), new FuzzyRelativePathHelper($currentWorkingDirectory, DIRECTORY_SEPARATOR, [])), new \PHPStan\PhpDoc\TypeNodeResolver($this->typeNodeResolverExtensions)),
+					$fileHelper,
+					$typeSpecifier,
+					$this->shouldPolluteScopeWithLoopInitialAssignments,
+					$this->shouldPolluteCatchScopeWithTryAssignments,
+					$this->shouldPolluteScopeWithAlwaysIterableForeach,
+					[]
+				),
+				$fileHelper,
+				[],
+				true,
+				50
+			);
+		}
+
+		return $this->analyser;
+	}
+
+	private function getFileHelper(): FileHelper
+	{
+		return TestCase::getContainer()->getByType(FileHelper::class);
+	}
+
+	/**
+	 * @param \PhpParser\PrettyPrinter\Standard $printer
+	 * @param \PHPStan\Broker\Broker $broker
+	 * @param \PHPStan\Type\MethodTypeSpecifyingExtension[] $methodTypeSpecifyingExtensions
+	 * @param \PHPStan\Type\StaticMethodTypeSpecifyingExtension[] $staticMethodTypeSpecifyingExtensions
+	 * @return \PHPStan\Analyser\TypeSpecifier
+	 */
+	private function createTypeSpecifier(
+		Standard $printer,
+		Broker $broker,
+		array $methodTypeSpecifyingExtensions = [],
+		array $staticMethodTypeSpecifyingExtensions = []
+	): TypeSpecifier
+	{
+		$tagToService = static function (array $tags) {
+			return array_map(static function (string $serviceName) {
+				return TestCase::getContainer()->getService($serviceName);
+			}, array_keys($tags));
+		};
+
+		return new TypeSpecifier(
+			$printer,
+			$broker,
+			$tagToService(TestCase::getContainer()->findByTag(TypeSpecifierFactory::FUNCTION_TYPE_SPECIFYING_EXTENSION_TAG)),
+			$methodTypeSpecifyingExtensions,
+			$staticMethodTypeSpecifyingExtensions
+		);
+	}
+
+	/**
+	 * @param Broker $broker
+	 * @param TypeSpecifier $typeSpecifier
+	 * @param string[] $dynamicConstantNames
+	 *
+	 * @return ScopeFactory
+	 */
+	private function createScopeFactory(Broker $broker, TypeSpecifier $typeSpecifier, array $dynamicConstantNames = []): ScopeFactory
+	{
+		$container = TestCase::getContainer();
+
+		if (count($dynamicConstantNames) > 0) {
+			$container->parameters['dynamicConstantNames'] = array_merge($container->parameters['dynamicConstantNames'], $dynamicConstantNames);
+		}
+
+		return new ScopeFactory(
+			Scope::class,
+			$broker,
+			new \PhpParser\PrettyPrinter\Standard(),
+			$typeSpecifier,
+			$container->getByType(Container::class)
+		);
+	}
+
+	private function getCurrentWorkingDirectory(): string
+	{
+		return $this->getFileHelper()->normalizePath(__DIR__ . '/../../..');
+	}
+
+}

--- a/src/Testing/AnalysisBased/Utils.php
+++ b/src/Testing/AnalysisBased/Utils.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Testing\AnalysisBased;
+
+class Utils
+{
+
+	/**
+	 * @param mixed $value
+	 */
+	public static function assertTypeDescription($value, string $description): void
+	{
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	public static function assertExistence($value, string $description): void
+	{
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	public static function assertNoExistence($value, string $description): void
+	{
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	public static function assertMaybeExistence($value, string $description): void
+	{
+	}
+
+	public static function assertErrorOnNextLine(string $description): void
+	{
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	public static function printType($value): void
+	{
+	}
+
+	public static function debugScope(): void
+	{
+	}
+
+}

--- a/src/Testing/AnalysisBased/UtilsRule.php
+++ b/src/Testing/AnalysisBased/UtilsRule.php
@@ -1,0 +1,196 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Testing\AnalysisBased;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+use function implode;
+use function is_string;
+use function sprintf;
+
+class UtilsRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var mixed[][] */
+	private $expectedErrors = [];
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\StaticCall::class;
+	}
+
+	/**
+	 * @return mixed[][]
+	 */
+	public function getExpectedErrors(): array
+	{
+		return $this->expectedErrors;
+	}
+
+	/**
+	 * @return string[] errors
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node instanceof Node\Expr\StaticCall) {
+			return [];
+		}
+
+		$nodeClass = $node->class;
+		if (!$nodeClass instanceof Node\Name) {
+			return [];
+		}
+
+		if ($nodeClass->toString() !== Utils::class) {
+			return [];
+		}
+
+		$nodeName = $node->name;
+		if (!$nodeName instanceof Node\Identifier) {
+			return [];
+		}
+
+		$nodeName = $nodeName->toString();
+		if ($nodeName === 'assertTypeDescription') {
+			$valueType = $scope->getType($node->args[0]->value);
+			$descriptionType = $scope->getType($node->args[1]->value);
+			if (!$descriptionType instanceof ConstantStringType) {
+				return ['Description must be constant string'];
+			}
+
+			$valueDescription = $this->getDescription($valueType);
+			if ($valueDescription === $descriptionType->getValue()) {
+				return [];
+			}
+
+			return [sprintf('Expected type is %s, current type is %s', $descriptionType->getValue(), $valueDescription)];
+		}
+
+		if ($nodeName === 'assertExistence') {
+			$errors = [];
+
+			$value = $node->args[0]->value;
+			if (!$value instanceof Variable) {
+				return ['Value must be variable'];
+			}
+
+			$variableName = $value->name;
+			if (!is_string($variableName)) {
+				return ['Value must be variable'];
+			}
+
+			if (!$scope->hasVariableType($variableName)->yes()) {
+				$errors[] = sprintf('Variable $%s is expected to be exists', $variableName);
+			}
+
+			if (isset($node->args[1])) {
+				$descriptionType = $scope->getType($node->args[1]->value);
+				if (!$descriptionType instanceof ConstantStringType) {
+					return ['Description must be constant string'];
+				}
+
+				$valueDescription = $this->getDescription($scope->getVariableType($variableName));
+				if ($valueDescription === $descriptionType->getValue()) {
+					return [];
+				}
+
+				$errors[] = sprintf('Expected type is %s, current type is %s', $descriptionType->getValue(), $valueDescription);
+			}
+
+			return $errors;
+		}
+
+		if ($nodeName === 'assertNoExistence') {
+			$value = $node->args[0]->value;
+			if (!$value instanceof Variable) {
+				return ['Value must be variable'];
+			}
+
+			$variableName = $value->name;
+			if (!is_string($variableName)) {
+				return ['Value must be variable'];
+			}
+
+			if ($scope->hasVariableType($variableName)->no()) {
+				return [];
+			}
+
+			return [sprintf('Variable $%s is not expected to be exists', $variableName)];
+		}
+
+		if ($nodeName === 'assertMaybeExistence') {
+			$errors = [];
+
+			$value = $node->args[0]->value;
+			if (!$value instanceof Variable) {
+				return ['Value must be variable'];
+			}
+
+			$variableName = $value->name;
+			if (!is_string($variableName)) {
+				return ['Value must be variable'];
+			}
+
+			if (!$scope->hasVariableType($variableName)->maybe()) {
+				$errors[] = sprintf('Variable $%s is expected to be maybe exists', $variableName);
+			}
+
+			if (isset($node->args[1])) {
+				$descriptionType = $scope->getType($node->args[1]->value);
+				if (!$descriptionType instanceof ConstantStringType) {
+					return ['Description must be constant string'];
+				}
+
+				$valueDescription = $this->getDescription($scope->getVariableType($variableName));
+				if ($valueDescription === $descriptionType->getValue()) {
+					return [];
+				}
+
+				$errors[] = sprintf('Expected type is %s, current type is %s', $descriptionType->getValue(), $valueDescription);
+			}
+
+			return $errors;
+		}
+
+		if ($nodeName === 'assertErrorOnNextLine') {
+			$descriptionType = $scope->getType($node->args[0]->value);
+			if (!$descriptionType instanceof ConstantStringType) {
+				return ['Description must be constant string'];
+			}
+
+			$this->expectedErrors[] = [$descriptionType->getValue(), $node->getEndLine() + 1];
+			return [];
+		}
+
+		if ($nodeName === 'printType') {
+			$valueType = $scope->getType($node->args[0]->value);
+			return [sprintf('Type: %s', $this->getDescription($valueType))];
+		}
+
+		if ($nodeName === 'debugScope') {
+			$debug = [];
+			foreach ($scope->debug() as $name => $type) {
+				$debug[] = sprintf('%s: %s', $name, $type);
+			}
+			$debug = implode("\n", $debug);
+			return [$debug];
+		}
+
+		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	private function getDescription(Type $type): string
+	{
+		if ($type instanceof ErrorType) {
+			return '*ERROR*';
+		}
+
+		return $type->describe(VerbosityLevel::precise());
+	}
+
+}

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -31,6 +31,7 @@ use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
 use PHPStan\Reflection\Php\UniversalObjectCratesClassReflectionExtension;
 use PHPStan\Reflection\PhpDefect\PhpDefectClassReflectionExtension;
 use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
+use PHPStan\Testing\AnalysisBased\TestBuilder;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Type;
 
@@ -329,6 +330,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 	public function getFileHelper(): FileHelper
 	{
 		return self::getContainer()->getByType(FileHelper::class);
+	}
+
+	public function createTestBuilder(): TestBuilder
+	{
+		return new TestBuilder(
+			$this->createMock(Cache::class)
+		);
 	}
 
 	protected function skipIfNotOnWindows(): void

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -747,29 +747,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider dataAssignInIf
-	 * @param \PHPStan\Analyser\Scope $scope
-	 * @param string $variableName
-	 * @param \PHPStan\TrinaryLogic $expectedCertainty
-	 * @param string|null $typeDescription
-	 * @param string|null $iterableValueTypeDescription
-	 */
-	public function testAssignInIf(
-		Scope $scope,
-		string $variableName,
-		TrinaryLogic $expectedCertainty,
-		?string $typeDescription = null,
-		?string $iterableValueTypeDescription = null
-	): void
+	public function testAssignInIf(): void
 	{
-		$this->assertVariables(
-			$scope,
-			$variableName,
-			$expectedCertainty,
-			$typeDescription,
-			$iterableValueTypeDescription
-		);
+		$this->createTestBuilder()
+			->checkFile(__DIR__ . '/data/if.php');
 	}
 
 	public function dataConstantTypes(): array
@@ -8102,21 +8083,9 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider dataCallables
-	 * @param string $description
-	 * @param string $expression
-	 */
-	public function testCallables(
-		string $description,
-		string $expression
-	): void
+	public function testCallables(): void
 	{
-		$this->assertTypes(
-			__DIR__ . '/data/callables.php',
-			$description,
-			$expression
-		);
+		$this->createTestBuilder()->checkFile(__DIR__ . '/data/callables.php');
 	}
 
 	public function dataArrayKeysInBranches(): array

--- a/tests/PHPStan/Analyser/data/callables.php
+++ b/tests/PHPStan/Analyser/data/callables.php
@@ -2,6 +2,8 @@
 
 namespace Callables;
 
+use PHPStan\Testing\AnalysisBased\Utils;
+
 class Foo
 {
 
@@ -14,7 +16,13 @@ class Foo
 		$arrayWithStaticMethod = ['Callables\\Foo', 'doBar'];
 		$stringWithStaticMethod = 'Callables\\Foo::doFoo';
 		$arrayWithInstanceMethod = [$this, 'doFoo'];
-		die;
+
+		Utils::assertTypeDescription($foo(), 'int');
+		Utils::assertTypeDescription($closure(), 'string');
+		Utils::assertTypeDescription($arrayWithStaticMethod(), 'Callables\\Bar');
+		Utils::assertTypeDescription($stringWithStaticMethod(), 'float');
+		Utils::assertTypeDescription($arrayWithInstanceMethod(), 'float');
+		Utils::assertTypeDescription($closureObject(), 'mixed');
 	}
 
 	public function doBar(): Bar

--- a/tests/PHPStan/Analyser/data/if.php
+++ b/tests/PHPStan/Analyser/data/if.php
@@ -1,5 +1,8 @@
 <?php
 
+use PHPStan\Testing\AnalysisBased\Utils;
+use PHPStan\TrinaryLogic;
+
 if (foo()) {
 	$ifVar = 1;
 	$issetFoo = new Foo();
@@ -68,11 +71,17 @@ try {
 	doFoo();
 }
 
+Utils::assertExistence($exceptionFromTryCatch, '(AnotherException&Throwable)|(Throwable&YetAnotherException)|null');
+
 $lorem = 1;
 $arrOne[] = 'one';
 $arrTwo['test'] = 'two';
 $anotherArray['test'][] = 'another';
+
 doSomething($one, $callParameter = 3);
+
+Utils::assertExistence($callParameter, '3');
+
 $arrTwo[] = new Foo([
 	$inArray = 1,
 ]);
@@ -369,3 +378,7 @@ try {
 		}
 	}
 }
+
+Utils::assertNoExistence($nonexistentVariable);
+Utils::assertMaybeExistence($foo, 'bool');
+Utils::assertExistence($lorem, '1');

--- a/tests/PHPStan/Rules/Cast/PrintRuleTest.php
+++ b/tests/PHPStan/Rules/Cast/PrintRuleTest.php
@@ -2,52 +2,21 @@
 
 namespace PHPStan\Rules\Cast;
 
-use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
-use PHPStan\Testing\RuleTestCase;
+use PHPStan\Testing\TestCase;
 
-class PrintRuleTest extends RuleTestCase
+class PrintRuleTest extends TestCase
 {
-
-	protected function getRule(): Rule
-	{
-		return new PrintRule(
-			new RuleLevelHelper($this->createBroker(), true, false, true)
-		);
-	}
 
 	public function testPrintRule(): void
 	{
-		$this->analyse([__DIR__ . '/data/print.php'], [
-			[
-				'Parameter array() of print cannot be converted to string.',
-				5,
-			],
-			[
-				'Parameter stdClass of print cannot be converted to string.',
-				7,
-			],
-			[
-				'Parameter Closure(): mixed of print cannot be converted to string.',
-				9,
-			],
-			[
-				'Parameter array() of print cannot be converted to string.',
-				13,
-			],
-			[
-				'Parameter stdClass of print cannot be converted to string.',
-				15,
-			],
-			[
-				'Parameter Closure(): mixed of print cannot be converted to string.',
-				17,
-			],
-			[
-				'Parameter \'string\'|array(\'string\') of print cannot be converted to string.',
-				21,
-			],
-		]);
+		$this->createTestBuilder()
+			->setRules([
+				new PrintRule(
+					new RuleLevelHelper($this->createBroker(), true, false, true)
+				),
+			])
+			->checkFile(__DIR__ . '/data/print.php');
 	}
 
 }

--- a/tests/PHPStan/Rules/Cast/data/print.php
+++ b/tests/PHPStan/Rules/Cast/data/print.php
@@ -2,20 +2,29 @@
 
 declare(strict_types=1);
 
+use PHPStan\Testing\AnalysisBased\Utils;
+
+Utils::assertErrorOnNextLine('Parameter array() of print cannot be converted to string.');
 print [];
 
+Utils::assertErrorOnNextLine('Parameter stdClass of print cannot be converted to string.');
 print new stdClass();
 
+Utils::assertErrorOnNextLine('Parameter Closure(): mixed of print cannot be converted to string.');
 print function () {};
 
 print 13132;
 
+Utils::assertErrorOnNextLine('Parameter array() of print cannot be converted to string.');
 print([]);
 
+Utils::assertErrorOnNextLine('Parameter stdClass of print cannot be converted to string.');
 print(new stdClass());
 
+Utils::assertErrorOnNextLine('Parameter Closure(): mixed of print cannot be converted to string.');
 print(function () {});
 
 print('string');
 
+Utils::assertErrorOnNextLine('Parameter \'string\'|array(\'string\') of print cannot be converted to string.');
 print random_int(0, 1) ? ['string'] : 'string';

--- a/tests/PHPStan/Type/Php/MinMaxFunctionReturnTypeExtensionTest.php
+++ b/tests/PHPStan/Type/Php/MinMaxFunctionReturnTypeExtensionTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+class MinMaxFunctionReturnTypeExtensionTest extends \PHPStan\Testing\TestCase
+{
+
+	public function testMinMax(): void
+	{
+		$this->createTestBuilder()
+			->checkFile(__DIR__ . '/data/min-max.php');
+	}
+
+}

--- a/tests/PHPStan/Type/Php/data/min-max.php
+++ b/tests/PHPStan/Type/Php/data/min-max.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PHPStan\Type\Php\MinMaxData;
+
+use PHPStan\Testing\AnalysisBased\Utils;
+
+Utils::assertTypeDescription(min([1, 2, 3]), '1');
+Utils::assertTypeDescription(min([1, 2, 3], [4, 5, 5]), 'array(1, 2, 3)');
+Utils::assertTypeDescription(min(...[1, 2, 3]), '1');
+Utils::assertTypeDescription(min(...[2, 3, 4], ...[5, 1, 8]), '1');
+Utils::assertTypeDescription(min(0, ...[1, 2, 3]), '0');
+
+Utils::assertTypeDescription(max([1, 10, 8], [5, 6, 9]), 'array(5, 6, 9)');
+Utils::assertTypeDescription(max(array(2, 2, 2), array(1, 1, 1, 1)), 'array(1, 1, 1, 1)');
+
+/** @var int[] $arrayOfUnknownIntegers */
+$arrayOfUnknownIntegers = doFoo();
+Utils::assertTypeDescription(max($arrayOfUnknownIntegers, $arrayOfUnknownIntegers), 'array<int>');
+
+Utils::assertTypeDescription(min(...[1.1, 2.2, 3.3]), '1.1');
+Utils::assertTypeDescription(min(...[1.1, 2, 3]), '1.1');
+
+Utils::assertTypeDescription(max(...[1, 2, 3]), '3');
+Utils::assertTypeDescription(max(...[1.1, 2.2, 3.3]), '3.3');
+
+Utils::assertTypeDescription(min(1, 2, 3), '1');
+Utils::assertTypeDescription(max(1, 2, 3), '3');
+Utils::assertTypeDescription(min(1.1, 2.2, 3.3), '1.1');
+Utils::assertTypeDescription(max(1.1, 2.2, 3.3), '3.3');
+Utils::assertTypeDescription(min(1, 1), '1');
+
+Utils::assertTypeDescription(min(1), '*ERROR*');
+
+/** @var int $integer */
+$integer = doFoo();
+/** @var string $string */
+$string = doFoo();
+Utils::assertTypeDescription(min($integer, $string), 'int|string');
+Utils::assertTypeDescription(min([$integer, $string]), 'int|string');
+Utils::assertTypeDescription(min(...[$integer, $string]), 'int|string');
+Utils::assertTypeDescription(min('a', 'b'), '\'a\'');
+Utils::assertTypeDescription(max(new \DateTimeImmutable("today"), new \DateTimeImmutable("tomorrow")), 'DateTimeImmutable');
+Utils::assertTypeDescription(min(1, 2.2, 3.3), '1');


### PR DESCRIPTION
Hi!
Currently, I have a serious problem with writing tests for rules, extensions and other parts of phpstan. It's because of:
1) analyzed code is out of assertion definition and when I change some parts of the analyzed code, I must update line numbers too. So every little change leads to a lot of changes in TestCases. 
2) There is no easy way how to check variable type line-by-line. It'd be very helpful for extension testing
3) Debugging is very hard. There is no way how to check the scope state in the concrete place. Sometimes I need to know what phpstan thinks.

So I've tried to write a little PoC. You can write type assertion (and some other asserts) directly into the analyzed (tested) code. These functions are doing nothing in runtime. They are just used for scope testing when phpstan is checking your code.

Example:

```php
$closure = function (): string {
    return 'abc';
};
Utils::assertTypeDescription($closure(), 'string');
```

When you make a mistake, phpunit shows you the point in your code where the error has occurred.

![image](https://user-images.githubusercontent.com/383294/56864657-5eb67380-69c5-11e9-96c3-a4cdd6ea3a25.png)

For more examples see the PR changes. I've rewritten some existing tests...

This feature is not ready to merge. I would like to hear your opinion and I'd like to improve the implementation and use better naming (suggestions are welcomed).
