### PR TITLE
update disk_total_space signature

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -1861,7 +1861,7 @@ return [
 'DirectoryIterator::valid' => ['bool'],
 'dirname' => ['string', 'path'=>'string', 'levels='=>'int'],
 'disk_free_space' => ['float|false', 'path'=>'string'],
-'disk_total_space' => ['float', 'path'=>'string'],
+'disk_total_space' => ['float|false', 'path'=>'string'],
 'diskfreespace' => ['float|false', 'path'=>'string'],
 'display_disabled_function' => [''],
 'dl' => ['bool', 'extension_filename'=>'string'],


### PR DESCRIPTION
Signature for `disk_free_space` and `disk_total_space` do not match but the documentation is practically identical
* https://www.php.net/manual/en/function.disk-free-space.php
* https://www.php.net/manual/en/function.disk-total-space.php