### PR TITLE
TemplateType ordering strategies

### DIFF
--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -104,6 +104,11 @@ class HasMethodType implements AccessoryType, CompoundType
 		];
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	public static function __set_state(array $properties): Type
 	{
 		return new self($properties['methodName']);

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -104,9 +104,9 @@ class HasMethodType implements AccessoryType, CompoundType
 		];
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	public static function __set_state(array $properties): Type

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -134,9 +134,9 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	public static function __set_state(array $properties): Type

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -134,6 +134,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	public static function __set_state(array $properties): Type
 	{
 		return new self($properties['offsetType']);

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -89,6 +89,11 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return [new TrivialParametersAcceptor()];
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	public static function __set_state(array $properties): Type
 	{
 		return new self($properties['propertyName']);

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -89,9 +89,9 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return [new TrivialParametersAcceptor()];
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	public static function __set_state(array $properties): Type

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -138,6 +138,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	public static function __set_state(array $properties): Type
 	{
 		return new self();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -138,9 +138,9 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	public static function __set_state(array $properties): Type

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -301,8 +301,8 @@ class ArrayType implements StaticResolvableType
 
 		if (
 			$receivedType instanceof ArrayType
-			&& $this->getKeyType()->isSuperTypeOf($receivedType->getKeyType())->yes()
-			&& $this->getItemType()->isSuperTypeOf($receivedType->getItemType())->yes()
+			&& !$this->getKeyType()->isSuperTypeOf($receivedType->getKeyType())->no()
+			&& !$this->getItemType()->isSuperTypeOf($receivedType->getItemType())->no()
 		) {
 			$receivedKey = $receivedType->getKeyType();
 			$receivedItem = $receivedType->getItemType();

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -317,16 +317,16 @@ class ArrayType implements StaticResolvableType
 		return $keyTypeMap->union($itemTypeMap);
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		$keyType = $this->keyType->map($cb);
-		$itemType = $this->itemType->map($cb);
+		$keyType = $cb($this->keyType);
+		$itemType = $cb($this->itemType);
 
 		if ($keyType !== $this->keyType || $itemType !== $this->itemType) {
-			return $cb(new static($keyType, $itemType));
+			return new static($keyType, $itemType);
 		}
 
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -317,6 +317,18 @@ class ArrayType implements StaticResolvableType
 		return $keyTypeMap->union($itemTypeMap);
 	}
 
+	public function map(callable $cb): Type
+	{
+		$keyType = $this->keyType->map($cb);
+		$itemType = $this->itemType->map($cb);
+
+		if ($keyType !== $this->keyType || $itemType !== $this->itemType) {
+			return $cb(new static($keyType, $itemType));
+		}
+
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -225,27 +225,27 @@ class CallableType implements CompoundType, ParametersAcceptor
 		return $typeMap->union($this->getReturnType()->inferTemplateTypes($returnType));
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
 		if ($this->isCommonCallable) {
-			return $cb($this);
+			return $this;
 		}
 
 		$parameters = array_map(static function (NativeParameterReflection $param) use ($cb): NativeParameterReflection {
 			return new NativeParameterReflection(
 				$param->getName(),
 				$param->isOptional(),
-				$param->getType()->map($cb),
+				$cb($param->getType()),
 				$param->passedByReference(),
 				$param->isVariadic()
 			);
 		}, $this->getParameters());
 
-		return $cb(new static(
+		return new static(
 			$parameters,
-			$this->getReturnType()->map($cb),
+			$cb($this->getReturnType()),
 			$this->isVariadic()
-		));
+		);
 	}
 
 	/**

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type;
 use PHPStan\Reflection\ClassMemberAccessAnswerer;
 use PHPStan\Reflection\ConstantReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\Native\NativeParameterReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\PropertyReflection;
@@ -272,6 +273,23 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 	public function getReturnType(): Type
 	{
 		return $this->returnType;
+	}
+
+	public function map(callable $cb): Type
+	{
+		return $cb(new static(
+			array_map(static function (NativeParameterReflection $param) use ($cb): NativeParameterReflection {
+				return new NativeParameterReflection(
+					$param->getName(),
+					$param->isOptional(),
+					$param->getType()->map($cb),
+					$param->passedByReference(),
+					$param->isVariadic()
+				);
+			}, $this->getParameters()),
+			$this->getReturnType()->map($cb),
+			$this->isVariadic()
+		));
 	}
 
 	/**

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -275,21 +275,21 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return $this->returnType;
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb(new static(
+		return new static(
 			array_map(static function (NativeParameterReflection $param) use ($cb): NativeParameterReflection {
 				return new NativeParameterReflection(
 					$param->getName(),
 					$param->isOptional(),
-					$param->getType()->map($cb),
+					$cb($param->getType()),
 					$param->passedByReference(),
 					$param->isVariadic()
 				);
 			}, $this->getParameters()),
-			$this->getReturnType()->map($cb),
+			$cb($this->getReturnType()),
 			$this->isVariadic()
-		));
+		);
 	}
 
 	/**

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -116,6 +116,11 @@ class FloatType implements Type
 		return new ErrorType();
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -116,9 +116,9 @@ class FloatType implements Type
 		return new ErrorType();
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -25,17 +25,17 @@ final class TemplateMixedType extends MixedType implements TemplateType
 
 	public function __construct(
 		TemplateTypeScope $scope,
+		TemplateTypeStrategy $templateTypeStrategy,
 		string $name,
 		bool $isExplicitMixed = false,
-		?Type $subtractedType = null,
-		?TemplateTypeStrategy $templateTypeStrategy = null
+		?Type $subtractedType = null
 	)
 	{
 		parent::__construct($isExplicitMixed, $subtractedType);
 
 		$this->scope = $scope;
+		$this->strategy = $templateTypeStrategy;
 		$this->name = $name;
-		$this->strategy = $templateTypeStrategy ?? new TemplateTypeParameterStrategy();
 	}
 
 	public function getName(): string
@@ -107,10 +107,10 @@ final class TemplateMixedType extends MixedType implements TemplateType
 	{
 		return new self(
 			$this->scope,
+			new TemplateTypeArgumentStrategy(),
 			$this->name,
 			$this->isExplicitMixed(),
-			$this->getSubtractedType(),
-			new TemplateTypeArgumentStrategy()
+			$this->getSubtractedType()
 		);
 	}
 
@@ -125,10 +125,10 @@ final class TemplateMixedType extends MixedType implements TemplateType
 
 		return new static(
 			$this->scope,
+			$this->strategy,
 			$this->name,
 			$this->isExplicitMixed(),
-			$type,
-			$this->strategy
+			$type
 		);
 	}
 
@@ -136,10 +136,10 @@ final class TemplateMixedType extends MixedType implements TemplateType
 	{
 		return new self(
 			$this->scope,
+			$this->strategy,
 			$this->name,
 			$this->isExplicitMixed(),
-			null,
-			$this->strategy
+			null
 		);
 	}
 
@@ -147,10 +147,10 @@ final class TemplateMixedType extends MixedType implements TemplateType
 	{
 		return new self(
 			$this->scope,
+			$this->strategy,
 			$this->name,
 			$this->isExplicitMixed(),
-			$subtractedType,
-			$this->strategy
+			$subtractedType
 		);
 	}
 
@@ -162,10 +162,10 @@ final class TemplateMixedType extends MixedType implements TemplateType
 	{
 		return new self(
 			$properties['scope'],
+			$properties['strategy'],
 			$properties['name'],
 			$properties['isExplicitMixed'],
-			$properties['subtractedType'],
-			$properties['strategy']
+			$properties['subtractedType']
 		);
 	}
 

--- a/src/Type/Generic/TemplateObjectType.php
+++ b/src/Type/Generic/TemplateObjectType.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Generic;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\CompoundType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -79,12 +80,31 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
-		return $this->strategy->isSuperTypeOf($this, $type);
+		if ($type instanceof CompoundType) {
+			return $type->isSubTypeOf($this);
+		}
+
+		return $this->getBound()->isSuperTypeOf($type)
+			->and(TrinaryLogic::createMaybe());
 	}
 
 	public function isSubTypeOf(Type $type): TrinaryLogic
 	{
-		return $this->strategy->isSubTypeOf($this, $type);
+		if ($type instanceof UnionType || $type instanceof IntersectionType) {
+			return $type->isSuperTypeOf($this);
+		}
+
+		if (!$type instanceof TemplateType) {
+			return $type->isSuperTypeOf($this->getBound())
+				->and(TrinaryLogic::createMaybe());
+		}
+
+		if ($this->equals($type)) {
+			return TrinaryLogic::createYes();
+		}
+
+		return $type->getBound()->isSuperTypeOf($this->getBound())
+			->and(TrinaryLogic::createMaybe());
 	}
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
@@ -93,7 +113,7 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 
-		if (!$this->isSuperTypeOf($receivedType)->yes()) {
+		if ($this->isSuperTypeOf($receivedType)->no()) {
 			return TemplateTypeMap::empty();
 		}
 

--- a/src/Type/Generic/TemplateObjectType.php
+++ b/src/Type/Generic/TemplateObjectType.php
@@ -24,17 +24,17 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 
 	public function __construct(
 		TemplateTypeScope $scope,
+		TemplateTypeStrategy $templateTypeStrategy,
 		string $name,
 		string $class,
-		?Type $subtractedType = null,
-		?TemplateTypeStrategy $templateTypeStrategy = null
+		?Type $subtractedType = null
 	)
 	{
 		parent::__construct($class, $subtractedType);
 
 		$this->scope = $scope;
+		$this->strategy = $templateTypeStrategy;
 		$this->name = $name;
-		$this->strategy = $templateTypeStrategy ?? new TemplateTypeParameterStrategy();
 	}
 
 	public function getName(): string
@@ -111,10 +111,10 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 	{
 		return new self(
 			$this->scope,
+			new TemplateTypeArgumentStrategy(),
 			$this->name,
 			$this->getClassName(),
-			$this->getSubtractedType(),
-			new TemplateTypeArgumentStrategy()
+			$this->getSubtractedType()
 		);
 	}
 
@@ -126,10 +126,10 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 
 		return new self(
 			$this->scope,
+			$this->strategy,
 			$this->name,
 			$this->getClassName(),
-			$type,
-			$this->strategy
+			$type
 		);
 	}
 
@@ -137,10 +137,10 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 	{
 		return new self(
 			$this->scope,
+			$this->strategy,
 			$this->name,
 			$this->getClassName(),
-			null,
-			$this->strategy
+			null
 		);
 	}
 
@@ -148,10 +148,10 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 	{
 		return new self(
 			$this->scope,
+			$this->strategy,
 			$this->name,
 			$this->getClassName(),
-			$subtractedType,
-			$this->strategy
+			$subtractedType
 		);
 	}
 
@@ -163,10 +163,10 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 	{
 		return new self(
 			$properties['scope'],
+			$properties['strategy'],
 			$properties['name'],
 			$properties['className'],
-			$properties['subtractedType'],
-			$properties['strategy']
+			$properties['subtractedType']
 		);
 	}
 

--- a/src/Type/Generic/TemplateType.php
+++ b/src/Type/Generic/TemplateType.php
@@ -2,11 +2,20 @@
 
 namespace PHPStan\Type\Generic;
 
+use PHPStan\Type\CompoundType;
 use PHPStan\Type\Type;
 
-interface TemplateType extends Type
+interface TemplateType extends CompoundType
 {
 
 	public function getName(): string;
+
+	public function getScope(): TemplateTypeScope;
+
+	public function getBound(): Type;
+
+	public function toArgument(): TemplateType;
+
+	public function isArgument(): bool;
 
 }

--- a/src/Type/Generic/TemplateTypeArgumentStrategy.php
+++ b/src/Type/Generic/TemplateTypeArgumentStrategy.php
@@ -3,10 +3,8 @@
 namespace PHPStan\Type\Generic;
 
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\CompoundType;
-use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
-use PHPStan\Type\UnionType;
 
 /**
  * Template type strategy suitable for return type acceptance contexts
@@ -16,25 +14,8 @@ class TemplateTypeArgumentStrategy implements TemplateTypeStrategy
 
 	public function accepts(TemplateType $left, Type $right, bool $strictTypes): TrinaryLogic
 	{
-		return $this->isSuperTypeOf($left, $right);
-	}
-
-	public function isSuperTypeOf(TemplateType $left, Type $right): TrinaryLogic
-	{
-		if ($right instanceof CompoundType && !$right instanceof TemplateType) {
-			return $right->isSubTypeOf($left);
-		}
-
-		return TrinaryLogic::createFromBoolean($left->equals($right));
-	}
-
-	public function isSubTypeOf(TemplateType $left, Type $right): TrinaryLogic
-	{
-		if ($right instanceof UnionType || $right instanceof IntersectionType) {
-			return $right->isSuperTypeOf($left);
-		}
-
-		return TrinaryLogic::createFromBoolean($left->equals($right));
+		return TrinaryLogic::createFromBoolean($left->equals($right))
+			->or(TrinaryLogic::createFromBoolean($right->equals(new MixedType())));
 	}
 
 	public function isArgument(): bool

--- a/src/Type/Generic/TemplateTypeArgumentStrategy.php
+++ b/src/Type/Generic/TemplateTypeArgumentStrategy.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\CompoundType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+/**
+ * Template type strategy suitable for return type acceptance contexts
+ */
+class TemplateTypeArgumentStrategy implements TemplateTypeStrategy
+{
+
+	public function accepts(TemplateType $left, Type $right, bool $strictTypes): TrinaryLogic
+	{
+		return $this->isSuperTypeOf($left, $right);
+	}
+
+	public function isSuperTypeOf(TemplateType $left, Type $right): TrinaryLogic
+	{
+		if ($right instanceof CompoundType && !$right instanceof TemplateType) {
+			return $right->isSubTypeOf($left);
+		}
+
+		return TrinaryLogic::createFromBoolean($left->equals($right));
+	}
+
+	public function isSubTypeOf(TemplateType $left, Type $right): TrinaryLogic
+	{
+		if ($right instanceof UnionType || $right instanceof IntersectionType) {
+			return $right->isSuperTypeOf($left);
+		}
+
+		return TrinaryLogic::createFromBoolean($left->equals($right));
+	}
+
+	public function isArgument(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @param mixed[] $properties
+	 */
+	public static function __set_state(array $properties): self
+	{
+		return new self();
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeFactory.php
+++ b/src/Type/Generic/TemplateTypeFactory.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+final class TemplateTypeFactory
+{
+
+	public static function create(TemplateTypeScope $scope, string $name, ?Type $bound): Type
+	{
+		if ($bound instanceof ObjectType) {
+			return new TemplateObjectType($scope, $name, $bound->getClassName());
+		}
+
+		if ($bound === null || $bound instanceof MixedType) {
+			return new TemplateMixedType($scope, $name);
+		}
+
+		return new ErrorType();
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeFactory.php
+++ b/src/Type/Generic/TemplateTypeFactory.php
@@ -12,12 +12,14 @@ final class TemplateTypeFactory
 
 	public static function create(TemplateTypeScope $scope, string $name, ?Type $bound): Type
 	{
+		$strategy = new TemplateTypeParameterStrategy();
+
 		if ($bound instanceof ObjectType) {
-			return new TemplateObjectType($scope, $name, $bound->getClassName());
+			return new TemplateObjectType($scope, $strategy, $name, $bound->getClassName());
 		}
 
 		if ($bound === null || $bound instanceof MixedType) {
-			return new TemplateMixedType($scope, $name);
+			return new TemplateMixedType($scope, $strategy, $name);
 		}
 
 		return new ErrorType();

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Generic;
 
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeTraverser;
 
 class TemplateTypeHelper
 {
@@ -13,7 +14,7 @@ class TemplateTypeHelper
 	 */
 	public static function resolveTemplateTypes(Type $type, TemplateTypeMap $standins): Type
 	{
-		return $type->map(static function (Type $type) use ($standins): Type {
+		return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($standins): Type {
 			if ($type instanceof TemplateType && !$type->isArgument()) {
 				$newType = $standins->getType($type->getName());
 
@@ -21,10 +22,10 @@ class TemplateTypeHelper
 					return new ErrorType();
 				}
 
-				return $newType;
+				return $traverse($newType);
 			}
 
-			return $type;
+			return $traverse($type);
 		});
 	}
 
@@ -33,12 +34,12 @@ class TemplateTypeHelper
 	 */
 	public static function toArgument(Type $type): Type
 	{
-		return $type->map(static function (Type $type): Type {
+		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
 			if ($type instanceof TemplateType) {
-				return $type->toArgument();
+				return $traverse($type->toArgument());
 			}
 
-			return $type;
+			return $traverse($type);
 		});
 	}
 

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
+
+class TemplateTypeHelper
+{
+
+	/**
+	 * Replaces template types with standin types
+	 */
+	public static function resolveTemplateTypes(Type $type, TemplateTypeMap $standins): Type
+	{
+		return $type->map(static function (Type $type) use ($standins): Type {
+			if ($type instanceof TemplateType && !$type->isArgument()) {
+				$newType = $standins->getType($type->getName());
+
+				if ($newType === null) {
+					return new ErrorType();
+				}
+
+				return $newType;
+			}
+
+			return $type;
+		});
+	}
+
+	/**
+	 * Switches all template types to their argument strategy
+	 */
+	public static function toArgument(Type $type): Type
+	{
+		return $type->map(static function (Type $type): Type {
+			if ($type instanceof TemplateType) {
+				return $type->toArgument();
+			}
+
+			return $type;
+		});
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeParameterStrategy.php
+++ b/src/Type/Generic/TemplateTypeParameterStrategy.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\CompoundType;
+use PHPStan\Type\CompoundTypeHelper;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+/**
+ * Template type strategy suitable for parameter type acceptance contexts
+ */
+class TemplateTypeParameterStrategy implements TemplateTypeStrategy
+{
+
+	public function accepts(TemplateType $left, Type $right, bool $strictTypes): TrinaryLogic
+	{
+		if ($right instanceof CompoundType) {
+			return CompoundTypeHelper::accepts($right, $left, $strictTypes);
+		}
+
+		return $left->getBound()->accepts($right, $strictTypes);
+	}
+
+	public function isSuperTypeOf(TemplateType $left, Type $right): TrinaryLogic
+	{
+		if ($right instanceof CompoundType) {
+			return $right->isSubTypeOf($left);
+		}
+
+		return $left->getBound()->isSuperTypeOf($right);
+	}
+
+	public function isSubTypeOf(TemplateType $left, Type $right): TrinaryLogic
+	{
+		// Inverse of isSuperTypeOf, except that TemplateTypes are
+		// never sub types of non-template types.
+
+		if ($right instanceof UnionType || $right instanceof IntersectionType) {
+			return $right->isSuperTypeOf($left);
+		}
+
+		if (!$right instanceof TemplateType) {
+			return TrinaryLogic::createNo();
+		}
+
+		return $right->getBound()->isSuperTypeOf($left->getBound());
+	}
+
+	public function isArgument(): bool
+	{
+		return false;
+	}
+
+	/**
+	 * @param mixed[] $properties
+	 */
+	public static function __set_state(array $properties): self
+	{
+		return new self();
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeParameterStrategy.php
+++ b/src/Type/Generic/TemplateTypeParameterStrategy.php
@@ -5,9 +5,7 @@ namespace PHPStan\Type\Generic;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\CompoundTypeHelper;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Type;
-use PHPStan\Type\UnionType;
 
 /**
  * Template type strategy suitable for parameter type acceptance contexts
@@ -22,31 +20,6 @@ class TemplateTypeParameterStrategy implements TemplateTypeStrategy
 		}
 
 		return $left->getBound()->accepts($right, $strictTypes);
-	}
-
-	public function isSuperTypeOf(TemplateType $left, Type $right): TrinaryLogic
-	{
-		if ($right instanceof CompoundType) {
-			return $right->isSubTypeOf($left);
-		}
-
-		return $left->getBound()->isSuperTypeOf($right);
-	}
-
-	public function isSubTypeOf(TemplateType $left, Type $right): TrinaryLogic
-	{
-		// Inverse of isSuperTypeOf, except that TemplateTypes are
-		// never sub types of non-template types.
-
-		if ($right instanceof UnionType || $right instanceof IntersectionType) {
-			return $right->isSuperTypeOf($left);
-		}
-
-		if (!$right instanceof TemplateType) {
-			return TrinaryLogic::createNo();
-		}
-
-		return $right->getBound()->isSuperTypeOf($left->getBound());
 	}
 
 	public function isArgument(): bool

--- a/src/Type/Generic/TemplateTypeScope.php
+++ b/src/Type/Generic/TemplateTypeScope.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+class TemplateTypeScope
+{
+
+	/** @var string|null */
+	private $className;
+
+	/** @var string|null */
+	private $functionName;
+
+	public function __construct(?string $className, ?string $functionName)
+	{
+		$this->className = $className;
+		$this->functionName = $functionName;
+	}
+
+	public function equals(self $other): bool
+	{
+		return $this->className === $other->className
+			&& $this->functionName === $other->functionName;
+	}
+
+	/**
+	 * @param mixed[] $properties
+	 */
+	public static function __set_state(array $properties): self
+	{
+		return new self(
+			$properties['className'],
+			$properties['functionName']
+		);
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeStrategy.php
+++ b/src/Type/Generic/TemplateTypeStrategy.php
@@ -10,10 +10,6 @@ interface TemplateTypeStrategy
 
 	public function accepts(TemplateType $left, Type $right, bool $strictTypes): TrinaryLogic;
 
-	public function isSuperTypeOf(TemplateType $left, Type $right): TrinaryLogic;
-
-	public function isSubTypeOf(TemplateType $left, Type $right): TrinaryLogic;
-
 	public function isArgument(): bool;
 
 }

--- a/src/Type/Generic/TemplateTypeStrategy.php
+++ b/src/Type/Generic/TemplateTypeStrategy.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+
+interface TemplateTypeStrategy
+{
+
+	public function accepts(TemplateType $left, Type $right, bool $strictTypes): TrinaryLogic;
+
+	public function isSuperTypeOf(TemplateType $left, Type $right): TrinaryLogic;
+
+	public function isSubTypeOf(TemplateType $left, Type $right): TrinaryLogic;
+
+	public function isArgument(): bool;
+
+}

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -377,13 +377,13 @@ class IntersectionType implements CompoundType, StaticResolvableType
 		return $types;
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
 		$types = [];
 		$changed = false;
 
 		foreach ($this->types as $type) {
-			$newType = $type->map($cb);
+			$newType = $cb($type);
 			if ($type !== $newType) {
 				$changed = true;
 			}
@@ -391,10 +391,10 @@ class IntersectionType implements CompoundType, StaticResolvableType
 		}
 
 		if ($changed) {
-			return $cb(new static($types));
+			return TypeCombinator::intersect(...$types);
 		}
 
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -377,6 +377,26 @@ class IntersectionType implements CompoundType, StaticResolvableType
 		return $types;
 	}
 
+	public function map(callable $cb): Type
+	{
+		$types = [];
+		$changed = false;
+
+		foreach ($this->types as $type) {
+			$newType = $type->map($cb);
+			if ($type !== $newType) {
+				$changed = true;
+			}
+			$types[] = $newType;
+		}
+
+		if ($changed) {
+			return $cb(new static($types));
+		}
+
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -188,16 +188,16 @@ class IterableType implements StaticResolvableType, CompoundType
 	}
 
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		$keyType = $this->keyType->map($cb);
-		$itemType = $this->itemType->map($cb);
+		$keyType = $cb($this->keyType);
+		$itemType = $cb($this->itemType);
 
 		if ($keyType !== $this->keyType || $itemType !== $this->itemType) {
-			return $cb(new static($keyType, $itemType));
+			return new static($keyType, $itemType);
 		}
 
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -187,6 +187,19 @@ class IterableType implements StaticResolvableType, CompoundType
 		return $this->getItemType();
 	}
 
+
+	public function map(callable $cb): Type
+	{
+		$keyType = $this->keyType->map($cb);
+		$itemType = $this->itemType->map($cb);
+
+		if ($keyType !== $this->keyType || $itemType !== $this->itemType) {
+			return $cb(new static($keyType, $itemType));
+		}
+
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -46,4 +46,9 @@ trait JustNullableTypeTrait
 		return $type instanceof self;
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 }

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -46,9 +46,9 @@ trait JustNullableTypeTrait
 		return $type instanceof self;
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 }

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -266,9 +266,9 @@ class MixedType implements CompoundType, SubtractableType
 		return $this->subtractedType;
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -266,6 +266,11 @@ class MixedType implements CompoundType, SubtractableType
 		return $this->subtractedType;
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -183,9 +183,9 @@ class NeverType implements CompoundType
 		return $this;
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -183,6 +183,11 @@ class NeverType implements CompoundType
 		return $this;
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -124,9 +124,9 @@ class NullType implements ConstantScalarType
 		return $array->setOffsetValueType($offsetType, $valueType);
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -124,6 +124,11 @@ class NullType implements ConstantScalarType
 		return $array->setOffsetValueType($offsetType, $valueType);
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -720,18 +720,18 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return $this->subtractedType;
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		$subtractedType = $this->subtractedType !== null ? $this->subtractedType->map($cb) : null;
+		$subtractedType = $this->subtractedType !== null ? $cb($this->subtractedType) : null;
 
 		if ($subtractedType !== $this->subtractedType) {
-			return $cb(new static(
+			return new static(
 				$this->className,
 				$subtractedType
-			));
+			);
 		}
 
-		return $cb($this);
+		return $this;
 	}
 
 }

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -720,4 +720,18 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return $this->subtractedType;
 	}
 
+	public function map(callable $cb): Type
+	{
+		$subtractedType = $this->subtractedType !== null ? $this->subtractedType->map($cb) : null;
+
+		if ($subtractedType !== $this->subtractedType) {
+			return $cb(new static(
+				$this->className,
+				$subtractedType
+			));
+		}
+
+		return $cb($this);
+	}
+
 }

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -141,15 +141,15 @@ class ObjectWithoutClassType implements SubtractableType
 	}
 
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		$subtractedType = $this->subtractedType !== null ? $this->subtractedType->map($cb) : null;
+		$subtractedType = $this->subtractedType !== null ? $cb($this->subtractedType) : null;
 
 		if ($subtractedType !== $this->subtractedType) {
-			return $cb(new static($subtractedType));
+			return new static($subtractedType);
 		}
 
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -140,6 +140,18 @@ class ObjectWithoutClassType implements SubtractableType
 		return $this->subtractedType;
 	}
 
+
+	public function map(callable $cb): Type
+	{
+		$subtractedType = $this->subtractedType !== null ? $this->subtractedType->map($cb) : null;
+
+		if ($subtractedType !== $this->subtractedType) {
+			return $cb(new static($subtractedType));
+		}
+
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -233,9 +233,9 @@ class StaticType implements StaticResolvableType, TypeWithClassName
 		return $this->staticObjectType->toArray();
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -233,6 +233,11 @@ class StaticType implements StaticResolvableType, TypeWithClassName
 		return $this->staticObjectType->toArray();
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -90,6 +90,13 @@ interface Type
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap;
 
 	/**
+	 * Transforms $this with the given callable
+	 *
+	 * @param callable(Type):Type $cb
+	 */
+	public function map(callable $cb): Type;
+
+	/**
 	 * @param mixed[] $properties
 	 * @return self
 	 */

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -90,11 +90,14 @@ interface Type
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap;
 
 	/**
-	 * Transforms $this with the given callable
+	 * Traverses inner types
+	 *
+	 * Returns a new instance with all inner types mapped through $cb. Might
+	 * return the same instance if inner types did not change.
 	 *
 	 * @param callable(Type):Type $cb
 	 */
-	public function map(callable $cb): Type;
+	public function traverse(callable $cb): Type;
 
 	/**
 	 * @param mixed[] $properties

--- a/src/Type/TypeTraverser.php
+++ b/src/Type/TypeTraverser.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+class TypeTraverser
+{
+
+	/**
+	 * Map a Type recursively
+	 *
+	 * For every Type instance, the callback can return a new Type, and/or
+	 * decide to traverse inner types or to ignore them.
+	 *
+	 * The following example converts constant strings to objects, while
+	 * preserving unions and intersections:
+	 *
+	 * TypeTraverser::map($type, function (Type $type, callable $traverse): Type {
+	 *     if ($type instanceof UnionType || $type instanceof IntersectionType) {
+	 *         // Traverse inner types
+	 *         return $traverse($type);
+	 *     }
+	 *     if ($type instanceof ConstantStringType) {
+	 *         // Replaces the current type, and don't traverse
+	 *         return new ObjectType($type->getValue());
+	 *     }
+	 *     // Replaces the current type, and don't traverse
+	 *     return new MixedType();
+	 * });
+	 *
+	 * @param callable(Type $type, callable(Type): Type $traverse): Type $cb
+	 */
+	public static function map(Type $type, callable $cb): Type
+	{
+		$map = static function (Type $type) use ($cb, &$map): Type {
+			static $traverse = null;
+			if ($traverse === null) {
+				$traverse = static function (Type $type) use ($map): Type {
+					return $type->traverse($map);
+				};
+			}
+			return $cb($type, $traverse);
+		};
+
+		return $map($type);
+	}
+
+}

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -555,13 +555,13 @@ class UnionType implements CompoundType, StaticResolvableType
 		return $types;
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
 		$types = [];
 		$changed = false;
 
 		foreach ($this->types as $type) {
-			$newType = $type->map($cb);
+			$newType = $cb($type);
 			if ($type !== $newType) {
 				$changed = true;
 			}
@@ -569,10 +569,10 @@ class UnionType implements CompoundType, StaticResolvableType
 		}
 
 		if ($changed) {
-			return $cb(new static($types));
+			return TypeCombinator::union(...$types);
 		}
 
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -555,6 +555,26 @@ class UnionType implements CompoundType, StaticResolvableType
 		return $types;
 	}
 
+	public function map(callable $cb): Type
+	{
+		$types = [];
+		$changed = false;
+
+		foreach ($this->types as $type) {
+			$newType = $type->map($cb);
+			if ($type !== $newType) {
+				$changed = true;
+			}
+			$types[] = $newType;
+		}
+
+		if ($changed) {
+			return $cb(new static($types));
+		}
+
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -81,9 +81,9 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
-	public function map(callable $cb): Type
+	public function traverse(callable $cb): Type
 	{
-		return $cb($this);
+		return $this;
 	}
 
 	/**

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -81,6 +81,11 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
+	public function map(callable $cb): Type
+	{
+		return $cb($this);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -5,7 +5,8 @@ namespace PHPStan\Type;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
-use PHPStan\Type\Generic\TemplateMixedType;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeScope;
 
 class ArrayTypeTest extends \PHPStan\Testing\TestCase
 {
@@ -139,6 +140,14 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 
 	public function dataInferTemplateTypes(): array
 	{
+		$templateType = static function (string $name): Type {
+			return TemplateTypeFactory::create(
+				new TemplateTypeScope(null, null),
+				$name,
+				new MixedType()
+			);
+		};
+
 		return [
 			'valid templated item' => [
 				new ArrayType(
@@ -147,7 +156,7 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 				),
 				new ArrayType(
 					new MixedType(),
-					new TemplateMixedType('T')
+					$templateType('T')
 				),
 				['T' => 'DateTime'],
 			],
@@ -155,7 +164,7 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 				new MixedType(),
 				new ArrayType(
 					new MixedType(),
-					new TemplateMixedType('T')
+					$templateType('T')
 				),
 				['T' => '*NEVER*'],
 			],
@@ -163,7 +172,7 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 				new StringType(),
 				new ArrayType(
 					new MixedType(),
-					new TemplateMixedType('T')
+					$templateType('T')
 				),
 				['T' => '*NEVER*'],
 			],
@@ -177,7 +186,7 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 				),
 				new ArrayType(
 					new MixedType(),
-					new TemplateMixedType('T')
+					$templateType('T')
 				),
 				['T' => 'int|string'],
 			],
@@ -195,7 +204,7 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				new ArrayType(
 					new MixedType(),
-					new TemplateMixedType('T')
+					$templateType('T')
 				),
 				['T' => 'int|string'],
 			],

--- a/tests/PHPStan/Type/CallableTypeTest.php
+++ b/tests/PHPStan/Type/CallableTypeTest.php
@@ -6,7 +6,8 @@ use PHPStan\Reflection\Native\NativeParameterReflection;
 use PHPStan\Reflection\PassedByReference;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\HasMethodType;
-use PHPStan\Type\Generic\TemplateMixedType;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeScope;
 
 class CallableTypeTest extends \PHPStan\Testing\TestCase
 {
@@ -163,6 +164,14 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 			);
 		};
 
+		$templateType = static function (string $name): Type {
+			return TemplateTypeFactory::create(
+				new TemplateTypeScope(null, null),
+				$name,
+				new MixedType()
+			);
+		};
+
 		return [
 			'template param' => [
 				new CallableType(
@@ -173,7 +182,7 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 				),
 				new CallableType(
 					[
-						$param(new TemplateMixedType('T')),
+						$param($templateType('T')),
 					],
 					new IntegerType()
 				),
@@ -190,7 +199,7 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 					[
 						$param(new StringType()),
 					],
-					new TemplateMixedType('T')
+					$templateType('T')
 				),
 				['T' => 'int'],
 			],
@@ -205,9 +214,9 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 				new CallableType(
 					[
 						$param(new StringType()),
-						$param(new TemplateMixedType('A')),
+						$param($templateType('A')),
 					],
-					new TemplateMixedType('B')
+					$templateType('B')
 				),
 				['A' => 'DateTime', 'B' => 'int'],
 			],
@@ -225,9 +234,9 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 				new CallableType(
 					[
 						$param(new StringType()),
-						$param(new TemplateMixedType('A')),
+						$param($templateType('A')),
 					],
-					new TemplateMixedType('B')
+					$templateType('B')
 				),
 				['A' => 'DateTime', 'B' => 'int'],
 			],
@@ -236,9 +245,9 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 				new CallableType(
 					[
 						$param(new StringType()),
-						$param(new TemplateMixedType('A')),
+						$param($templateType('A')),
 					],
-					new TemplateMixedType('B')
+					$templateType('B')
 				),
 				[],
 			],

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -10,6 +10,73 @@ use PHPStan\Type\Generic\TemplateTypeScope;
 class TemplateTypeTest extends \PHPStan\Testing\TestCase
 {
 
+	public function dataAccepts(): array
+	{
+		$templateType = static function (string $name, ?Type $bound, ?string $functionName = null): Type {
+			return TemplateTypeFactory::create(
+				new TemplateTypeScope(null, $functionName),
+				$name,
+				$bound
+			);
+		};
+
+		return [
+			[
+				$templateType('T', new ObjectType('DateTime')),
+				new ObjectType('DateTime'),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				$templateType('T', new ObjectType('DateTime')),
+				$templateType('T', new ObjectType('DateTime')),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createYes(),
+			],
+			[
+				$templateType('T', new ObjectType('DateTime'), 'a'),
+				$templateType('T', new ObjectType('DateTime'), 'b'),
+				TrinaryLogic::createMaybe(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				$templateType('T', null),
+				new MixedType(),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createYes(),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataAccepts
+	 */
+	public function testAccepts(
+		Type $type,
+		Type $otherType,
+		TrinaryLogic $expectedAccept,
+		TrinaryLogic $expectedAcceptArg
+	): void
+	{
+		assert($type instanceof TemplateType);
+
+		$actualResult = $type->accepts($otherType, true);
+		$this->assertSame(
+			$expectedAccept->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise()))
+		);
+
+		$type = $type->toArgument();
+
+		$actualResult = $type->accepts($otherType, true);
+		$this->assertSame(
+			$expectedAcceptArg->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> accepts(%s) (Argument strategy)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise()))
+		);
+	}
+
 	public function dataIsSuperTypeOf(): array
 	{
 		$templateType = static function (string $name, Type $bound, ?string $functionName = null): Type {
@@ -24,32 +91,24 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 			[
 				$templateType('T', new ObjectType('DateTime')),
 				new ObjectType('DateTime'),
-				TrinaryLogic::createYes(),
-				TrinaryLogic::createNo(),
-				TrinaryLogic::createNo(),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
+				TrinaryLogic::createMaybe(),
 			],
 			[
 				$templateType('T', new ObjectType('DateTime')),
 				$templateType('T', new ObjectType('DateTime')),
-				TrinaryLogic::createYes(),
-				TrinaryLogic::createYes(),
 				TrinaryLogic::createYes(),
 				TrinaryLogic::createYes(),
 			],
 			[
 				$templateType('T', new ObjectType('DateTime'), 'a'),
 				$templateType('T', new ObjectType('DateTime'), 'b'),
-				TrinaryLogic::createYes(),
-				TrinaryLogic::createYes(),
-				TrinaryLogic::createNo(),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
+				TrinaryLogic::createMaybe(),
 			],
 			[
 				$templateType('T', new ObjectType('DateTime')),
 				new StringType(),
-				TrinaryLogic::createNo(),
-				TrinaryLogic::createNo(),
 				TrinaryLogic::createNo(),
 				TrinaryLogic::createNo(),
 			],
@@ -57,17 +116,13 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 				$templateType('T', new ObjectType('DateTime')),
 				new ObjectType('DateTimeInterface'),
 				TrinaryLogic::createMaybe(),
-				TrinaryLogic::createNo(),
-				TrinaryLogic::createNo(),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
 			],
 			[
 				$templateType('T', new ObjectType('DateTime')),
 				$templateType('T', new ObjectType('DateTimeInterface')),
 				TrinaryLogic::createMaybe(),
-				TrinaryLogic::createYes(),
-				TrinaryLogic::createNo(),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
 			],
 			[
 				$templateType('T', new ObjectType('DateTime')),
@@ -76,9 +131,7 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 					new ObjectType('DateTime'),
 				]),
 				TrinaryLogic::createMaybe(),
-				TrinaryLogic::createNo(),
-				TrinaryLogic::createNo(),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
 			],
 		];
 	}
