### PR TITLE
Check template type inference failures

### DIFF
--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -165,6 +165,7 @@ class InstantiationRule implements \PHPStan\Rules\Rule
 				'Parameter #%d %s of class ' . $classReflection->getDisplayName() . ' constructor expects %s, %s given.',
 				'', // constructor does not have a return type
 				'Parameter #%d %s of class ' . $classReflection->getDisplayName() . ' constructor is passed by reference, so it expects variables only',
+				'Unable to resolve the template type %s in instantiation of class ' . $classReflection->getDisplayName(),
 			]
 		));
 	}

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -5,8 +5,10 @@ namespace PHPStan\Rules;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
@@ -38,7 +40,7 @@ class FunctionCallParametersCheck
 	 * @param \PHPStan\Reflection\ParametersAcceptor $parametersAcceptor
 	 * @param \PHPStan\Analyser\Scope $scope
 	 * @param \PhpParser\Node\Expr\FuncCall|\PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall|\PhpParser\Node\Expr\New_ $funcCall
-	 * @param string[] $messages Eight message templates
+	 * @param string[] $messages Nine message templates
 	 * @return string[]
 	 */
 	public function check(
@@ -184,6 +186,14 @@ class FunctionCallParametersCheck
 				$i + 1,
 				sprintf('%s$%s', $parameter->isVariadic() ? '...' : '', $parameter->getName())
 			);
+		}
+
+		foreach ($parametersAcceptor->getTemplateTypeMap()->getTypes() as $name => $type) {
+			if (!($type instanceof ErrorType) && !($type instanceof NeverType)) {
+				continue;
+			}
+
+			$errors[] = sprintf($messages[9], $name);
 		}
 
 		return $errors;

--- a/src/Rules/Functions/CallCallablesRule.php
+++ b/src/Rules/Functions/CallCallablesRule.php
@@ -123,6 +123,7 @@ class CallCallablesRule implements \PHPStan\Rules\Rule
 					'Parameter #%d %s of ' . $callableDescription . ' expects %s, %s given.',
 					'Result of ' . $callableDescription . ' (void) is used.',
 					'Parameter #%d %s of ' . $callableDescription . ' is passed by reference, so it expects variables only.',
+					'Unable to resolve the template type %s in call to ' . ucfirst($callableDescription),
 				]
 			)
 		);

--- a/src/Rules/Functions/CallToFunctionParametersRule.php
+++ b/src/Rules/Functions/CallToFunctionParametersRule.php
@@ -64,6 +64,7 @@ class CallToFunctionParametersRule implements \PHPStan\Rules\Rule
 				'Parameter #%d %s of function ' . $function->getName() . ' expects %s, %s given.',
 				'Result of function ' . $function->getName() . ' (void) is used.',
 				'Parameter #%d %s of function ' . $function->getName() . ' is passed by reference, so it expects variables only.',
+				'Unable to resolve the template type %s in call to function ' . $function->getName(),
 			]
 		);
 	}

--- a/src/Rules/Methods/CallMethodsRule.php
+++ b/src/Rules/Methods/CallMethodsRule.php
@@ -154,6 +154,7 @@ class CallMethodsRule implements \PHPStan\Rules\Rule
 				'Parameter #%d %s of method ' . $messagesMethodName . ' expects %s, %s given.',
 				'Result of method ' . $messagesMethodName . ' (void) is used.',
 				'Parameter #%d %s of method ' . $messagesMethodName . ' is passed by reference, so it expects variables only.',
+				'Unable to resolve the template type %s in call to method ' . $messagesMethodName,
 			]
 		));
 

--- a/src/Rules/Methods/CallStaticMethodsRule.php
+++ b/src/Rules/Methods/CallStaticMethodsRule.php
@@ -263,6 +263,7 @@ class CallStaticMethodsRule implements \PHPStan\Rules\Rule
 				'Parameter #%d %s of ' . $lowercasedMethodName . ' expects %s, %s given.',
 				'Result of ' . $lowercasedMethodName . ' (void) is used.',
 				'Parameter #%d %s of ' . $lowercasedMethodName . ' is passed by reference, so it expects variables only.',
+				'Unable to resolve the template type %s in call to method ' . $displayMethodName,
 			]
 		));
 

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Type\Generic;
 
-use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 
@@ -19,7 +18,7 @@ class TemplateTypeHelper
 				$newType = $standins->getType($type->getName());
 
 				if ($newType === null) {
-					return new ErrorType();
+					return $type->getBound();
 				}
 
 				return $traverse($newType);

--- a/tests/PHPStan/Generics/data/functions-5.json
+++ b/tests/PHPStan/Generics/data/functions-5.json
@@ -5,7 +5,17 @@
         "ignorable": true
     },
     {
+        "message": "Unable to resolve the template type B in call to function PHPStan\\Generics\\Functions\\f",
+        "line": 38,
+        "ignorable": true
+    },
+    {
         "message": "Parameter #2 $b of function PHPStan\\Generics\\Functions\\f expects callable(int): mixed, '' given.",
+        "line": 39,
+        "ignorable": true
+    },
+    {
+        "message": "Unable to resolve the template type B in call to function PHPStan\\Generics\\Functions\\f",
         "line": 39,
         "ignorable": true
     }

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -6,7 +6,6 @@ use PHPStan\Reflection\Php\DummyParameter;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeScope;
@@ -339,7 +338,7 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 						),
 						new DummyParameter(
 							'b',
-							new ErrorType(),
+							new MixedType(),
 							false,
 							PassedByReference::createNo(),
 							false,

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -297,4 +297,19 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 		$this->analyse([__DIR__ . '/data/callable-or-closure-problem.php'], []);
 	}
 
+	public function testGenericFunction(): void
+	{
+		require_once __DIR__ . '/data/call-generic-function.php';
+		$this->analyse([__DIR__ . '/data/call-generic-function.php'], [
+			[
+				'Unable to resolve the template type A in call to function CallGenericFunction\f',
+				15,
+			],
+			[
+				'Unable to resolve the template type B in call to function CallGenericFunction\f',
+				15,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -309,6 +309,14 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Unable to resolve the template type B in call to function CallGenericFunction\f',
 				15,
 			],
+			[
+				'Parameter #1 $a of function CallGenericFunction\g expects DateTime, DateTimeImmutable given.',
+				26,
+			],
+			[
+				'Unable to resolve the template type A in call to function CallGenericFunction\g',
+				26,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/data/call-generic-function.php
+++ b/tests/PHPStan/Rules/Functions/data/call-generic-function.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CallGenericFunction;
+
+/**
+ * @template A
+ * @template B
+ * @param int|array<A> $a
+ * @param int|array<B> $b
+ */
+function f($a, $b): void {
+}
+
+function test(): void {
+	f(1, 2);
+}

--- a/tests/PHPStan/Rules/Functions/data/call-generic-function.php
+++ b/tests/PHPStan/Rules/Functions/data/call-generic-function.php
@@ -14,3 +14,14 @@ function f($a, $b): void {
 function test(): void {
 	f(1, 2);
 }
+
+/**
+ * @template A of \DateTime
+ * @param A $a
+ */
+function g($a): void {
+}
+
+function testg(): void {
+	g(new \DateTimeImmutable());
+}


### PR DESCRIPTION
This changes `FunctionCallParametersCheck` to check that template types were successfully inferred in function calls.

``` php
 <?php

 /**
  * @template A
  * @param int|array<A> $a
  */
 function f($a): void {
 }

 function test(): void {
     f(1); // Unable to resolve the template type A in call to function f
 }
```