### PR TITLE
Fix igbinary_serialize() return type to string

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -4510,7 +4510,7 @@ return [
 'ifxus_seek_slob' => ['int', 'bid'=>'int', 'mode'=>'int', 'offset'=>'int'],
 'ifxus_tell_slob' => ['int', 'bid'=>'int'],
 'ifxus_write_slob' => ['int', 'bid'=>'int', 'content'=>'string'],
-'igbinary_serialize' => ['string|false', 'value'=>''],
+'igbinary_serialize' => ['string', 'value'=>''],
 'igbinary_unserialize' => ['', 'str'=>'string'],
 'ignore_user_abort' => ['int', 'value='=>'bool'],
 'iis_add_server' => ['int', 'path'=>'string', 'comment'=>'string', 'server_ip'=>'string', 'port'=>'int', 'host_name'=>'string', 'rights'=>'int', 'start_server'=>'int'],


### PR DESCRIPTION
See https://github.com/phadej/igbinary/blob/a0316ffc8bab7e628c3679dac0ec6b78ded52f12/php_igbinary.h#L48 - the function always return `string` and not `?string`