@@ -90,9 +143,7 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 		Type $type,
 		Type $otherType,
 		TrinaryLogic $expectedIsSuperType,
-		TrinaryLogic $expectedIsSuperTypeInverse,
-		TrinaryLogic $expectedIsSuperTypeArg,
-		TrinaryLogic $expectedIsSuperTypeArgInverse
+		TrinaryLogic $expectedIsSuperTypeInverse
 	): void
 	{
 		assert($type instanceof TemplateType);
@@ -107,23 +158,6 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 		$actualResult = $otherType->isSuperTypeOf($type);
 		$this->assertSame(
 			$expectedIsSuperTypeInverse->describe(),
-			$actualResult->describe(),
-			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise()))
-		);
-
-		// Switch to ArgumentStrategy
-		$type = $type->toArgument();
-
-		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
-			$expectedIsSuperTypeArg->describe(),
-			$actualResult->describe(),
-			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise()))
-		);
-
-		$actualResult = $otherType->isSuperTypeOf($type);
-		$this->assertSame(
-			$expectedIsSuperTypeArgInverse->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise()))
 		);

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeScope;
+
+class TemplateTypeTest extends \PHPStan\Testing\TestCase
+{
+
+	public function dataIsSuperTypeOf(): array
+	{
+		$templateType = static function (string $name, Type $bound, ?string $functionName = null): Type {
+			return TemplateTypeFactory::create(
+				new TemplateTypeScope(null, $functionName),
+				$name,
+				$bound
+			);
+		};
+
+		return [
+			[
+				$templateType('T', new ObjectType('DateTime')),
+				new ObjectType('DateTime'),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				$templateType('T', new ObjectType('DateTime')),
+				$templateType('T', new ObjectType('DateTime')),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createYes(),
+			],
+			[
+				$templateType('T', new ObjectType('DateTime'), 'a'),
+				$templateType('T', new ObjectType('DateTime'), 'b'),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				$templateType('T', new ObjectType('DateTime')),
+				new StringType(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				$templateType('T', new ObjectType('DateTime')),
+				new ObjectType('DateTimeInterface'),
+				TrinaryLogic::createMaybe(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				$templateType('T', new ObjectType('DateTime')),
+				$templateType('T', new ObjectType('DateTimeInterface')),
+				TrinaryLogic::createMaybe(),
+				TrinaryLogic::createYes(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				$templateType('T', new ObjectType('DateTime')),
+				new UnionType([
+					new NullType(),
+					new ObjectType('DateTime'),
+				]),
+				TrinaryLogic::createMaybe(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataIsSuperTypeOf
+	 */
+	public function testIsSuperTypeOf(
+		Type $type,
+		Type $otherType,
+		TrinaryLogic $expectedIsSuperType,
+		TrinaryLogic $expectedIsSuperTypeInverse,
+		TrinaryLogic $expectedIsSuperTypeArg,
+		TrinaryLogic $expectedIsSuperTypeArgInverse
+	): void
+	{
+		assert($type instanceof TemplateType);
+
+		$actualResult = $type->isSuperTypeOf($otherType);
+		$this->assertSame(
+			$expectedIsSuperType->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise()))
+		);
+
+		$actualResult = $otherType->isSuperTypeOf($type);
+		$this->assertSame(
+			$expectedIsSuperTypeInverse->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise()))
+		);
+
+		// Switch to ArgumentStrategy
+		$type = $type->toArgument();
+
+		$actualResult = $type->isSuperTypeOf($otherType);
+		$this->assertSame(
+			$expectedIsSuperTypeArg->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise()))
+		);
+
+		$actualResult = $otherType->isSuperTypeOf($type);
+		$this->assertSame(
+			$expectedIsSuperTypeArgInverse->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise()))
+		);
+	}
+
+}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -11,6 +11,9 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeScope;
 
 class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 {
@@ -1095,6 +1098,62 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 				MixedType::class,
 				'mixed',
 			],
