### PR TITLE
Template type handling in parameters acceptors 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -228,7 +228,7 @@
 				checkreturn="true"
 		>
 			<arg value="-d"/>
-			<arg value="memory_limit=512M"/>
+			<arg value="memory_limit=640M"/>
 			<arg path="bin/phpstan"/>
 			<arg value="analyse"/>
 			<arg value="-c"/>

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -198,6 +198,9 @@ services:
 		class: PHPStan\PhpDoc\PhpDocStringResolver
 
 	-
+		class: PHPStan\PhpDoc\ConstExprNodeResolver
+
+	-
 		class: PHPStan\PhpDoc\TypeNodeResolver
 		factory: @typeNodeResolverFactory::create
 

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -1960,7 +1960,7 @@ class Scope implements ClassMemberAccessAnswerer
 	): self
 	{
 		$variableTypes = $this->getVariableTypes();
-		foreach (ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getParameters() as $parameter) {
+		foreach (ParametersAcceptorSelector::selectArguments($functionReflection->getVariants())->getParameters() as $parameter) {
 			$variableTypes[$parameter->getName()] = VariableTypeHolder::createYes($parameter->getType());
 		}
 

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -52,6 +52,7 @@ use PHPStan\Type\ConstantType;
 use PHPStan\Type\ConstantTypeHelper;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
@@ -1860,11 +1861,13 @@ class Scope implements ClassMemberAccessAnswerer
 				$this->getClassReflection(),
 				$classMethod,
 				$this->getRealParameterTypes($classMethod),
-				$phpDocParameterTypes,
+				array_map(static function (Type $type): Type {
+					return TemplateTypeHelper::toArgument($type);
+				}, $phpDocParameterTypes),
 				$this->getRealParameterDefaultValues($classMethod),
 				$classMethod->returnType !== null,
 				$this->getFunctionType($classMethod->returnType, $classMethod->returnType === null, false),
-				$phpDocReturnType,
+				$phpDocReturnType !== null ? TemplateTypeHelper::toArgument($phpDocReturnType) : null,
 				$throwType,
 				$deprecatedDescription,
 				$isDeprecated,
@@ -1941,11 +1944,13 @@ class Scope implements ClassMemberAccessAnswerer
 			new PhpFunctionFromParserNodeReflection(
 				$function,
 				$this->getRealParameterTypes($function),
-				$phpDocParameterTypes,
+				array_map(static function (Type $type): Type {
+					return TemplateTypeHelper::toArgument($type);
+				}, $phpDocParameterTypes),
 				$this->getRealParameterDefaultValues($function),
 				$function->returnType !== null,
 				$this->getFunctionType($function->returnType, $function->returnType === null, false),
-				$phpDocReturnType,
+				$phpDocReturnType !== null ? TemplateTypeHelper::toArgument($phpDocReturnType) : null,
 				$throwType,
 				$deprecatedDescription,
 				$isDeprecated,
@@ -1960,7 +1965,7 @@ class Scope implements ClassMemberAccessAnswerer
 	): self
 	{
 		$variableTypes = $this->getVariableTypes();
-		foreach (ParametersAcceptorSelector::selectArguments($functionReflection->getVariants())->getParameters() as $parameter) {
+		foreach (ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getParameters() as $parameter) {
 			$variableTypes[$parameter->getName()] = VariableTypeHolder::createYes($parameter->getType());
 		}
 

--- a/src/Broker/Broker.php
+++ b/src/Broker/Broker.php
@@ -419,7 +419,8 @@ class Broker
 								$parameterSignature->isOptional(),
 								$type,
 								$parameterSignature->passedByReference(),
-								$parameterSignature->isVariadic()
+								$parameterSignature->isVariadic(),
+								null
 							);
 						}, $functionSignature->getParameters()),
 						$functionSignature->isVariadic(),

--- a/src/PhpDoc/ConstExprNodeResolver.php
+++ b/src/PhpDoc/ConstExprNodeResolver.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDoc;
+
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprArrayNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFalseNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFloatNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNullNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprTrueNode;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\ConstantTypeHelper;
+use PHPStan\Type\Type;
+
+class ConstExprNodeResolver
+{
+
+	public function resolve(ConstExprNode $node): Type
+	{
+		if ($node instanceof ConstExprArrayNode) {
+			return $this->resolveArrayNode($node);
+		}
+
+		if ($node instanceof ConstExprFalseNode) {
+			return ConstantTypeHelper::getTypeFromValue(false);
+		}
+
+		if ($node instanceof ConstExprTrueNode) {
+			return ConstantTypeHelper::getTypeFromValue(true);
+		}
+
+		if ($node instanceof ConstExprFloatNode) {
+			return ConstantTypeHelper::getTypeFromValue((float) $node->value);
+		}
+
+		if ($node instanceof ConstExprIntegerNode) {
+			return ConstantTypeHelper::getTypeFromValue((int) $node->value);
+		}
+
+		if ($node instanceof ConstExprNullNode) {
+			return ConstantTypeHelper::getTypeFromValue(null);
+		}
+
+		if ($node instanceof ConstExprStringNode) {
+			return ConstantTypeHelper::getTypeFromValue($node->value);
+		}
+
+		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	private function resolveArrayNode(ConstExprArrayNode $node): Type
+	{
+		$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
+		$nextIndex = 0;
+
+		foreach ($node->items as $item) {
+			if ($item->key === null) {
+				$key = new ConstantIntegerType($nextIndex);
+				$nextIndex++;
+			} else {
+				$key = $this->resolve($item->key);
+			}
+			$arrayBuilder->setOffsetValueType($key, $this->resolve($item->value));
+		}
+
+		return $arrayBuilder->getArray();
+	}
+
+}

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -27,9 +27,13 @@ class PhpDocNodeResolver
 	/** @var TypeNodeResolver */
 	private $typeNodeResolver;
 
-	public function __construct(TypeNodeResolver $typeNodeResolver)
+	/** @var ConstExprNodeResolver */
+	private $constExprNodeResolver;
+
+	public function __construct(TypeNodeResolver $typeNodeResolver, ConstExprNodeResolver $constExprNodeResolver)
 	{
 		$this->typeNodeResolver = $typeNodeResolver;
+		$this->constExprNodeResolver = $constExprNodeResolver;
 	}
 
 	public function resolve(PhpDocNode $phpDocNode, NameScope $nameScope): ResolvedPhpDocBlock
@@ -140,13 +144,19 @@ class PhpDocNodeResolver
 				if ($parameterNode->defaultValue instanceof ConstExprNullNode) {
 					$type = TypeCombinator::addNull($type);
 				}
+				$defaultValue = null;
+				if ($parameterNode->defaultValue !== null) {
+					$defaultValue = $this->constExprNodeResolver->resolve($parameterNode->defaultValue);
+				}
+
 				$parameters[$parameterName] = new MethodTagParameter(
 					$type,
 					$parameterNode->isReference
 						? PassedByReference::createCreatesNewVariable()
 						: PassedByReference::createNo(),
 					$parameterNode->isVariadic || $parameterNode->defaultValue !== null,
-					$parameterNode->isVariadic
+					$parameterNode->isVariadic,
+					$defaultValue
 				);
 			}
 

--- a/src/PhpDoc/Tag/MethodTagParameter.php
+++ b/src/PhpDoc/Tag/MethodTagParameter.php
@@ -20,17 +20,22 @@ class MethodTagParameter
 	/** @var bool */
 	private $isVariadic;
 
+	/** @var \PHPStan\Type\Type|null */
+	private $defaultValue;
+
 	public function __construct(
 		Type $type,
 		PassedByReference $passedByReference,
 		bool $isOptional,
-		bool $isVariadic
+		bool $isVariadic,
+		?Type $defaultValue
 	)
 	{
 		$this->type = $type;
 		$this->passedByReference = $passedByReference;
 		$this->isOptional = $isOptional;
 		$this->isVariadic = $isVariadic;
+		$this->defaultValue = $defaultValue;
 	}
 
 	public function getType(): Type
@@ -53,6 +58,11 @@ class MethodTagParameter
 		return $this->isVariadic;
 	}
 
