### PR TITLE
Do not union when offset value type is an array

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -209,7 +209,14 @@ class ArrayType implements StaticResolvableType
 			$offsetType = new IntegerType();
 		}
 
-		return new ArrayType(
+		if ($this->itemType instanceof ArrayType && $valueType instanceof ArrayType) {
+			return new self(
+				TypeCombinator::union($this->keyType, self::castToArrayKeyType($offsetType)),
+				$valueType
+			);
+		}
+
+		return new self(
 			TypeCombinator::union($this->keyType, self::castToArrayKeyType($offsetType)),
 			TypeCombinator::union($this->itemType, $valueType)
 		);

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -90,6 +90,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends \PHPStan\Testing\RuleTest
 				'Offset int does not exist on array<string, string>.',
 				312,
 			],
+			[
+				'Offset \'baz\' does not exist on array(\'bar\' => 1, ?\'baz\' => 2).',
+				344,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/data/nonexistent-offset.php
+++ b/tests/PHPStan/Rules/Arrays/data/nonexistent-offset.php
@@ -329,6 +329,45 @@ class Foo
 	{
 		echo $xml['asdf'];
 	}
+
+	public function arrayWithMultipleKeysAfterForeaches(int $i, int $j)
+	{
+		// Must fail
+		$array = [];
+
+		$array[$i]['bar'] = 1;
+		if ((bool) rand(0, 1)) {
+		  $array[$i]['baz'] = 2;
+		}
+
+		echo $array[$i]['bar'];
+		echo $array[$i]['baz'];
+
+		// Must work
+		$array = [];
+
+		$array['bar'] = 1;
+		$array['baz'] = 2;
+
+		echo $array['bar'];
+		echo $array['baz'];
+
+		$array = [];
+
+		$array[$i]['bar'] = 1;
+		$array[$i]['baz'] = 2;
+
+		echo $array[$i]['bar'];
+		echo $array[$i]['baz'];
+
+		$array = [];
+
+		$array[$i][$j]['bar'] = 1;
+		$array[$i][$j]['baz'] = 2;
+
+		echo $array[$i][$j]['bar'];
+		echo $array[$i][$j]['baz'];
+	}
 }
 
 class SubClassSimpleXMLElement extends \SimpleXMLElement


### PR DESCRIPTION
This PR is intended to fix the following bug: https://github.com/phpstan/phpstan/issues/2145

It appeared that `ArrayType::setOffsetValueType` was re-computing the new value type by doing an union:
```php
TypeCombinator::union($this->itemType, $valueType)
```
But this seems wrong when dealing with a value type of type `ArrayType` because the resulting type of `[bar]` union `[bar, baz]` is `[bar, ?baz]`. But we expect it to be `[bar, baz]`.