### PR TITLE
Fix union() when subtractable types are enabled

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -10,6 +10,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\TemplateType;
 
 class TypeCombinator
 {
@@ -140,7 +141,7 @@ class TypeCombinator
 				unset($types[$i]);
 				continue;
 			}
-			if (!self::$enableSubtractableTypes && $types[$i] instanceof MixedType) {
+			if (!self::$enableSubtractableTypes && $types[$i] instanceof MixedType && !$types[$i] instanceof TemplateType) {
 				return $types[$i];
 			}
 			if ($types[$i] instanceof ConstantScalarType) {


### PR DESCRIPTION
When subtractable types are disabled, `T|null` is `null`.

This is caused by TypeCombinator checking that the type is a MixedType.

I added a special case, but a proper fix would be to not inherit MixedType/ObjectType in template types.

I changed `TypeCombinatorTest::testUnion()` to test with subtractable types enabled and disabled.