+	public function getDefaultValue(): ?Type
+	{
+		return $this->defaultValue;
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return self
@@ -63,7 +73,8 @@ class MethodTagParameter
 			$properties['type'],
 			$properties['passedByReference'],
 			$properties['isOptional'],
-			$properties['isVariadic']
+			$properties['isVariadic'],
+			$properties['defaultValue']
 		);
 	}
 

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -336,7 +336,8 @@ class TypeNodeResolver
 					$parameterNode->isOptional,
 					$this->resolve($parameterNode->type, $nameScope),
 					$parameterNode->isReference ? PassedByReference::createCreatesNewVariable() : PassedByReference::createNo(),
-					$parameterNode->isVariadic
+					$parameterNode->isVariadic,
+					null
 				);
 			},
 			$typeNode->parameters

--- a/src/Reflection/Annotations/AnnotationsMethodParameterReflection.php
+++ b/src/Reflection/Annotations/AnnotationsMethodParameterReflection.php
@@ -24,13 +24,17 @@ class AnnotationsMethodParameterReflection implements ParameterReflection
 	/** @var bool */
 	private $isVariadic;
 
-	public function __construct(string $name, Type $type, PassedByReference $passedByReference, bool $isOptional, bool $isVariadic)
+	/** @var Type|null */
+	private $defaultValue;
+
+	public function __construct(string $name, Type $type, PassedByReference $passedByReference, bool $isOptional, bool $isVariadic, ?Type $defaultValue)
 	{
 		$this->name = $name;
 		$this->type = $type;
 		$this->passedByReference = $passedByReference;
 		$this->isOptional = $isOptional;
 		$this->isVariadic = $isVariadic;
+		$this->defaultValue = $defaultValue;
 	}
 
 	public function getName(): string
@@ -56,6 +60,11 @@ class AnnotationsMethodParameterReflection implements ParameterReflection
 	public function isVariadic(): bool
 	{
 		return $this->isVariadic;
+	}
+
+	public function getDefaultValue(): ?Type
+	{
+		return $this->defaultValue;
 	}
 
 }

