### PR TITLE
README.md: link Zend Framework extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Unofficial extensions for other frameworks and libraries are also available:
 * [moneyphp/money](https://github.com/JohnstonCode/phpstan-moneyphp)
 * [Drupal](https://github.com/mglaman/phpstan-drupal)
 * [WordPress](https://github.com/szepeviktor/phpstan-wordpress)
+* [Zend Framework](https://github.com/Slamdunk/phpstan-zend-framework)
 
 Unofficial extensions with third-party rules:
 


### PR DESCRIPTION
:eyes: 

As asked in https://github.com/bitwombat/phpstan-zend-framework/issues/3, previous developers that have done similar efforts allowed me to mark this as the latest one among unofficial but supported Zend PHPStan extension.

I'm asking here to link it in the README to help the extension spread in both usage and support