### PR TITLE
date_create_immutable_from_format also supports false

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -1541,7 +1541,7 @@ return [
 'date_create' => ['DateTime|false', 'time='=>'string|null', 'timezone='=>'?\DateTimeZone'],
 'date_create_from_format' => ['DateTime|false', 'format'=>'string', 'time'=>'string', 'timezone='=>'DateTimeZone'],
 'date_create_immutable' => ['DateTimeImmutable|false', 'time='=>'string', 'timezone='=>'?\DateTimeZone'],
-'date_create_immutable_from_format' => ['DateTimeImmutable', 'format'=>'string', 'time'=>'string', 'timezone='=>'?\DateTimeZone'],
+'date_create_immutable_from_format' => ['DateTimeImmutable|false', 'format'=>'string', 'time'=>'string', 'timezone='=>'?\DateTimeZone'],
 'date_date_set' => ['DateTime|false', 'object'=>'', 'year'=>'', 'month'=>'', 'day'=>''],
 'date_default_timezone_get' => ['string'],
 'date_default_timezone_set' => ['bool', 'timezone_identifier'=>'string'],


### PR DESCRIPTION
When parsing of the date/time fails for date_create_immutable_from_format
it will return false as a valid value. Although the php documentation does not
reflect this, it is demonstratable by visiting https://3v4l.org/etHCv.