### PR TITLE
TypeTraverser: Avoid creating a reference cycle

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -228,7 +228,7 @@
 				checkreturn="true"
 		>
 			<arg value="-d"/>
-			<arg value="memory_limit=640M"/>
+			<arg value="memory_limit=512M"/>
 			<arg path="bin/phpstan"/>
 			<arg value="analyse"/>
 			<arg value="-c"/>


### PR DESCRIPTION
I didn't notice at first, but the TypeTraverser introduced in #2177 leaks a lot of memory because it creates a reference cycle.

Here I remove the reference cycle. As a result, the increased memory limit in build.xml is not needed anymore. Time/CPU-wise, the change has no noticeable impact.

Caveat: I had to make the methods public. I'm not very happy with this, but this is the best solution I found.