### PR TITLE
Support template type inference on constant arrays

### DIFF
--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -226,3 +226,19 @@ function iterableToArray($it) {
 function testIterable(iterable $it) {
 	assertType('array<string, PHPStan\Generics\FunctionsAssertType\Foo>', iterableToArray($it));
 }
+
+/**
+ * @template T
+ * @template U
+ * @param array{a: T, b: U, c: int} $a
+ * @return array{T, U}
+ */
+function constantArray($a): array {
+	return [$a['a'], $a['b']];
+}
+
+function testConstantArray(int $int, string $str) {
+	[$a, $b] = constantArray(['a' => $int, 'b' => $str, 'c' => 1]);
+	assertType('int', $a);
+	assertType('string', $b);
+}


### PR DESCRIPTION
This adds support for type inference on constant arrays: 

``` php
<?php

/**
 * @template T
 * @param array{foo: T, bar: int} $a
 * @return T
 */
function f(array $a) {
    return $a['foo'];
}

f(["foo" => "hello", "bar" => 1]); // string
```