+			[
+				[
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						null
+					),
+					new ObjectType('DateTime'),
+				],
+				UnionType::class,
+				'DateTime|T',
+			],
+			[
+				[
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						new ObjectType('DateTime')
+					),
+					new ObjectType('DateTime'),
+				],
+				UnionType::class,
+				'DateTime|T of DateTime',
+			],
+			[
+				[
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						new ObjectType('DateTime')
+					),
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						new ObjectType('DateTime')
+					),
+				],
+				TemplateType::class,
+				'T of DateTime',
+			],
+			[
+				[
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						new ObjectType('DateTime')
+					),
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'U',
+						new ObjectType('DateTime')
+					),
+				],
+				UnionType::class,
+				'T of DateTime|U of DateTime',
+			],
 		];
 	}
 
@@ -1692,6 +1751,62 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 				],
 				MixedType::class,
 				'mixed~int|string',
+			],
+			[
+				[
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						null
+					),
+					new ObjectType('DateTime'),
+				],
+				IntersectionType::class,
+				'DateTime&T',
+			],
+			[
+				[
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						new ObjectType('DateTime')
+					),
+					new ObjectType('DateTime'),
+				],
+				IntersectionType::class,
+				'DateTime&T of DateTime',
+			],
+			[
+				[
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						new ObjectType('DateTime')
+					),
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						new ObjectType('DateTime')
+					),
+				],
+				TemplateType::class,
+				'T of DateTime',
+			],
+			[
+				[
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'T',
+						new ObjectType('DateTime')
+					),
+					TemplateTypeFactory::create(
+						new TemplateTypeScope(null, null),
+						'U',
+						new ObjectType('DateTime')
+					),
+				],
+				IntersectionType::class,
+				'T of DateTime&U of DateTime',
 			],
 		];
 	}


### PR DESCRIPTION
TemplateType must behave differently depending on the context:

 - In a parameter acceptance context, when inferring template types, they must behave mostly like their bound: `T of DateTime` accepts a `DateTime`, etc.
 - In the context of a generic function's body, and especially for return type acceptance, they must accept only themselves (see example bellow).

In this PR I add two strategies to be used by template types to implement these behaviors. I also add `Type::map()` to quickly transform a type, and `TemplateTypeHelper`.

This allows to check return types properly, as in the following example:

```
/**
 * @template T of \DateTime
 * @param T $x
 * @return T
 */
function f($x) {
    return new DateTime(); // ERROR
    return rand(0, 1) === 1 ? $x : new DateTime(); // ERROR
    return $x; // OK
    return g($x); // OK
}

/**
 * @template U
 * @param U $x
 * @return U
 */
function g($x) {
    return $x;
}
```