--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -78,7 +78,8 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 					$parameterTag->getType(),
 					$parameterTag->passedByReference(),
 					$parameterTag->isOptional(),
-					$parameterTag->isVariadic()
+					$parameterTag->isVariadic(),
+					$parameterTag->getDefaultValue()
 				);
 			}
 

--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection;
+
+use PHPStan\Reflection\Php\DummyParameter;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Generic\TemplateTypeHelper;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\TypeCombinator;
+
+class GenericParametersAcceptorResolver
+{
+
+	/**
+	 * Resolve template types
+	 *
+	 * @param \PHPStan\Type\Type[] $argTypes Unpacked arguments
+	 */
+	public static function resolve(array $argTypes, ParametersAcceptor $parametersAcceptor): ParametersAcceptor
+	{
+		$typeMap = TemplateTypeMap::empty();
+
+		foreach ($parametersAcceptor->getParameters() as $i => $param) {
+			if (isset($argTypes[$i])) {
+				if ($param->isVariadic()) {
+					$argType = new ArrayType(new MixedType(), TypeCombinator::union(...array_slice($argTypes, $i)));
+				} else {
+					$argType = $argTypes[$i];
+				}
+			} elseif ($param->getDefaultValue() !== null) {
+				$argType = $param->getDefaultValue();
+			} else {
+				break;
+			}
+
+			$paramType = $param->getType();
+			$typeMap = $typeMap->union($paramType->inferTemplateTypes($argType));
+		}
+
+		return new FunctionVariant(
+			array_map(static function (ParameterReflection $param) use ($typeMap): ParameterReflection {
+				return new DummyParameter(
+					$param->getName(),
+					TemplateTypeHelper::resolveTemplateTypes($param->getType(), $typeMap),
+					$param->isOptional(),
+					$param->passedByReference(),
+					$param->isVariadic(),
+					$param->getDefaultValue()
+				);
+			}, $parametersAcceptor->getParameters()),
+			$parametersAcceptor->isVariadic(),
+			TemplateTypeHelper::resolveTemplateTypes($parametersAcceptor->getReturnType(), $typeMap)
+		);
+	}
+
+}

--- a/src/Reflection/Native/NativeParameterReflection.php
+++ b/src/Reflection/Native/NativeParameterReflection.php
@@ -26,12 +26,16 @@ class NativeParameterReflection implements ParameterReflection
 	/** @var bool */
 	private $variadic;
 
+	/** @var \PHPStan\Type\Type|null */
+	private $defaultValue;
+
 	public function __construct(
 		string $name,
 		bool $optional,
 		Type $type,
 		PassedByReference $passedByReference,
-		bool $variadic
+		bool $variadic,
+		?Type $defaultValue
 	)
 	{
 		$this->name = $name;
@@ -39,6 +43,7 @@ class NativeParameterReflection implements ParameterReflection
 		$this->type = $type;
 		$this->passedByReference = $passedByReference;
 		$this->variadic = $variadic;
+		$this->defaultValue = $defaultValue;
 	}
 
 	public function getName(): string
@@ -71,6 +76,11 @@ class NativeParameterReflection implements ParameterReflection
 		return $this->variadic;
 	}
 
+	public function getDefaultValue(): ?Type
+	{
+		return $this->defaultValue;
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return self
@@ -82,7 +92,8 @@ class NativeParameterReflection implements ParameterReflection
 			$properties['optional'],
 			$properties['type'],
 			$properties['passedByReference'],
-			$properties['variadic']
+			$properties['variadic'],
+			$properties['defaultValue']
 		);
 	}
 

--- a/src/Reflection/ParameterReflection.php
+++ b/src/Reflection/ParameterReflection.php
@@ -17,4 +17,6 @@ interface ParameterReflection
 
 	public function isVariadic(): bool;
 
+	public function getDefaultValue(): ?Type;
+
 }

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -219,19 +219,28 @@ class ParametersAcceptorSelector
 						$i + 1 > $minimumNumberOfParameters,
 						$parameter->getType(),
 						$parameter->passedByReference(),
-						$parameter->isVariadic()
+						$parameter->isVariadic(),
+						$parameter->getDefaultValue()
 					);
 					continue;
 				}
 
 				$isVariadic = $parameters[$i]->isVariadic() || $parameter->isVariadic();
+				$defaultValueLeft = $parameters[$i]->getDefaultValue();
+				$defaultValueRight = $parameter->getDefaultValue();
+				if ($defaultValueLeft !== null && $defaultValueRight !== null) {
+					$defaultValue = TypeCombinator::union($defaultValue, $prevDefaultValue);
+				} else {
+					$defaultValue = null;
+				}
 
 				$parameters[$i] = new NativeParameterReflection(
 					$parameters[$i]->getName() !== $parameter->getName() ? sprintf('%s|%s', $parameters[$i]->getName(), $parameter->getName()) : $parameter->getName(),
 					$i + 1 > $minimumNumberOfParameters,
 					TypeCombinator::union($parameters[$i]->getType(), $parameter->getType()),
 					$parameters[$i]->passedByReference()->combine($parameter->passedByReference()),
-					$isVariadic
+					$isVariadic,
+					$defaultValue
 				);
 
 				if ($isVariadic) {

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -4,9 +4,7 @@ namespace PHPStan\Reflection;
 
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\Native\NativeParameterReflection;
-use PHPStan\Reflection\Php\DummyParameter;
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\TypeCombinator;
 
@@ -26,37 +24,6 @@ class ParametersAcceptorSelector
 		}
 
 		return $parametersAcceptors[0];
