### PR TITLE
Add TemplateType with inference capabilities

### DIFF
--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -9,6 +9,7 @@ use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -17,6 +18,7 @@ class HasMethodType implements AccessoryType, CompoundType
 {
 
 	use ObjectTypeTrait;
+	use NonGenericTypeTrait;
 
 	/** @var string */
 	private $methodName;

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -12,6 +12,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -23,6 +24,7 @@ class HasOffsetType implements CompoundType, AccessoryType
 	use MaybeIterableTypeTrait;
 	use MaybeObjectTypeTrait;
 	use TruthyBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	/** @var \PHPStan\Type\Type */
 	private $offsetType;

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -15,6 +16,7 @@ class HasPropertyType implements AccessoryType, CompoundType
 {
 
 	use ObjectTypeTrait;
+	use NonGenericTypeTrait;
 
 	/** @var string */
 	private $propertyName;

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -10,6 +10,7 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
 use PHPStan\Type\Type;
@@ -21,6 +22,7 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 	use MaybeCallableTypeTrait;
 	use NonObjectTypeTrait;
 	use TruthyBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	public function getReferencedClasses(): array
 	{

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -20,6 +21,7 @@ class BooleanType implements Type
 	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	public function describe(VerbosityLevel $level): string
 	{

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -12,9 +12,12 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 
 class ClosureType implements TypeWithClassName, ParametersAcceptor
 {
+
+	use NonGenericTypeTrait;
 
 	/** @var ObjectType */
 	private $objectType;

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -6,6 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -17,6 +18,7 @@ class FloatType implements Type
 	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	/**
 	 * @return string[]

--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
+
+final class TemplateMixedType extends MixedType implements TemplateType
+{
+
+	/** @var string */
+	private $name;
+
+	public function __construct(
+		string $name,
+		bool $isExplicitMixed = false,
+		?Type $subtractedType = null
+	)
+	{
+		parent::__construct($isExplicitMixed, $subtractedType);
+
+		$this->name = $name;
+	}
+
+	public function getName(): string
+	{
+		return $this->name;
+	}
+
+	public function describe(VerbosityLevel $level): string
+	{
+		return $this->name;
+	}
+
+	public function equals(Type $type): bool
+	{
+		return $type instanceof self
+			&& $type->name === $this->name;
+	}
+
+	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
+	{
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+			return $receivedType->inferTemplateTypesOn($this);
+		}
+
+		if (!$this->isSuperTypeOf($receivedType)->yes()) {
+			return TemplateTypeMap::empty();
+		}
+
+		return new TemplateTypeMap([
+			$this->name => $receivedType,
+		]);
+	}
+
+	public function subtract(Type $type): Type
+	{
+		if ($type instanceof self) {
+			return new NeverType();
+		}
+		if ($this->getSubtractedType() !== null) {
+			$type = TypeCombinator::union($this->getSubtractedType(), $type);
+		}
+
+		return new static(
+			$this->name,
+			$this->isExplicitMixed(),
+			$type
+		);
+	}
+
+	public function getTypeWithoutSubtractedType(): Type
+	{
+		return new self(
+			$this->name,
+			$this->isExplicitMixed(),
+			null
+		);
+	}
+
+	public function changeSubtractedType(?Type $subtractedType): Type
+	{
+		return new self(
+			$this->name,
+			$this->isExplicitMixed(),
+			$subtractedType
+		);
+	}
+
+	/**
+	 * @param mixed[] $properties
+	 * @return Type
+	 */
+	public static function __set_state(array $properties): Type
+	{
+		return new self(
+			$properties['name'],
+			$properties['isExplicitMixed'],
+			$properties['subtractedType']
+		);
+	}
+
+}

--- a/src/Type/Generic/TemplateObjectType.php
+++ b/src/Type/Generic/TemplateObjectType.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
+
+final class TemplateObjectType extends ObjectType implements TemplateType
+{
+
+	/** @var string */
+	private $name;
+
+	public function __construct(
+		string $name,
+		string $class,
+		?Type $subtractedType = null
+	)
+	{
+		parent::__construct($class, $subtractedType);
+
+		$this->name = $name;
+	}
+
+	public function getName(): string
+	{
+		return $this->name;
+	}
+
+	public function describe(VerbosityLevel $level): string
+	{
+		return sprintf(
+			'%s of %s',
+			$this->name,
+			parent::describe($level)
+		);
+	}
+
+	public function equals(Type $type): bool
+	{
+		return $type instanceof self
+			&& $type->name === $this->name;
+	}
+
+	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
+	{
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+			return $receivedType->inferTemplateTypesOn($this);
+		}
+
+		if (!$this->isSuperTypeOf($receivedType)->yes()) {
+			return TemplateTypeMap::empty();
+		}
+
+		return new TemplateTypeMap([
+			$this->name => $receivedType,
+		]);
+	}
+
+	public function subtract(Type $type): Type
+	{
+		if ($this->getSubtractedType() !== null) {
+			$type = TypeCombinator::union($this->getSubtractedType(), $type);
+		}
+
+		return new self(
+			$this->name,
+			$this->getClassName(),
+			$type
+		);
+	}
+
+	public function getTypeWithoutSubtractedType(): Type
+	{
+		return new self(
+			$this->name,
+			$this->getClassName(),
+			null
+		);
+	}
+
+	public function changeSubtractedType(?Type $subtractedType): Type
+	{
+		return new self(
+			$this->name,
+			$this->getClassName(),
+			$subtractedType
+		);
+	}
+
+	/**
+	 * @param mixed[] $properties
+	 * @return Type
+	 */
+	public static function __set_state(array $properties): Type
+	{
+		return new self(
+			$properties['name'],
+			$properties['className'],
+			$properties['subtractedType']
+		);
+	}
+
+}

--- a/src/Type/Generic/TemplateType.php
+++ b/src/Type/Generic/TemplateType.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\Type;
+
+interface TemplateType extends Type
+{
+
+	public function getName(): string;
+
+}

--- a/src/Type/Generic/TemplateTypeMap.php
+++ b/src/Type/Generic/TemplateTypeMap.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+class TemplateTypeMap
+{
+
+	/** @var array<string,\PHPStan\Type\Type> */
+	private $types;
+
+	/** @param array<string,\PHPStan\Type\Type> $types */
+	public function __construct(array $types)
+	{
+		$this->types = $types;
+	}
+
+	public static function empty(): self
+	{
+		return new self([]);
+	}
+
+	/** @return array<string,\PHPStan\Type\Type> */
+	public function getTypes(): array
+	{
+		return $this->types;
+	}
+
+	public function getType(string $name): ?Type
+	{
+		return $this->types[$name] ?? null;
+	}
+
+	public function union(self $other): self
+	{
+		$result = $this->types;
+
+		foreach ($other->types as $name => $type) {
+			if (isset($result[$name])) {
+				$result[$name] = TypeCombinator::union($result[$name], $type);
+			} else {
+				$result[$name] = $type;
+			}
+		}
+
+		return new self($result);
+	}
+
+	public function intersect(self $other): self
+	{
+		$result = $this->types;
+
+		foreach ($other->types as $name => $type) {
+			if (isset($result[$name])) {
+				$result[$name] = TypeCombinator::intersect($result[$name], $type);
+			} else {
+				$result[$name] = $type;
+			}
+		}
+
+		return new self($result);
+	}
+
+}

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -6,6 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -18,6 +19,7 @@ class IntegerType implements Type
 	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	public function describe(VerbosityLevel $level): string
 	{

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -6,6 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
 use PHPStan\Type\Traits\MaybeOffsetAccessibleTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 
 class IterableType implements StaticResolvableType, CompoundType
@@ -15,6 +16,7 @@ class IterableType implements StaticResolvableType, CompoundType
 	use MaybeObjectTypeTrait;
 	use MaybeOffsetAccessibleTypeTrait;
 	use UndecidedBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	/** @var \PHPStan\Type\Type */
 	private $keyType;

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -13,6 +13,7 @@ use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\MaybeOffsetAccessibleTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 
 class MixedType implements CompoundType, SubtractableType
@@ -21,6 +22,7 @@ class MixedType implements CompoundType, SubtractableType
 	use MaybeIterableTypeTrait;
 	use MaybeOffsetAccessibleTypeTrait;
 	use UndecidedBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	/** @var bool */
 	private $isExplicitMixed;

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -9,11 +9,13 @@ use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\FalseyBooleanTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 
 class NeverType implements CompoundType
 {
 
 	use FalseyBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	/**
 	 * @return string[]

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
@@ -20,6 +21,7 @@ class NonexistentParentClassType implements Type
 	use NonIterableTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
 	use TruthyBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	public function describe(VerbosityLevel $level): string
 	{

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Traits\FalseyBooleanTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 
@@ -18,6 +19,7 @@ class NullType implements ConstantScalarType
 	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use FalseyBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	/**
 	 * @return string[]

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -13,12 +13,14 @@ use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
 
 class ObjectType implements TypeWithClassName, SubtractableType
 {
 
 	use TruthyBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	private const EXTRA_OFFSET_CLASSES = ['SimpleXMLElement', 'DOMNodeList'];
 

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -3,12 +3,14 @@
 namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
 
 class ObjectWithoutClassType implements SubtractableType
 {
 
 	use ObjectTypeTrait;
+	use NonGenericTypeTrait;
 
 	/** @var \PHPStan\Type\Type|null */
 	private $subtractedType;

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -6,6 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
@@ -18,6 +19,7 @@ class ResourceType implements Type
 	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use TruthyBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	public function describe(VerbosityLevel $level): string
 	{

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -7,12 +7,14 @@ use PHPStan\Reflection\ConstantReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
 
 class StaticType implements StaticResolvableType, TypeWithClassName
 {
 
 	use TruthyBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	/** @var string */
 	private $baseClass;

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -7,6 +7,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -19,6 +20,7 @@ class StringType implements Type
 	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	public function describe(VerbosityLevel $level): string
 	{

--- a/src/Type/Traits/NonGenericTypeTrait.php
+++ b/src/Type/Traits/NonGenericTypeTrait.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Traits;
+
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Type;
+
+trait NonGenericTypeTrait
+{
+
+	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
+	{
+		return TemplateTypeMap::empty();
+	}
+
+}

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\ConstantReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Generic\TemplateTypeMap;
 
 interface Type
 {
@@ -79,6 +80,14 @@ interface Type
 	public function toString(): Type;
 
 	public function toArray(): Type;
+
+	/**
+	 * Infers template types
+	 *
+	 * Infers the real Type of the TemplateTypes found in $this, based on
+	 * the received Type.
+	 */
+	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap;
 
 	/**
 	 * @param mixed[] $properties

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -9,6 +9,7 @@ use PHPStan\Reflection\PropertyReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Generic\TemplateTypeMap;
 
 class UnionType implements CompoundType, StaticResolvableType
 {
@@ -529,6 +530,29 @@ class UnionType implements CompoundType, StaticResolvableType
 		});
 
 		return $type;
+	}
+
+	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
+	{
+		$types = TemplateTypeMap::empty();
+
+		foreach ($this->types as $type) {
+			$receive = $type->isSuperTypeOf($receivedType)->yes() ? $receivedType : new NeverType();
+			$types = $types->union($type->inferTemplateTypes($receive));
+		}
+
+		return $types;
+	}
+
+	public function inferTemplateTypesOn(Type $templateType): TemplateTypeMap
+	{
+		$types = TemplateTypeMap::empty();
+
+		foreach ($this->types as $type) {
+			$types = $types->union($templateType->inferTemplateTypes($type));
+		}
+
+		return $types;
 	}
 
 	/**

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\FalseyBooleanTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
@@ -17,6 +18,7 @@ class VoidType implements Type
 	use NonObjectTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
 	use FalseyBooleanTypeTrait;
+	use NonGenericTypeTrait;
 
 	/**
 	 * @return string[]


### PR DESCRIPTION
This adds TemplateType, which represents a type placeholder in generic code.

A placeholder can have a bound: we can say that the real type must be a sub-type of some specified type. The placeholder must behave like its bound in most situations, and the only way to achieve this currently is to extend the bound (e.g. TemplateObjectType extends ObjectType). I'm not happy with this, but this appears to be the only solution right now.

In order to support inference, this also introduces an `inferTemplateTypes()` method on `Type`, whose job is to pattern-match a parameter (potentially containing template types) with an argument (containing only non-template types), in order to find the real type of each placeholder.

When a placeholder receives different types, we do a union of both. This seems to be the most useful and practical strategy:

```
/**
 * @template T
 * @param T $a
 * @param T $b
 * @return T
 */
function f($a, $b) {
    return $a;
}

function x(\DateTimeInterface $dateTimeInterface) {
    f($dateTimeInterface, new \DateTime());    // T=union(DateTimeInterface|DateTime)
    f(new \DateTime(),    $dateTimeInterface); // T=union(DateTimeInterface|DateTime)
    f(new \DateTime(),    new \DateTime());    // T=union(DateTime)
}
```

Limitations:
 - Only single-class-name bounds are supported right now (we could imagine supporting union bounds, scalars, etc)
 - Type inference is implemented on arrays, callables; but not on iterables, etc.
 - Not attempt is made to support optional/variadic parameters in inference