### PR TITLE
Document Redis::close returns bool

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9218,7 +9218,7 @@ return [
 'Redis::brpoplpush' => ['string|false', 'srcKey'=>'string', 'dstKey'=>'string', 'timeout'=>'int'],
 'Redis::clearLastError' => ['bool'],
 'Redis::client' => ['mixed', 'command'=>'string', 'arg='=>'string'],
-'Redis::close' => ['void'],
+'Redis::close' => ['bool'],
 'Redis::config' => ['string', 'key'=>'string', 'value='=>'string'],
 'Redis::connect' => ['bool', 'host'=>'string', 'port='=>'int', 'timeout='=>'float', 'retry_interval='=>'?int'],
 'Redis::dbSize' => ['int'],


### PR DESCRIPTION
As both the documentation and the [source code](https://github.com/phpredis/phpredis/blob/60223762ada628c26cb82386bed281e4ec097f4f/redis.c#L1001-L1009) say