-	}
-
-	/**
-	 * Returns argument types (types as seen in the function body)
-	 *
-	 * @param ParametersAcceptor[] $parametersAcceptors
-	 */
-	public static function selectArguments(
-		array $parametersAcceptors
-	): ParametersAcceptor
-	{
-		if (count($parametersAcceptors) !== 1) {
-			throw new \PHPStan\ShouldNotHappenException();
-		}
-
-		$parametersAcceptor = $parametersAcceptors[0];
-
-		return new FunctionVariant(
-			array_map(static function (ParameterReflection $param): ParameterReflection {
-				return new DummyParameter(
-					$param->getName(),
-					TemplateTypeHelper::toArgument($param->getType()),
-					$param->isOptional(),
-					$param->passedByReference(),
-					$param->isVariadic(),
-					$param->getDefaultValue()
-				);
-			}, $parametersAcceptor->getParameters()),
-			$parametersAcceptor->isVariadic(),
-			TemplateTypeHelper::toArgument($parametersAcceptor->getReturnType())
-		);
 	}
 
 	/**

--- a/src/Reflection/Php/DummyParameter.php
+++ b/src/Reflection/Php/DummyParameter.php
@@ -24,15 +24,17 @@ class DummyParameter implements ParameterReflection
 	/** @var bool */
 	private $variadic;
 
-	public function __construct(string $name, Type $type, bool $optional, ?PassedByReference $passedByReference = null, bool $variadic = false)
+	/** @var ?\PHPStan\Type\Type */
+	private $defaultValue;
+
+	public function __construct(string $name, Type $type, bool $optional, ?PassedByReference $passedByReference = null, bool $variadic, ?Type $defaultValue)
 	{
 		$this->name = $name;
 		$this->type = $type;
 		$this->optional = $optional;
-		$this->passedByReference = $passedByReference !== null
-			? PassedByReference::createCreatesNewVariable()
-			: PassedByReference::createNo();
+		$this->passedByReference = $passedByReference ?? PassedByReference::createNo();
 		$this->variadic = $variadic;
+		$this->defaultValue = $defaultValue;
 	}
 
 	public function getName(): string
@@ -58,6 +60,11 @@ class DummyParameter implements ParameterReflection
 	public function isVariadic(): bool
 	{
 		return $this->variadic;
+	}
+
+	public function getDefaultValue(): ?Type
+	{
+		return $this->defaultValue;
 	}
 
 }

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -303,7 +303,8 @@ class PhpClassReflectionExtension
 							$parameterSignature->isOptional(),
 							$parameterSignature->getType(),
 							$parameterSignature->passedByReference(),
-							$parameterSignature->isVariadic()
+							$parameterSignature->isVariadic(),
+							null
 						);
 					}, $methodSignature->getParameters()),
 					$methodSignature->isVariadic(),

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -24,6 +24,9 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 	/** @var \PHPStan\Type\Type[] */
 	private $phpDocParameterTypes;
 
+	/** @var \PHPStan\Type\Type[] */
+	private $realParameterDefaultValues;
+
 	/** @var bool */
 	private $realReturnTypePresent;
 
@@ -55,6 +58,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 	 * @param FunctionLike $functionLike
 	 * @param \PHPStan\Type\Type[] $realParameterTypes
 	 * @param \PHPStan\Type\Type[] $phpDocParameterTypes
+	 * @param \PHPStan\Type\Type[] $realParameterDefaultValues
 	 * @param bool $realReturnTypePresent
 	 * @param Type $realReturnType
 	 * @param Type|null $phpDocReturnType
@@ -68,6 +72,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 		FunctionLike $functionLike,
 		array $realParameterTypes,
 		array $phpDocParameterTypes,
+		array $realParameterDefaultValues,
 		bool $realReturnTypePresent,
 		Type $realReturnType,
 		?Type $phpDocReturnType = null,
@@ -81,6 +86,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 		$this->functionLike = $functionLike;
 		$this->realParameterTypes = $realParameterTypes;
 		$this->phpDocParameterTypes = $phpDocParameterTypes;
+		$this->realParameterDefaultValues = $realParameterDefaultValues;
 		$this->realReturnTypePresent = $realReturnTypePresent;
 		$this->realReturnType = $realReturnType;
 		$this->phpDocReturnType = $phpDocReturnType;
@@ -150,7 +156,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 				$parameter->byRef
 					? PassedByReference::createCreatesNewVariable()
 					: PassedByReference::createNo(),
-				$parameter->default,
+				$this->realParameterDefaultValues[$parameter->var->name] ?? null,
 				$parameter->variadic
 			);
 		}

