### PR TITLE
Rename TemplateTypeMap::empty() to ::createEmpty() for consistency

### DIFF
--- a/src/Analyser/NameScope.php
+++ b/src/Analyser/NameScope.php
@@ -35,7 +35,7 @@ class NameScope
 		$this->uses = $uses;
 		$this->className = $className;
 		$this->functionName = $functionName;
-		$this->templateTypeMap = $templateTypeMap ?? TemplateTypeMap::empty();
+		$this->templateTypeMap = $templateTypeMap ?? TemplateTypeMap::createEmpty();
 	}
 
 	public function getClassName(): ?string

--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -19,7 +19,7 @@ class GenericParametersAcceptorResolver
 	 */
 	public static function resolve(array $argTypes, ParametersAcceptor $parametersAcceptor): ParametersAcceptor
 	{
-		$typeMap = TemplateTypeMap::empty();
+		$typeMap = TemplateTypeMap::createEmpty();
 
 		foreach ($parametersAcceptor->getParameters() as $i => $param) {
 			if (isset($argTypes[$i])) {

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -201,12 +201,12 @@ class CallableType implements CompoundType, ParametersAcceptor
 		}
 
 		if ($receivedType->isCallable()->no()) {
-			return TemplateTypeMap::empty();
+			return TemplateTypeMap::createEmpty();
 		}
 
 		$parametersAcceptors = $receivedType->getCallableParametersAcceptors(new OutOfClassScope());
 
-		$typeMap = TemplateTypeMap::empty();
+		$typeMap = TemplateTypeMap::createEmpty();
 
 		foreach ($parametersAcceptors as $parametersAcceptor) {
 			$typeMap = $typeMap->union($this->inferTemplateTypesOnParametersAcceptor($receivedType, $parametersAcceptor));
@@ -217,7 +217,7 @@ class CallableType implements CompoundType, ParametersAcceptor
 
 	private function inferTemplateTypesOnParametersAcceptor(Type $receivedType, ParametersAcceptor $parametersAcceptor): TemplateTypeMap
 	{
-		$typeMap = TemplateTypeMap::empty();
+		$typeMap = TemplateTypeMap::createEmpty();
 		$args = $parametersAcceptor->getParameters();
 		$returnType = $parametersAcceptor->getReturnType();
 

--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -119,7 +119,7 @@ final class TemplateMixedType extends MixedType implements TemplateType
 		}
 
 		if ($this->isSuperTypeOf($receivedType)->no()) {
-			return TemplateTypeMap::empty();
+			return TemplateTypeMap::createEmpty();
 		}
 
 		return new TemplateTypeMap([

--- a/src/Type/Generic/TemplateObjectType.php
+++ b/src/Type/Generic/TemplateObjectType.php
@@ -124,7 +124,7 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 		}
 
 		if ($this->isSuperTypeOf($receivedType)->no()) {
-			return TemplateTypeMap::empty();
+			return TemplateTypeMap::createEmpty();
 		}
 
 		return new TemplateTypeMap([

--- a/src/Type/Generic/TemplateTypeMap.php
+++ b/src/Type/Generic/TemplateTypeMap.php
@@ -8,6 +8,9 @@ use PHPStan\Type\TypeCombinator;
 class TemplateTypeMap
 {
 
+	/** @var TemplateTypeMap|null */
+	private static $empty;
+
 	/** @var array<string,\PHPStan\Type\Type> */
 	private $types;
 
@@ -17,9 +20,18 @@ class TemplateTypeMap
 		$this->types = $types;
 	}
 
-	public static function empty(): self
+	public static function createEmpty(): self
 	{
-		return new self([]);
+		$empty = self::$empty;
+
+		if ($empty !== null) {
+			return $empty;
+		}
+
+		$empty = new self([]);
+		self::$empty = $empty;
+
+		return $empty;
 	}
 
 	/** @return array<string,\PHPStan\Type\Type> */

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -356,7 +356,7 @@ class IntersectionType implements CompoundType, StaticResolvableType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		$types = TemplateTypeMap::empty();
+		$types = TemplateTypeMap::createEmpty();
 
 		foreach ($this->types as $type) {
 			$receive = $type->isSuperTypeOf($receivedType)->yes() ? $receivedType : new NeverType();
@@ -368,7 +368,7 @@ class IntersectionType implements CompoundType, StaticResolvableType
 
 	public function inferTemplateTypesOn(Type $templateType): TemplateTypeMap
 	{
-		$types = TemplateTypeMap::empty();
+		$types = TemplateTypeMap::createEmpty();
 
 		foreach ($this->types as $type) {
 			$types = $types->intersect($templateType->inferTemplateTypes($type));

--- a/src/Type/Traits/NonGenericTypeTrait.php
+++ b/src/Type/Traits/NonGenericTypeTrait.php
@@ -10,7 +10,7 @@ trait NonGenericTypeTrait
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		return TemplateTypeMap::empty();
+		return TemplateTypeMap::createEmpty();
 	}
 
 }

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -534,7 +534,7 @@ class UnionType implements CompoundType, StaticResolvableType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		$types = TemplateTypeMap::empty();
+		$types = TemplateTypeMap::createEmpty();
 
 		foreach ($this->types as $type) {
 			$receive = $type->isSuperTypeOf($receivedType)->yes() ? $receivedType : new NeverType();
@@ -546,7 +546,7 @@ class UnionType implements CompoundType, StaticResolvableType
 
 	public function inferTemplateTypesOn(Type $templateType): TemplateTypeMap
 	{
-		$types = TemplateTypeMap::empty();
+		$types = TemplateTypeMap::createEmpty();
 
 		foreach ($this->types as $type) {
 			$types = $types->union($templateType->inferTemplateTypes($type));


### PR DESCRIPTION
I'm adding a `::createXxx()` static constructor in this class in an other PR, so it makes sense to rename the existing `::empty()` to `::createEmpty()`. It's also more consistent with the rest of the code base.