### PR TITLE
Support template type inference on iterables

### DIFF
--- a/tests/PHPStan/Type/IterableTypeTest.php
+++ b/tests/PHPStan/Type/IterableTypeTest.php
@@ -6,6 +6,8 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\HasMethodType;
 use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeScope;
 
 class IterableTypeTest extends \PHPStan\Testing\TestCase
 {
@@ -167,6 +169,63 @@ class IterableTypeTest extends \PHPStan\Testing\TestCase
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise()))
+		);
+	}
+
+	public function dataInferTemplateTypes(): array
+	{
+		$templateType = static function (string $name): Type {
+			return TemplateTypeFactory::create(
+				TemplateTypeScope::createWithFunction('a'),
+				$name,
+				new MixedType()
+			);
+		};
+
+		return [
+			'receive iterable' => [
+				new IterableType(
+					new MixedType(),
+					new ObjectType('DateTime')
+				),
+				new IterableType(
+					new MixedType(),
+					$templateType('T')
+				),
+				['T' => 'DateTime'],
+			],
+			'receive mixed' => [
+				new MixedType(),
+				new IterableType(
+					new MixedType(),
+					$templateType('T')
+				),
+				[],
+			],
+			'receive non-accepted' => [
+				new StringType(),
+				new IterableType(
+					new MixedType(),
+					$templateType('T')
+				),
+				[],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataInferTemplateTypes
+	 * @param array<string,string> $expectedTypes
+	 */
+	public function testResolveTemplateTypes(Type $received, Type $template, array $expectedTypes): void
+	{
+		$result = $template->inferTemplateTypes($received);
+
+		$this->assertSame(
+			$expectedTypes,
+			array_map(static function (Type $type): string {
+				return $type->describe(VerbosityLevel::precise());
+			}, $result->getTypes())
 		);
 	}
 


### PR DESCRIPTION
Note: This PR depends on https://github.com/phpstan/phpstan/pull/2241.

This adds support for type inference on the iterable type:

``` php
<?php

/**
 * @template K
 * @template V
 * @param iterable<K, V> $it
 * @return array<K, V>
 */
function f($it) {
    $ret = [];
    foreach ($it as $k => $v) {
        $ret[$k] = $v;
    }
    return $ret;
}

f(new ArrayIterator([1, 2, 3])); // array<int>
```