--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -25,6 +25,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 	 * @param ClassMethod $classMethod
 	 * @param \PHPStan\Type\Type[] $realParameterTypes
 	 * @param \PHPStan\Type\Type[] $phpDocParameterTypes
+	 * @param \PHPStan\Type\Type[] $realParameterDefaultValues
 	 * @param bool $realReturnTypePresent
 	 * @param Type $realReturnType
 	 * @param Type|null $phpDocReturnType
@@ -39,6 +40,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 		ClassMethod $classMethod,
 		array $realParameterTypes,
 		array $phpDocParameterTypes,
+		array $realParameterDefaultValues,
 		bool $realReturnTypePresent,
 		Type $realReturnType,
 		?Type $phpDocReturnType,
@@ -53,6 +55,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 			$classMethod,
 			$realParameterTypes,
 			$phpDocParameterTypes,
+			$realParameterDefaultValues,
 			$realReturnTypePresent,
 			$realReturnType,
 			$phpDocReturnType,

--- a/src/Reflection/Php/PhpParameterFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpParameterFromParserNodeReflection.php
@@ -2,10 +2,9 @@
 
 namespace PHPStan\Reflection\Php;
 
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ConstFetch;
 use PHPStan\Reflection\PassedByReference;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypehintHelper;
 
@@ -27,7 +26,7 @@ class PhpParameterFromParserNodeReflection implements \PHPStan\Reflection\Parame
 	/** @var \PHPStan\Reflection\PassedByReference */
 	private $passedByReference;
 
-	/** @var \PhpParser\Node\Expr|null */
+	/** @var \PHPStan\Type\Type|null */
 	private $defaultValue;
 
 	/** @var bool */
@@ -42,7 +41,7 @@ class PhpParameterFromParserNodeReflection implements \PHPStan\Reflection\Parame
 		Type $realType,
 		?Type $phpDocType,
 		PassedByReference $passedByReference,
-		?Expr $defaultValue,
+		?Type $defaultValue,
 		bool $variadic
 	)
 	{
@@ -70,10 +69,7 @@ class PhpParameterFromParserNodeReflection implements \PHPStan\Reflection\Parame
 		if ($this->type === null) {
 			$phpDocType = $this->phpDocType;
 			if ($phpDocType !== null && $this->defaultValue !== null) {
-				if (
-					$this->defaultValue instanceof ConstFetch
-					&& strtolower((string) $this->defaultValue->name) === 'null'
-				) {
+				if ($this->defaultValue instanceof NullType) {
 					$phpDocType = \PHPStan\Type\TypeCombinator::addNull($phpDocType);
 				}
 			}
@@ -101,6 +97,11 @@ class PhpParameterFromParserNodeReflection implements \PHPStan\Reflection\Parame
 	public function isVariadic(): bool
 	{
 		return $this->variadic;
+	}
+
+	public function getDefaultValue(): ?Type
+	{
+		return $this->defaultValue;
 	}
 
 }

--- a/src/Reflection/Php/PhpParameterReflection.php
+++ b/src/Reflection/Php/PhpParameterReflection.php
@@ -4,6 +4,7 @@ namespace PHPStan\Reflection\Php;
 
 use PHPStan\Reflection\ParameterReflectionWithPhpDocs;
 use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\ConstantTypeHelper;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypehintHelper;
@@ -46,6 +47,7 @@ class PhpParameterReflection implements ParameterReflectionWithPhpDocs
 			if ($phpDocType !== null && $this->reflection->isDefaultValueAvailable() && $this->reflection->getDefaultValue() === null) {
 				$phpDocType = \PHPStan\Type\TypeCombinator::addNull($phpDocType);
 			}
+
 			$this->type = TypehintHelper::decideTypeFromReflection(
 				$this->reflection->getType(),
 				$phpDocType,
@@ -90,6 +92,15 @@ class PhpParameterReflection implements ParameterReflectionWithPhpDocs
 		}
 
 		return $this->nativeType;
+	}
+
+	public function getDefaultValue(): ?Type
+	{
+		if ($this->reflection->isDefaultValueAvailable()) {
+			return ConstantTypeHelper::getTypeFromValue($this->reflection->getDefaultValue());
+		}
+
+		return null;
 	}
 
 }

