### PR TITLE
Add missing array key `mediatype` to return of `stream_get_meta_data`

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -11668,7 +11668,7 @@ return [
 'stream_get_contents' => ['string|false', 'source'=>'resource', 'maxlen='=>'int', 'offset='=>'int'],
 'stream_get_filters' => ['array'],
 'stream_get_line' => ['string|false', 'stream'=>'resource', 'maxlen'=>'int', 'ending='=>'string'],
-'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string}', 'fp'=>'resource'],
+'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string}', 'fp'=>'resource'],
 'stream_get_transports' => ['array'],
 'stream_get_wrappers' => ['array'],
 'stream_is_local' => ['bool', 'stream'=>'resource|string'],


### PR DESCRIPTION
The array returned from `stream_get_meta_data` at least _can_ contain the key `mediatype` containing the MIME type of a given base64 resource: https://3v4l.org/f094m

```php
<?php
$rh = fopen('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAGCAYAAAD68A/GAAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAAQFJREFUCB0B9gAJ/wEAAAAA/+PVEuTTxWX17+g7BwsQHPb5/f7z7ebgEA0JtSdcgaABAQH/AezQvRvv4tu4//PwLAUNCwD+/P8A+fz8AAIC/QD/9e0A6/UCqz7bFF8E/fb3cxQD/izQ7/PzEAECBvHv6wAEBAQABwwN//r2/gAGAAJVoSYHvQT3Bw/d/f0EAP738g3w6vb8AP/7//r7/wDs6egAEAb8Be0JIgDuAf3rAiAzPZXd/Q+B+AcV9/j+AgQJCg4FDg4VBQkQGQXjAx/v3voIbXFubq4BAAAAAAAAAACEnqcdIgLzOQH8+R77/QL/7vf74KXl+sXLi3boAAAAALtXdPvxF24RAAAAAElFTkSuQmCC', 'R');
$meta = stream_get_meta_data($rh);
var_dump($meta);
```

I simply added the key to the known list of keys