### PR TITLE
exec(): use PHP_BINARY instead of env php

### DIFF
--- a/src/Testing/LevelsTestCase.php
+++ b/src/Testing/LevelsTestCase.php
@@ -39,7 +39,7 @@ abstract class LevelsTestCase extends \PHPUnit\Framework\TestCase
 
 		foreach (range(0, 7) as $level) {
 			unset($outputLines);
-			exec(sprintf('%s %s analyse --no-progress --error-format=prettyJson --level=%d %s --autoload-file %s %s', PHP_BINARY, $command, $level, $configPath !== null ? '--configuration ' . escapeshellarg($configPath) : '', escapeshellarg($file), escapeshellarg($file)), $outputLines);
+			exec(sprintf('%s %s analyse --no-progress --error-format=prettyJson --level=%d %s --autoload-file %s %s', escapeshellarg(PHP_BINARY), $command, $level, $configPath !== null ? '--configuration ' . escapeshellarg($configPath) : '', escapeshellarg($file), escapeshellarg($file)), $outputLines);
 
 			$output = implode("\n", $outputLines);
 

--- a/src/Testing/LevelsTestCase.php
+++ b/src/Testing/LevelsTestCase.php
@@ -39,7 +39,7 @@ abstract class LevelsTestCase extends \PHPUnit\Framework\TestCase
 
 		foreach (range(0, 7) as $level) {
 			unset($outputLines);
-			exec(sprintf('php %s analyse --no-progress --error-format=prettyJson --level=%d %s --autoload-file %s %s', $command, $level, $configPath !== null ? '--configuration ' . escapeshellarg($configPath) : '', escapeshellarg($file), escapeshellarg($file)), $outputLines);
+			exec(sprintf('%s %s analyse --no-progress --error-format=prettyJson --level=%d %s --autoload-file %s %s', PHP_BINARY, $command, $level, $configPath !== null ? '--configuration ' . escapeshellarg($configPath) : '', escapeshellarg($file), escapeshellarg($file)), $outputLines);
 
 			$output = implode("\n", $outputLines);
 


### PR DESCRIPTION
When building on systems with multiple php binaries, `exec('php -v');` takes the user/system default binary alias instead of the one that runs the command.

Using `PHP_BINARY` ensure that tests run with the same php binary and version.