--- a/src/Rules/Functions/ReturnTypeRule.php
+++ b/src/Rules/Functions/ReturnTypeRule.php
@@ -56,7 +56,7 @@ class ReturnTypeRule implements \PHPStan\Rules\Rule
 
 		return $this->returnTypeCheck->checkReturnType(
 			$scope,
-			ParametersAcceptorSelector::selectArguments($function->getVariants())->getReturnType(),
+			ParametersAcceptorSelector::selectSingle($function->getVariants())->getReturnType(),
 			$node->expr,
 			sprintf(
 				'Function %s() should return %%s but empty return statement found.',

--- a/src/Rules/Functions/ReturnTypeRule.php
+++ b/src/Rules/Functions/ReturnTypeRule.php
@@ -56,7 +56,7 @@ class ReturnTypeRule implements \PHPStan\Rules\Rule
 
 		return $this->returnTypeCheck->checkReturnType(
 			$scope,
-			ParametersAcceptorSelector::selectSingle($function->getVariants())->getReturnType(),
+			ParametersAcceptorSelector::selectArguments($function->getVariants())->getReturnType(),
 			$node->expr,
 			sprintf(
 				'Function %s() should return %%s but empty return statement found.',

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -237,12 +237,14 @@ class CallableType implements CompoundType, ParametersAcceptor
 		}
 
 		$parameters = array_map(static function (NativeParameterReflection $param) use ($cb): NativeParameterReflection {
+			$defaultValue = $param->getDefaultValue();
 			return new NativeParameterReflection(
 				$param->getName(),
 				$param->isOptional(),
 				$cb($param->getType()),
 				$param->passedByReference(),
-				$param->isVariadic()
+				$param->isVariadic(),
+				$defaultValue !== null ? $cb($defaultValue) : null
 			);
 		}, $this->getParameters());
 

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -285,12 +285,14 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 	{
 		return new static(
 			array_map(static function (NativeParameterReflection $param) use ($cb): NativeParameterReflection {
+				$defaultValue = $param->getDefaultValue();
 				return new NativeParameterReflection(
 					$param->getName(),
 					$param->isOptional(),
 					$cb($param->getType()),
 					$param->passedByReference(),
-					$param->isVariadic()
+					$param->isVariadic(),
+					$defaultValue !== null ? $cb($defaultValue) : null
 				);
 			}, $this->getParameters()),
 			$cb($this->getReturnType()),

--- a/src/Type/ConstantTypeHelper.php
+++ b/src/Type/ConstantTypeHelper.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantFloatType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+
+class ConstantTypeHelper
+{
+
+	/**
+	 * @param mixed $value
+	 */
+	public static function getTypeFromValue($value): Type
+	{
+		if (is_int($value)) {
+			return new ConstantIntegerType($value);
+		} elseif (is_float($value)) {
+			return new ConstantFloatType($value);
+		} elseif (is_bool($value)) {
+			return new ConstantBooleanType($value);
+		} elseif ($value === null) {
+			return new NullType();
+		} elseif (is_string($value)) {
+			return new ConstantStringType($value);
+		} elseif (is_array($value)) {
+			$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
+			foreach ($value as $k => $v) {
+				$arrayBuilder->setOffsetValueType(self::getTypeFromValue($k), self::getTypeFromValue($v));
+			}
+			return $arrayBuilder->getArray();
+		}
+
+		return new MixedType();
+	}
+
+}

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Reflection;
 use PHPStan\Reflection\Php\DummyParameter;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
@@ -335,6 +336,17 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					false,
 					new NullType()
 				),
+			],
+			'constant string arg resolved to constant string' => [
+				[
+					new ConstantStringType('foo'),
+				],
+				new FunctionVariant([
+					new DummyParameter('str', $templateType('T'), false, null, false, null),
+				], false, $templateType('T')),
+				new FunctionVariant([
+					new DummyParameter('str', new ConstantStringType('foo'), false, null, false, null),
+				], false, new ConstantStringType('foo')),
 			],
 		];
 	}

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -1,0 +1,382 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection;
+
+use PHPStan\Reflection\Php\DummyParameter;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
+
+class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
+{
+
+	/**
+	 * @return array<array{Type[], ParametersAcceptor, ParametersAcceptor}>
+	 */
+	public function dataResolve(): array
+	{
+		$templateType = static function (string $name, ?Type $type = null): Type {
+			return TemplateTypeFactory::create(
+				new TemplateTypeScope(null, null),
+				$name,
+				$type
+			);
+		};
+
+		return [
+			'one param, one arg' => [
+				[
+					new ObjectType('DateTime'),
+				],
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							$templateType('T'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					new NullType()
+				),
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							new ObjectType('DateTime'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					new NullType()
+				),
+			],
+			'two params, two args, return type' => [
+				[
+					new ObjectType('DateTime'),
+					new IntegerType(),
+				],
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							$templateType('T'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							$templateType('U'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					$templateType('U')
+				),
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							new ObjectType('DateTime'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							new IntegerType(),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					new IntegerType()
+				),
+			],
+			'mixed types' => [
+				[
+					new ObjectType('DateTime'),
+					new IntegerType(),
+				],
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							$templateType('T'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							$templateType('T'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					$templateType('T')
+				),
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							new UnionType([
+								new ObjectType('DateTime'),
+								new IntegerType(),
+							]),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							new UnionType([
+								new ObjectType('DateTime'),
+								new IntegerType(),
+							]),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					new UnionType([
+						new ObjectType('DateTime'),
+						new IntegerType(),
+					])
+				),
+			],
+			'parameter default value' => [
+				[
+					new ObjectType('DateTime'),
+				],
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							$templateType('T'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							$templateType('U'),
+							true,
+							PassedByReference::createNo(),
+							false,
+							new ConstantIntegerType(42)
+						),
+					],
+					false,
+					new NullType()
+				),
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							new ObjectType('DateTime'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							new ConstantIntegerType(42),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					new NullType()
+				),
+			],
+			'variadic parameter' => [
+				[
+					new ObjectType('DateTime'),
+					new ConstantIntegerType(1),
+					new ConstantIntegerType(2),
+					new ConstantIntegerType(3),
+				],
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							$templateType('T'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							new ArrayType(new MixedType(), $templateType('U')),
+							false,
+							PassedByReference::createNo(),
+							true,
+							null
+						),
+					],
+					true,
+					$templateType('U')
+				),
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							new ObjectType('DateTime'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							new ArrayType(
+								new MixedType(),
+								new UnionType([
+									new ConstantIntegerType(1),
+									new ConstantIntegerType(2),
+									new ConstantIntegerType(3),
+								])
+							),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					new UnionType([
+						new ConstantIntegerType(1),
+						new ConstantIntegerType(2),
+						new ConstantIntegerType(3),
+					])
+				),
+			],
+			'missing args' => [
+				[
+					new ObjectType('DateTime'),
+				],
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							$templateType('T'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							$templateType('U'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					new NullType()
+				),
+				new FunctionVariant(
+					[
+						new DummyParameter(
+							'a',
+							new ObjectType('DateTime'),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+						new DummyParameter(
+							'b',
+							new ErrorType(),
+							false,
+							PassedByReference::createNo(),
+							false,
+							null
+						),
+					],
+					false,
+					new NullType()
+				),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataResolve
+	 */
+	public function testResolve(array $argTypes, ParametersAcceptor $parametersAcceptor, ParametersAcceptor $expectedResult): void
+	{
+		$result = GenericParametersAcceptorResolver::resolve(
+			$argTypes,
+			$parametersAcceptor
+		);
+
+		$this->assertInstanceOf(
+			get_class($expectedResult->getReturnType()),
+			$result->getReturnType(),
+			'Unexpected return type'
+		);
+		$this->assertSame(
+			$expectedResult->getReturnType()->describe(VerbosityLevel::precise()),
+			$result->getReturnType()->describe(VerbosityLevel::precise()),
+			'Unexpected return type'
+		);
+
+		$resultParameters = $result->getParameters();
+		$expectedParameters = $expectedResult->getParameters();
+
+		$this->assertCount(count($expectedParameters), $resultParameters);
+
+		foreach ($expectedParameters as $i => $param) {
+			$this->assertInstanceOf(
+				get_class($param->getType()),
+				$resultParameters[$i]->getType(),
+				sprintf('Unexpected parameter %d', $i + 1)
+			);
+			$this->assertSame(
+				$param->getType()->describe(VerbosityLevel::precise()),
+				$resultParameters[$i]->getType()->describe(VerbosityLevel::precise()),
+				sprintf('Unexpected parameter %d', $i + 1)
+			);
+		}
+	}
+
+}

--- a/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
+++ b/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
@@ -9,7 +9,6 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\FloatType;
-use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\IntegerType;

--- a/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
+++ b/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
@@ -455,41 +455,4 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 		$this->assertSame($expected->isVariadic(), $selectedAcceptor->isVariadic());
 	}
 
-	public function testSelectArguments(): void
-	{
-		$templateType = TemplateTypeFactory::create(
-			new TemplateTypeScope(null, null),
-			'T',
-			null
-		);
-
-		$acceptors = [
-			new FunctionVariant(
-				[
-					new DummyParameter(
-						'a',
-						$templateType,
-						false,
-						PassedByReference::createNo(),
-						false,
-						null
-					),
-				],
-				false,
-				$templateType
-			),
-		];
-
-		$acceptor = ParametersAcceptorSelector::selectArguments($acceptors);
-
-		$argument = $acceptor->getParameters()[0];
-		$type = $argument->getType();
-		$this->assertInstanceOf(TemplateType::class, $type);
-		$this->assertTrue($type->isArgument());
-
-		$returnType = $acceptor->getReturnType();
-		$this->assertInstanceOf(TemplateType::class, $returnType);
-		$this->assertTrue($returnType->isArgument());
-	}
-
 }

--- a/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
+++ b/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
@@ -110,7 +110,8 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 						false,
 						new MixedType(),
 						PassedByReference::createNo(),
-						false
+						false,
+						null
 					),
 					new NativeParameterReflection(
 						'event|args',
@@ -120,7 +121,8 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 							new StringType(),
 						]),
 						PassedByReference::createNo(),
