### PR TITLE
Small simplification on type inference

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -285,17 +285,13 @@ class ArrayType implements Type
 			&& !$this->getKeyType()->isSuperTypeOf($receivedType->getKeyType())->no()
 			&& !$this->getItemType()->isSuperTypeOf($receivedType->getItemType())->no()
 		) {
-			$receivedKey = $receivedType->getKeyType();
-			$receivedItem = $receivedType->getItemType();
-		} else {
-			$receivedKey = new NeverType();
-			$receivedItem = new NeverType();
+			$keyTypeMap = $this->getKeyType()->inferTemplateTypes($receivedType->getKeyType());
+			$itemTypeMap = $this->getItemType()->inferTemplateTypes($receivedType->getItemType());
+
+			return $keyTypeMap->union($itemTypeMap);
 		}
 
-		$keyTypeMap = $this->getKeyType()->inferTemplateTypes($receivedKey);
-		$itemTypeMap = $this->getItemType()->inferTemplateTypes($receivedItem);
-
-		return $keyTypeMap->union($itemTypeMap);
+		return TemplateTypeMap::createEmpty();
 	}
 
 	public function traverse(callable $cb): Type

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -369,8 +369,7 @@ class IntersectionType implements CompoundType
 		$types = TemplateTypeMap::createEmpty();
 
 		foreach ($this->types as $type) {
-			$receive = $type->isSuperTypeOf($receivedType)->yes() ? $receivedType : new NeverType();
-			$types = $types->intersect($type->inferTemplateTypes($receive));
+			$types = $types->intersect($type->inferTemplateTypes($receivedType));
 		}
 
 		return $types;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -546,8 +546,7 @@ class UnionType implements CompoundType
 		$types = TemplateTypeMap::createEmpty();
 
 		foreach ($this->types as $type) {
-			$receive = $type->isSuperTypeOf($receivedType)->yes() ? $receivedType : new NeverType();
-			$types = $types->union($type->inferTemplateTypes($receive));
+			$types = $types->union($type->inferTemplateTypes($receivedType));
 		}
 
 		return $types;

--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -99,7 +99,7 @@ function e($a) {
  * @param int $int
  */
 function testE($int) {
-	assertType('*NEVER*', e([[$int]]));
+	assertType('int', e([[$int]]));
 }
 
 /**

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -166,7 +166,7 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 					new MixedType(),
 					$templateType('T')
 				),
-				['T' => '*NEVER*'],
+				[],
 			],
 			'receive non-accepted' => [
 				new StringType(),
@@ -174,7 +174,7 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 					new MixedType(),
 					$templateType('T')
 				),
-				['T' => '*NEVER*'],
+				[],
 			],
 			'receive union items' => [
 				new ArrayType(


### PR DESCRIPTION

Instead of passing a NeverType down the inner types when the received type is not compatible, we just skip. This simplifies inference a little.

Also, in unions and intersections, we can always let the inner type handle the received type.

This has the effect of allowing this to pass:

``` php
<?php

/**
 * @template T
 * @param array<\DateTime|array<T>> $a
 * @return T
 */
function e($a) {
	throw new \Exception();
}
/**
 * @param int $int
 */
function testE($int) {
	assertType('int', e([[$int]]));
}
```