### PR TITLE
Add TemplateTypeDeclarationRule

### DIFF
--- a/conf/config.level2.neon
+++ b/conf/config.level2.neon
@@ -14,7 +14,9 @@ rules:
 	- PHPStan\Rules\Cast\InvalidPartOfEncapsedStringRule
 	- PHPStan\Rules\Cast\PrintRule
 	- PHPStan\Rules\Functions\IncompatibleDefaultParameterTypeRule
+	- PHPStan\Rules\Functions\TemplateTypeDeclarationRule
 	- PHPStan\Rules\Methods\IncompatibleDefaultParameterTypeRule
+	- PHPStan\Rules\Methods\TemplateTypeDeclarationRule
 	- PHPStan\Rules\Operators\InvalidBinaryOperationRule
 	- PHPStan\Rules\Operators\InvalidUnaryOperationRule
 	- PHPStan\Rules\Operators\InvalidComparisonOperationRule

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -352,6 +352,9 @@ services:
 		class: PHPStan\Type\FileTypeMapper
 
 	-
+		class: PHPStan\Rules\TemplateTypeCheck
+
+	-
 		class: PHPStan\Type\Php\ArgumentBasedFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Rules/Functions/TemplateTypeDeclarationRule.php
+++ b/src/Rules/Functions/TemplateTypeDeclarationRule.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\TemplateTypeCheck;
+use PHPStan\Type\Generic\TemplateTypeScope;
+
+class TemplateTypeDeclarationRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var TemplateTypeCheck */
+	private $templateTypeCheck;
+
+	public function __construct(TemplateTypeCheck $check)
+	{
+		$this->templateTypeCheck = $check;
+	}
+
+	public function getNodeType(): string
+	{
+		return Function_::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Stmt\Function_ $node
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$functionName = (string) $node->name;
+
+		$templateTypeScope = TemplateTypeScope::createWithFunction($functionName);
+
+		return $this->templateTypeCheck->checkTemplateTypeDeclarations(
+			$node,
+			$scope,
+			$templateTypeScope,
+			sprintf(
+				'Type parameter %%s of function %s() has invalid bound %%s (only class name bounds are supported currently).',
+				$functionName
+			)
+		);
+	}
+
+}

--- a/src/Rules/Methods/TemplateTypeDeclarationRule.php
+++ b/src/Rules/Methods/TemplateTypeDeclarationRule.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassMethodNode;
+use PHPStan\Reflection\Php\PhpMethodFromParserNodeReflection;
+use PHPStan\Rules\TemplateTypeCheck;
+use PHPStan\Type\Generic\TemplateTypeScope;
+
+class TemplateTypeDeclarationRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var TemplateTypeCheck */
+	private $templateTypeCheck;
+
+	public function __construct(TemplateTypeCheck $check)
+	{
+		$this->templateTypeCheck = $check;
+	}
+
+	public function getNodeType(): string
+	{
+		return InClassMethodNode::class;
+	}
+
+	/**
+	 * @param \PHPStan\Node\InClassMethodNode $node
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$methodReflection = $scope->getFunction();
+		if (!$methodReflection instanceof PhpMethodFromParserNodeReflection) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+		if (!$scope->isInClass()) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
+		$templateTypeScope = TemplateTypeScope::createWithMethod(
+			$methodReflection->getDeclaringClass()->getName(),
+			$methodReflection->getName()
+		);
+
+		return $this->templateTypeCheck->checkTemplateTypeDeclarations(
+			$node->getOriginalNode(),
+			$scope,
+			$templateTypeScope,
+			sprintf(
+				'Type parameter %%s of method %s::%s() has invalid bound %%s (only class name bounds are supported currently).',
+				$scope->getClassReflection()->getDisplayName(),
+				$methodReflection->getName()
+			)
+		);
+	}
+
+}

--- a/src/Rules/TemplateTypeCheck.php
+++ b/src/Rules/TemplateTypeCheck.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules;
+
+use PhpParser\Node\FunctionLike;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\FileTypeMapper;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\VerbosityLevel;
+
+class TemplateTypeCheck
+{
+
+	/** @var \PHPStan\Type\FileTypeMapper */
+	private $fileTypeMapper;
+
+	public function __construct(FileTypeMapper $fileTypeMapper)
+	{
+		$this->fileTypeMapper = $fileTypeMapper;
+	}
+
+	/** @return string[] */
+	public function checkTemplateTypeDeclarations(
+		FunctionLike $node,
+		Scope $scope,
+		TemplateTypeScope $templateTypeScope,
+		string $boundMessage
+	): array
+	{
+		$docComment = $node->getDocComment();
+		if ($docComment === null) {
+			return [];
+		}
+
+		$resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+			$scope->getFile(),
+			$scope->isInClass() ? $scope->getClassReflection()->getName() : null,
+			$scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,
+			$docComment->getText()
+		);
+
+		$errors = [];
+
+		foreach ($resolvedPhpDoc->getTemplateTags() as $tag) {
+			$templateType = TemplateTypeFactory::fromTemplateTag($templateTypeScope, $tag);
+			if (!($templateType instanceof ErrorType)) {
+				continue;
+			}
+
+			$errors[] = sprintf(
+				$boundMessage,
+				$tag->getName(),
+				$tag->getBound()->describe(VerbosityLevel::precise())
+			);
+		}
+
+		return $errors;
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeFactory.php
+++ b/src/Type/Generic/TemplateTypeFactory.php
@@ -19,7 +19,7 @@ final class TemplateTypeFactory
 			return new TemplateObjectType($scope, $strategy, $name, $bound->getClassName());
 		}
 