-						true
+						true,
+						null
 					),
 				],
 				true,
@@ -159,14 +161,16 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 						false,
 						new StringType(),
 						PassedByReference::createNo(),
-						false
+						false,
+						null
 					),
 					new NativeParameterReflection(
 						'token',
 						true,
 						new StringType(),
 						PassedByReference::createNo(),
-						false
+						false,
+						null
 					),
 				],
 				false,
@@ -190,14 +194,16 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 						false,
 						new IntegerType(),
 						PassedByReference::createNo(),
-						false
+						false,
+						null
 					),
 					new NativeParameterReflection(
 						'intVariadic',
 						true,
 						new IntegerType(),
 						PassedByReference::createNo(),
-						true
+						true,
+						null
 					),
 				],
 				true,
@@ -210,14 +216,16 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 						false,
 						new IntegerType(),
 						PassedByReference::createNo(),
-						false
+						false,
+						null
 					),
 					new NativeParameterReflection(
 						'floatVariadic',
 						true,
 						new FloatType(),
 						PassedByReference::createNo(),
-						true
+						true,
+						null
 					),
 				],
 				true,

--- a/tests/PHPStan/Type/CallableTypeTest.php
+++ b/tests/PHPStan/Type/CallableTypeTest.php
@@ -31,13 +31,13 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 				TrinaryLogic::createYes(),
 			],
 			[
-				new CallableType([new NativeParameterReflection('foo', false, new MixedType(), PassedByReference::createNo(), false)], new MixedType(), false),
-				new CallableType([new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false)], new MixedType(), false),
+				new CallableType([new NativeParameterReflection('foo', false, new MixedType(), PassedByReference::createNo(), false, null)], new MixedType(), false),
+				new CallableType([new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false, null)], new MixedType(), false),
 				TrinaryLogic::createMaybe(),
 			],
 			[
-				new CallableType([new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false)], new MixedType(), false),
-				new CallableType([new NativeParameterReflection('foo', false, new MixedType(), PassedByReference::createNo(), false)], new MixedType(), false),
+				new CallableType([new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false, null)], new MixedType(), false),
+				new CallableType([new NativeParameterReflection('foo', false, new MixedType(), PassedByReference::createNo(), false, null)], new MixedType(), false),
 				TrinaryLogic::createYes(),
 			],
 		];
