### PR TITLE
Improve IterableType::describe() with template types

### DIFF
--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
@@ -108,8 +109,11 @@ class IterableType implements CompoundType
 
 	public function describe(VerbosityLevel $level): string
 	{
-		if ($this->keyType instanceof MixedType) {
-			if ($this->itemType instanceof MixedType) {
+		$isMixedKeyType = $this->keyType instanceof MixedType && !$this->keyType instanceof TemplateType;
+		$isMixedItemType = $this->itemType instanceof MixedType && !$this->itemType instanceof TemplateType;
+
+		if ($isMixedKeyType) {
+			if ($isMixedItemType) {
 				return 'iterable';
 			}
 

--- a/tests/PHPStan/Type/IterableTypeTest.php
+++ b/tests/PHPStan/Type/IterableTypeTest.php
@@ -240,4 +240,50 @@ class IterableTypeTest extends \PHPStan\Testing\TestCase
 		);
 	}
 
+	public function dataDescribe(): array
+	{
+		$templateType = TemplateTypeFactory::create(
+			TemplateTypeScope::createWithFunction('a'),
+			'T',
+			null
+		);
+
+		return [
+			[
+				new IterableType(new IntegerType(), new StringType()),
+				'iterable<int, string>',
+			],
+			[
+				new IterableType(new MixedType(), new StringType()),
+				'iterable<string>',
+			],
+			[
+				new IterableType(new MixedType(), new MixedType()),
+				'iterable',
+			],
+			[
+				new IterableType($templateType, new MixedType()),
+				'iterable<T, mixed>',
+			],
+			[
+				new IterableType(new MixedType(), $templateType),
+				'iterable<T>',
+			],
+			[
+				new IterableType($templateType, $templateType),
+				'iterable<T, T>',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataDescribe
+	 */
+	public function testDescribe(Type $type, string $expect): void
+	{
+		$result = $type->describe(VerbosityLevel::typeOnly());
+
+		$this->assertSame($expect, $result);
+	}
+
 }


### PR DESCRIPTION
Changes `IterableType::describe()` such that `IterableType(TemplateType(K), TemplateType(V))` is described as `iterable<K, V>` rather than `iterable`.