### PR TITLE
Fix "Couldn't find constant __COMPILER_HALT_OFFSET__"

### DIFF
--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -1244,6 +1244,9 @@ class Scope implements ClassMemberAccessAnswerer
 						new ConstantStringType("\r\n"),
 					]);
 				}
+				if ($resolvedConstantName === '__COMPILER_HALT_OFFSET__') {
+					return new IntegerType();
+				}
 
 				$constantType = $this->getTypeFromValue(constant($resolvedConstantName));
 				if ($constantType instanceof ConstantType && in_array($resolvedConstantName, $this->dynamicConstantNames, true)) {

--- a/tests/PHPStan/Analyser/ScopeTest.php
+++ b/tests/PHPStan/Analyser/ScopeTest.php
@@ -2,6 +2,8 @@
 
 namespace PHPStan\Analyser;
 
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Testing\TestCase;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -170,6 +172,16 @@ class ScopeTest extends TestCase
 		$scopeB = $scopeFactory->create(ScopeContext::create('file.php'))->assignVariable('a', $b);
 		$resultScope = $scopeA->generalizeWith($scopeB);
 		$this->assertSame($expectedTypeDescription, $resultScope->getVariableType('a')->describe(VerbosityLevel::precise()));
+	}
+
+	public function testGetConstantType(): void
+	{
+		/** @var ScopeFactory $scopeFactory */
+		$scopeFactory = self::getContainer()->getByType(ScopeFactory::class);
+		$scope = $scopeFactory->create(ScopeContext::create(__DIR__ . '/data/compiler-halt-offset.php'));
+		$node = new ConstFetch(new FullyQualified('__COMPILER_HALT_OFFSET__'));
+		$type = $scope->getType($node);
+		$this->assertSame('int', $type->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/compiler-halt-offset.php
+++ b/tests/PHPStan/Analyser/data/compiler-halt-offset.php
@@ -1,0 +1,5 @@
+<?php
+
+__COMPILER_HALT_OFFSET__ ? 1 : 2;
+
+__halt_compiler();


### PR DESCRIPTION
`Scope::resolveType()` may fetch constants while trying to resolve their type. When the constant is `__COMPILER_HALT_OFFSET__`, if fails with the following error:

    PHP Warning:  constant(): Couldn't find constant __COMPILER_HALT_OFFSET__

Currently, `Scope::resolveType()` has a special case for a few constants. I've added a new special case for `__COMPILER_HALT_OFFSET__`.