@@ -170,7 +170,8 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 				false,
 				$type,
 				PassedByReference::createNo(),
-				false
+				false,
+				null
 			);
 		};
 
@@ -284,34 +285,34 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 	{
 		return [
 			[
-				new CallableType([new NativeParameterReflection('foo', false, new MixedType(), PassedByReference::createNo(), false)], new MixedType(), false),
-				new CallableType([new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false)], new MixedType(), false),
+				new CallableType([new NativeParameterReflection('foo', false, new MixedType(), PassedByReference::createNo(), false, null)], new MixedType(), false),
+				new CallableType([new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false, null)], new MixedType(), false),
 				TrinaryLogic::createYes(),
 			],
 			[
-				new CallableType([new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false)], new MixedType(), false),
-				new CallableType([new NativeParameterReflection('foo', false, new MixedType(), PassedByReference::createNo(), false)], new MixedType(), false),
-				TrinaryLogic::createYes(),
-			],
-			[
-				new CallableType([
-					new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false),
-				], new MixedType(), false),
-				new CallableType([
-					new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false),
-					new NativeParameterReflection('bar', true, new IntegerType(), PassedByReference::createNo(), false),
-					new NativeParameterReflection('bar', true, new IntegerType(), PassedByReference::createNo(), false),
-				], new MixedType(), false),
+				new CallableType([new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false, null)], new MixedType(), false),
+				new CallableType([new NativeParameterReflection('foo', false, new MixedType(), PassedByReference::createNo(), false, null)], new MixedType(), false),
 				TrinaryLogic::createYes(),
 			],
 			[
 				new CallableType([
-					new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false),
-					new NativeParameterReflection('bar', false, new StringType(), PassedByReference::createNo(), false),
+					new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false, null),
 				], new MixedType(), false),
 				new CallableType([
-					new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false),
-					new NativeParameterReflection('bar', true, new IntegerType(), PassedByReference::createNo(), false),
+					new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false, null),
+					new NativeParameterReflection('bar', true, new IntegerType(), PassedByReference::createNo(), false, null),
+					new NativeParameterReflection('bar', true, new IntegerType(), PassedByReference::createNo(), false, null),
+				], new MixedType(), false),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new CallableType([
+					new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false, null),
+					new NativeParameterReflection('bar', false, new StringType(), PassedByReference::createNo(), false, null),
+				], new MixedType(), false),
+				new CallableType([
+					new NativeParameterReflection('foo', false, new IntegerType(), PassedByReference::createNo(), false, null),
+					new NativeParameterReflection('bar', true, new IntegerType(), PassedByReference::createNo(), false, null),
 				], new MixedType(), false),
 				TrinaryLogic::createNo(),
 			],


### PR DESCRIPTION
This PR changes `ParametersAcceptorSelector` such that generics handling is transparent in most code that care about types in a function signature.

- Exposes parameter default values in Reflection (`ParameterReflection::getDefaultValue()`; this is needed during template type inference when some optional parameters are omitted)
- Adds `GenericParametersAcceptorResolver::resolve()`, a method that infers the template types of a `ParametersAcceptor` based on received arguments, and returns a fully resolved `ParametersAcceptor` (with template types replaced by standin types).
- Changes `ParametersAcceptorSelector::selectFromArgs()` / `ParametersAcceptorSelector::selectFromTypes()` to resolve the chosen `ParametersAcceptor`.
- Adds `ParametersAcceptorSelector::selectArguments()`, a method that returns the `ParametersAcceptor` of a function, as seen by the function's body. This `ParametersAcceptor` is suitable for return type acceptance checks.