### PR TITLE
Allow native typehints with template types

### DIFF
--- a/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
@@ -8,6 +8,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FileTypeMapper;
+use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
@@ -67,7 +68,7 @@ class IncompatiblePhpDocTypeRule implements \PHPStan\Rules\Rule
 
 			} else {
 				$nativeParamType = $nativeParameterTypes[$parameterName];
-				$isParamSuperType = $nativeParamType->isSuperTypeOf($phpDocParamType);
+				$isParamSuperType = $nativeParamType->isSuperTypeOf(TemplateTypeHelper::resolveToBounds($phpDocParamType));
 
 				if (
 					$phpDocParamTag->isVariadic()
@@ -97,7 +98,7 @@ class IncompatiblePhpDocTypeRule implements \PHPStan\Rules\Rule
 		}
 
 		if ($resolvedPhpDoc->getReturnTag() !== null) {
-			$phpDocReturnType = $resolvedPhpDoc->getReturnTag()->getType();
+			$phpDocReturnType = TemplateTypeHelper::resolveToBounds($resolvedPhpDoc->getReturnTag()->getType());
 
 			if ($phpDocReturnType instanceof ErrorType || $phpDocReturnType instanceof NeverType) {
 				$errors[] = 'PHPDoc tag @return contains unresolvable type.';

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -18,10 +18,21 @@ class TemplateTypeHelper
 				$newType = $standins->getType($type->getName());
 
 				if ($newType === null) {
-					return $type->getBound();
+					$newType = $type->getBound();
 				}
 
 				return $traverse($newType);
+			}
+
+			return $traverse($type);
+		});
+	}
+
+	public static function resolveToBounds(Type $type): Type
+	{
+		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
+			if ($type instanceof TemplateType) {
+				return $traverse($type->getBound());
 			}
 
 			return $traverse($type);

--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type;
 
 use PHPStan\Broker\Broker;
+use PHPStan\Type\Generic\TemplateTypeHelper;
 
 class TypehintHelper
 {
@@ -103,7 +104,8 @@ class TypehintHelper
 				}
 			}
 
-			$resultType = $type->isSuperTypeOf($phpDocType)->yes() ? $phpDocType : $type;
+			$resultType = $type->isSuperTypeOf(TemplateTypeHelper::resolveToBounds($phpDocType))->yes() ? $phpDocType : $type;
+
 			if (TypeCombinator::containsNull($type)) {
 				$type = TypeCombinator::addNull($resultType);
 			} else {

--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -242,3 +242,17 @@ function testConstantArray(int $int, string $str) {
 	assertType('int', $a);
 	assertType('string', $b);
 }
+
+/**
+ * @template U of \DateTimeInterface
+ * @param U $a
+ * @return U
+ */
+function typeHints(\DateTimeInterface $a): \DateTimeInterface {
+	assertType('U of DateTimeInterface (function PHPStan\Generics\FunctionsAssertType\typeHints())', $a);
+	return $a;
+}
+
+function testTypeHints(): void {
+	assertType('DateTime', typeHints(new \DateTime()));
+}

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -65,6 +65,18 @@ class IncompatiblePhpDocTypeRuleTest extends \PHPStan\Testing\RuleTestCase
 				'PHPDoc tag @return contains unresolvable type.',
 				126,
 			],
+			[
+				'PHPDoc tag @param for parameter $a with type T is not subtype of native type int.',
+				154,
+			],
+			[
+				'PHPDoc tag @param for parameter $b with type U of DateTimeInterface is not subtype of native type DateTime.',
+				154,
+			],
+			[
+				'PHPDoc tag @return with type DateTimeInterface is not subtype of native type DateTime.',
+				154,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-types.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-types.php
@@ -127,3 +127,30 @@ function neverTypes($foo)
 {
 
 }
+
+/**
+ * @template T
+ * @template U of \DateTimeInterface
+ *
+ * @param T $a
+ * @param U $b
+ * @param U $c
+ *
+ * @return U
+ */
+function genericWithTypeHints($a, $b, \DateTimeInterface $c): \DateTimeInterface
+{
+}
+
+/**
+ * @template T
+ * @template U of \DateTimeInterface
+ *
+ * @param T $a
+ * @param U $b
+ *
+ * @return U
+ */
+function genericWithTypeHintsNotSubType(int $a, \DateTime $b): \DateTime
+{
+}


### PR DESCRIPTION
There are two issues with template types when using native type hints:

 - The IncompatiblePhpDocTypeRule rule will complain that the template type is not a super type of the type hint (because `(T of DateTime)->isSuperTypeOf(DateTime) is Maybe`)
 - In the reflection of the function, the native type hint wins over the template type (for the same reasons). As a result, in the function body, template parameters have the type of their type hints

This PR fixes both issues. 

