### PR TITLE
nonEmptiness for sizeof and comparison operators with count functions

### DIFF
--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -5,8 +5,12 @@ namespace PHPStan\Analyser;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Equal;
+use PhpParser\Node\Expr\BinaryOp\Greater;
+use PhpParser\Node\Expr\BinaryOp\GreaterOrEqual;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BinaryOp\Smaller;
+use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\PropertyFetch;
@@ -560,6 +564,186 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 				[
 					'$array' => '~nonEmpty',
 				],
+				[
+					'$array' => 'nonEmpty',
+				],
+			],
+			[
+				new Greater(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(-1)),
+				[],
+				[
+					'$array' => '~nonEmpty',
+				],
+			],
+			[
+				new GreaterOrEqual(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(-1)),
+				[],
+				[
+					'$array' => '~nonEmpty',
+				],
+			],
+			[
+				new Greater(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(0)),
+				[
+					'$array' => 'nonEmpty',
+				],
+				[
+					'$array' => '~nonEmpty',
+				],
+			],
+			[
+				new GreaterOrEqual(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(0)),
+				[],
+				[
+					'$array' => '~nonEmpty',
+				],
+			],
+			[
+				new Greater(new FuncCall(new Name('sizeof'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(1)),
+				[
+					'$array' => 'nonEmpty',
+				],
+				[],
+			],
+			[
+				new GreaterOrEqual(new FuncCall(new Name('sizeof'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(1)),
+				[
+					'$array' => 'nonEmpty',
+				],
+				[
+					'$array' => '~nonEmpty',
+				],
+			],
+			[
+				new Greater(new FuncCall(new Name('sizeof'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(5)),
+				[
+					'$array' => 'nonEmpty',
+				],
+				[],
+			],
+			[
+				new Smaller(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(0)),
+				[
+					'$array' => '~nonEmpty',
+				],
+				[],
+			],
+			[
+				new SmallerOrEqual(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(0)),
+				[
+					'$array' => '~nonEmpty',
+				],
+				[
+					'$array' => 'nonEmpty',
+				],
+			],
+			[
+				new Identical(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(0)),
+				[
+					'$array' => '~nonEmpty',
+				],
+				[
+					'$array' => 'nonEmpty',
+				],
+			],
+			[
+				new Equal(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(0)),
+				[
+					'$array' => '~nonEmpty',
+				],
+				[
+					'$array' => 'nonEmpty',
+				],
+			],
+			[
+				new Identical(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(1)),
+				[
+					'$array' => 'nonEmpty',
+				],
+				[
+					'count($array)' => '~1',
+				],
+			],
+			[
+				new Equal(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(1)),
+				[
+					'$array' => 'nonEmpty',
+				],
+				[],
+			],
+			/*
+			[
+				new Identical(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(-1)),
+				[
+					'$array' => '~nonEmpty',
+				],
+				[
+					'count($array)' => '~-1',
+				],
+			],
+			[
+				new Equal(new FuncCall(new Name('count'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(-1)),
+				[
+					'$array' => '~nonEmpty',
+				],
+				[],
+			],
+			*/
+			[
+				new Smaller(new FuncCall(new Name('sizeof'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(1)),
+				[
+					'$array' => '~nonEmpty',
+				],
+				[
+					'$array' => 'nonEmpty',
+				],
+			],
+			[
+				new SmallerOrEqual(new FuncCall(new Name('sizeof'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(1)),
+				[],
+				[
+					'$array' => 'nonEmpty',
+				],
+			],
+			[
+				new Smaller(new FuncCall(new Name('sizeof'), [
+					new Arg(new Variable('array')),
+				]), new LNumber(5)),
+				[],
 				[
 					'$array' => 'nonEmpty',
 				],

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -90,6 +90,14 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends \PHPStan\Testing\RuleTest
 				'Offset int does not exist on array<string, string>.',
 				312,
 			],
+			[
+				'Offset 0 does not exist on array().',
+				347,
+			],
+			[
+				'Offset 0 does not exist on array().',
+				349,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/data/nonexistent-offset.php
+++ b/tests/PHPStan/Rules/Arrays/data/nonexistent-offset.php
@@ -329,6 +329,29 @@ class Foo
 	{
 		echo $xml['asdf'];
 	}
+
+	function offsetExistsFromCount(array $arrayAccessoryTypes)
+	{
+		$arrayAccessoryTypesToProcess = [];
+		if (count($arrayAccessoryTypes) > 1) {
+			$arrayAccessoryTypesToProcess = array_values(array_intersect_key(...$arrayAccessoryTypes));
+		} elseif (count($arrayAccessoryTypes) > 0) {
+			$arrayAccessoryTypesToProcess = array_values($arrayAccessoryTypes[0]);
+		}
+	}
+
+	function offsetNotExistsFromCount(array $arrayAccessoryTypes)
+	{
+		$arrayAccessoryTypesToProcess = [];
+		if (count($arrayAccessoryTypes) < 0) {
+			$arrayAccessoryTypesToProcess = array_values($arrayAccessoryTypes[0]);
+		} elseif (count($arrayAccessoryTypes) < -1) {
+			$arrayAccessoryTypesToProcess = array_values($arrayAccessoryTypes[0]);
+		} else {
+			$arrayAccessoryTypesToProcess = array_values($arrayAccessoryTypes[0]);
+		}
+	}
+
 }
 
 class SubClassSimpleXMLElement extends \SimpleXMLElement

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -514,6 +514,30 @@ class DefinedVariableRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Variable $test might not be defined.',
 				218,
 			],
+			[
+				'Undefined variable: $val',
+				229,
+			],
+			[
+				'Undefined variable: $test',
+				230,
+			],
+			[
+				'Undefined variable: $val',
+				245,
+			],
+			[
+				'Undefined variable: $test',
+				246,
+			],
+			[
+				'Variable $val might not be defined.',
+				275,
+			],
+			[
+				'Variable $test might not be defined.',
+				276,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Variables/data/foreach.php
+++ b/tests/PHPStan/Rules/Variables/data/foreach.php
@@ -107,7 +107,7 @@ function (array $arr) {
 
 };
 
-/*function (array $arr) {
+function (array $arr) {
 
 	if (count($arr) > 0) {
 		foreach ($arr as $val) {
@@ -131,7 +131,7 @@ function (array $arr) {
 		echo $test;
 	}
 
-};*/
+};
 
 function (array $arr) {
 
@@ -216,5 +216,196 @@ function (array $arr) {
 
 	echo $val;
 	echo $test;
+
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) === 0) {
+		foreach ($arr as $val) {
+			$test = 1;
+		}
+
+		echo $val;
+		echo $test;
+	}
+
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) !== 0) {
+		return;
+	}
+
+	foreach ($arr as $val) {
+		$test = 1;
+	}
+
+	echo $val;
+	echo $test;
+
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) !== 1) {
+		return;
+	}
+
+	foreach ($arr as $val) {
+		$test = 1;
+	}
+
+	echo $val;
+	echo $test;
+
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) === 1) {
+		return;
+	}
+
+	foreach ($arr as $val) {
+		$test = 1;
+	}
+
+	echo $val;
+	echo $test;
+
+};
+
+
+function (array $arr) {
+
+	if (sizeof($arr) === 0) {
+		return;
+	}
+
+	foreach ($arr as $val) {
+		$test = 1;
+	}
+
+	echo $val;
+	echo $test;
+
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) === 0) {
+		return;
+	}
+
+	if ($arr) {
+		$test = 1;
+	}
+
+	echo $test;
+
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) > 0) {
+		foreach ($arr as $val) {
+			$test = 1;
+		}
+
+		echo $val;
+		echo $test;
+	}
+
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) >= 1) {
+		foreach ($arr as $val) {
+			$test = 1;
+		}
+
+		echo $val;
+		echo $test;
+	}
+
+};
+
+
+function (array $arr) {
+
+	if (count($arr) == 0) {
+		return;
+	}
+
+	if ($arr) {
+		$test = 1;
+	}
+
+	echo $test;
+
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) == 0) {
+		return;
+	}
+
+	if ($arr) {
+		$test = 1;
+	}
+
+	echo $test;
+
+};
+
+
+function (array $arr) {
+
+	if (count($arr) === 1) {
+		if ($arr) {
+			$test = 1;
+		}
+
+		echo $test;
+	}
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) === 1) {
+		if ($arr) {
+			$test = 1;
+		}
+
+		echo $test;
+	}
+
+};
+
+
+function (array $arr) {
+
+	if (count($arr) != 0) {
+		if ($arr) {
+			$test = 1;
+		}
+
+		echo $test;
+	}
+};
+
+function (array $arr) {
+
+	if (sizeof($arr) != 0) {
+		if ($arr) {
+			$test = 1;
+		}
+
+		echo $test;
+	}
 
 };


### PR DESCRIPTION
fixes #2142 


btw. Why does \PHPStan\Rules\Variables\DefinedVariableRuleTest::testForeach fail? Should I ignore it (comment out as it was before) or is it part of this fix?