-		if ($bound === null || $bound instanceof MixedType) {
+		if ($bound === null || get_class($bound) === MixedType::class) {
 			return new TemplateMixedType($scope, $strategy, $name);
 		}
 

--- a/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
+++ b/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Generics;
+
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+class TemplateTypeFactoryTest extends \PHPStan\Testing\TestCase
+{
+
+	/** @return array<array{?Type, bool}> */
+	public function dataCreate(): array
+	{
+		return [
+			[
+				new ObjectType('DateTime'),
+				true,
+			],
+			[
+				new MixedType(),
+				true,
+			],
+			[
+				null,
+				true,
+			],
+			[
+				new StringType(),
+				false,
+			],
+			[
+				new ErrorType(),
+				false,
+			],
+			[
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithFunction('a'),
+					'U',
+					null
+				),
+				false,
+			],
+			[
+				new UnionType([
+					new StringType(),
+					new IntegerType(),
+				]),
+				false,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataCreate
+	 */
+	public function testCreate(?Type $bound, bool $expectSuccess): void
+	{
+		$scope = TemplateTypeScope::createWithFunction('a');
+		$templateType = TemplateTypeFactory::create($scope, 'T', $bound);
+
+		if ($expectSuccess) {
+			$this->assertInstanceOf(TemplateType::class, $templateType);
+			$this->assertTrue(($bound ?? new MixedType())->equals($templateType->getBound()));
+		} else {
+			$this->assertInstanceOf(ErrorType::class, $templateType);
+		}
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/TemplateTypeDeclarationRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/TemplateTypeDeclarationRuleTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PHPStan\Rules\TemplateTypeCheck;
+use PHPStan\Type\FileTypeMapper;
+
+class TemplateTypeDeclarationRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		$fileTypeMapper = self::getContainer()->getByType(FileTypeMapper::class);
+
+		return new TemplateTypeDeclarationRule(
+			new TemplateTypeCheck($fileTypeMapper)
+		);
+	}
+
+	public function testRule(): void
+	{
+		require_once __DIR__ . '/data/template-type-bounds.php';
+		$this->analyse([__DIR__ . '/data/template-type-bounds.php'], [
+			[
+				'Type parameter T of function a() has invalid bound float|int (only class name bounds are supported currently).',
+				9,
+			],
+			[
+				'Type parameter U of function b() has invalid bound DateTime|DateTimeImmutable (only class name bounds are supported currently).',
+				18,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/data/template-type-bounds.php
+++ b/tests/PHPStan/Rules/Functions/data/template-type-bounds.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TemplateTypeBound;
+
+/**
+ * @template T of int|float
+ * @param T $a
+ */
+function a($a): void {
+}
+
+/**
+ * @template T of \DateTime
+ * @template U of \DateTime|\DateTimeImmutable
+ * @param T $a
+ * @param U $b
+ */
+function b($a, $b): void {
+}
+

--- a/tests/PHPStan/Rules/Methods/TemplateTypeDeclarationRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/TemplateTypeDeclarationRuleTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Rules\TemplateTypeCheck;
+use PHPStan\Type\FileTypeMapper;
+
+class TemplateTypeDeclarationRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		$fileTypeMapper = self::getContainer()->getByType(FileTypeMapper::class);
+
+		return new TemplateTypeDeclarationRule(
+			new TemplateTypeCheck($fileTypeMapper)
+		);
+	}
+
+	public function testRule(): void
+	{
+		require_once __DIR__ . '/data/template-type-bounds.php';
+		$this->analyse([__DIR__ . '/data/template-type-bounds.php'], [
+			[
+				'Type parameter T of method TemplateTypeBound\C::a() has invalid bound float|int (only class name bounds are supported currently).',
+				11,
+			],
+			[
+				'Type parameter U of method TemplateTypeBound\C::b() has invalid bound DateTime|DateTimeImmutable (only class name bounds are supported currently).',
+				20,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/data/template-type-bounds.php
+++ b/tests/PHPStan/Rules/Methods/data/template-type-bounds.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace TemplateTypeBound;
+
+class C
+{
+	/**
+	 * @template T of int|float
+	 * @param T $a
+	 */
+	public function a($a): void {
+	}
+
+	/**
+	 * @template T of \DateTime
+	 * @template U of \DateTime|\DateTimeImmutable
+	 * @param T $a
+	 * @param U $b
+	 */
+	public function b($a, $b): void {
+	}
+}


### PR DESCRIPTION
Adds a rule to check the bound in `@template` annotations:

```
@template T of Foo // OK
@template T of int // Type parameter T of function foo has invalid bound int (only class name bounds are supported currently).
```