### PR TITLE
Improve template type inheritance

### DIFF
--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -58,7 +58,7 @@ final class TemplateMixedType extends MixedType implements TemplateType
 			$basicDescription,
 			$basicDescription,
 			function () use ($basicDescription): string {
-				return sprintf('%s (%s)', $basicDescription(), $this->scope->describe());
+				return sprintf('%s (%s, %s)', $basicDescription(), $this->scope->describe(), $this->isArgument() ? 'argument' : 'parameter');
 			}
 		);
 	}

--- a/src/Type/Generic/TemplateObjectType.php
+++ b/src/Type/Generic/TemplateObjectType.php
@@ -66,7 +66,7 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 			$basicDescription,
 			$basicDescription,
 			function () use ($basicDescription): string {
-				return sprintf('%s (%s)', $basicDescription(), $this->scope->describe());
+				return sprintf('%s (%s, %s)', $basicDescription(), $this->scope->describe(), $this->isArgument() ? 'argument' : 'parameter');
 			}
 		);
 	}

--- a/src/Type/Generic/TemplateTypeScope.php
+++ b/src/Type/Generic/TemplateTypeScope.php
@@ -32,6 +32,16 @@ class TemplateTypeScope
 		$this->functionName = $functionName;
 	}
 
+	public function getClassName(): ?string
+	{
+		return $this->className;
+	}
+
+	public function getFunctionName(): ?string
+	{
+		return $this->functionName;
+	}
+
 	public function equals(self $other): bool
 	{
 		return $this->className === $other->className

--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -10,7 +10,7 @@ use function PHPStan\Analyser\assertType;
  * @return T
  */
 function a($a) {
-	assertType('T (function PHPStan\Generics\FunctionsAssertType\a())', $a);
+	assertType('T (function PHPStan\Generics\FunctionsAssertType\a(), argument)', $a);
 	return $a;
 }
 
@@ -32,8 +32,8 @@ function testA($int, $intFloat, $mixed) {
  * @return T
  */
 function b($a) {
-	assertType('T of DateTimeInterface (function PHPStan\Generics\FunctionsAssertType\b())', $a);
-	assertType('T of DateTimeInterface (function PHPStan\Generics\FunctionsAssertType\b())', b($a));
+	assertType('T of DateTimeInterface (function PHPStan\Generics\FunctionsAssertType\b(), argument)', $a);
+	assertType('T of DateTimeInterface (function PHPStan\Generics\FunctionsAssertType\b(), argument)', b($a));
 	return $a;
 }
 
@@ -113,12 +113,12 @@ function testE($int) {
  */
 function f($a, $b) {
 	$result = [];
-	assertType('array<A (function PHPStan\Generics\FunctionsAssertType\f())>', $a);
-	assertType('callable(A (function PHPStan\Generics\FunctionsAssertType\f())): B (function PHPStan\Generics\FunctionsAssertType\f())', $b);
+	assertType('array<A (function PHPStan\Generics\FunctionsAssertType\f(), argument)>', $a);
+	assertType('callable(A (function PHPStan\Generics\FunctionsAssertType\f(), argument)): B (function PHPStan\Generics\FunctionsAssertType\f(), argument)', $b);
 	foreach ($a as $k => $v) {
-		assertType('A (function PHPStan\Generics\FunctionsAssertType\f())', $v);
+		assertType('A (function PHPStan\Generics\FunctionsAssertType\f(), argument)', $v);
 		$newV = $b($v);
-		assertType('B (function PHPStan\Generics\FunctionsAssertType\f())', $newV);
+		assertType('B (function PHPStan\Generics\FunctionsAssertType\f(), argument)', $newV);
 		$result[$k] = $newV;
 	}
 	return $result;
@@ -176,8 +176,8 @@ class Foo {
  * @param T $foo
  */
 function testReturnsStatic($foo) {
-	assertType('T of PHPStan\Generics\FunctionsAssertType\Foo (function PHPStan\Generics\FunctionsAssertType\testReturnsStatic())', $foo::returnsStatic());
-	assertType('T of PHPStan\Generics\FunctionsAssertType\Foo (function PHPStan\Generics\FunctionsAssertType\testReturnsStatic())', $foo->instanceReturnsStatic());
+	assertType('T of PHPStan\Generics\FunctionsAssertType\Foo (function PHPStan\Generics\FunctionsAssertType\testReturnsStatic(), argument)', $foo::returnsStatic());
+	assertType('T of PHPStan\Generics\FunctionsAssertType\Foo (function PHPStan\Generics\FunctionsAssertType\testReturnsStatic(), argument)', $foo->instanceReturnsStatic());
 }
 
 /**
@@ -249,7 +249,7 @@ function testConstantArray(int $int, string $str) {
  * @return U
  */
 function typeHints(\DateTimeInterface $a): \DateTimeInterface {
-	assertType('U of DateTimeInterface (function PHPStan\Generics\FunctionsAssertType\typeHints())', $a);
+	assertType('U of DateTimeInterface (function PHPStan\Generics\FunctionsAssertType\typeHints(), argument)', $a);
 	return $a;
 }
 
@@ -259,7 +259,7 @@ function typeHints(\DateTimeInterface $a): \DateTimeInterface {
  * @return U
  */
 function typeHintsSuperType(\DateTimeInterface $a): \DateTimeInterface {
-	assertType('U of DateTime (function PHPStan\Generics\FunctionsAssertType\typeHintsSuperType())', $a);
+	assertType('U of DateTime (function PHPStan\Generics\FunctionsAssertType\typeHintsSuperType(), argument)', $a);
 	return $a;
 }
 
@@ -306,7 +306,7 @@ function varAnnotation($cb)
 	/** @var T */
 	$v = $cb();
 
-	assertType('T (function PHPStan\Generics\FunctionsAssertType\varAnnotation())', $v);
+	assertType('T (function PHPStan\Generics\FunctionsAssertType\varAnnotation(), argument)', $v);
 
 	return $v;
 }
@@ -325,14 +325,14 @@ class C
 	 */
 	public function f($p, $cb)
 	{
-		assertType('T (class PHPStan\Generics\FunctionsAssertType\C)', $p);
+		assertType('T (class PHPStan\Generics\FunctionsAssertType\C, argument)', $p);
 
 		/** @var T */
 		$v = $cb();
 
-		assertType('T (class PHPStan\Generics\FunctionsAssertType\C)', $v);
+		assertType('T (class PHPStan\Generics\FunctionsAssertType\C, argument)', $v);
 
-		assertType('T (class PHPStan\Generics\FunctionsAssertType\C)', $this->a);
+		assertType('T (class PHPStan\Generics\FunctionsAssertType\C, argument)', $this->a);
 
 		$a = new class {
 			/** @return T */
@@ -341,6 +341,6 @@ class C
 			}
 		};
 
-		assertType('T (class PHPStan\Generics\FunctionsAssertType\C)', $a->g());
+		assertType('T (class PHPStan\Generics\FunctionsAssertType\C, argument)', $a->g());
 	}
 }

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -1108,7 +1108,7 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					new ObjectType('DateTime'),
 				],
 				UnionType::class,
-				'DateTime|T (function a())',
+				'DateTime|T (function a(), parameter)',
 			],
 			[
 				[
@@ -1120,7 +1120,7 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					new ObjectType('DateTime'),
 				],
 				UnionType::class,
-				'DateTime|T of DateTime (function a())',
+				'DateTime|T of DateTime (function a(), parameter)',
 			],
 			[
 				[
@@ -1136,7 +1136,7 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					),
 				],
 				TemplateType::class,
-				'T of DateTime (function a())',
+				'T of DateTime (function a(), parameter)',
 			],
 			[
 				[
@@ -1152,7 +1152,7 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					),
 				],
 				UnionType::class,
-				'T of DateTime (function a())|U of DateTime (function a())',
+				'T of DateTime (function a(), parameter)|U of DateTime (function a(), parameter)',
 			],
 			[
 				[
@@ -1849,7 +1849,7 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					new ObjectType('DateTime'),
 				],
 				IntersectionType::class,
-				'DateTime&T (function a())',
+				'DateTime&T (function a(), parameter)',
 			],
 			[
 				[
@@ -1861,7 +1861,7 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					new ObjectType('DateTime'),
 				],
 				IntersectionType::class,
-				'DateTime&T of DateTime (function a())',
+				'DateTime&T of DateTime (function a(), parameter)',
 			],
 			[
 				[
@@ -1877,7 +1877,7 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					),
 				],
 				TemplateType::class,
-				'T of DateTime (function a())',
+				'T of DateTime (function a(), parameter)',
 			],
 			[
 				[
@@ -1893,7 +1893,7 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					),
 				],
 				IntersectionType::class,
-				'T of DateTime (function a())&U of DateTime (function a())',
+				'T of DateTime (function a(), parameter)&U of DateTime (function a(), parameter)',
 			],
 		];
 	}


### PR DESCRIPTION
This improves the logic of choosing whether a template type is resolvable (parameter strategy) or not (argument strategy). This also exposes the strategy in `TemplateType::describe(VerbosityLevel::precise())`.

Template types are resolvable when:
- Referenced in a param of the function where the template type was declared
- Referenced in a param of the method where the template type was declared
- Referenced in a param of a method of the class where the template type was declared
- Referenced in a property of the class where the template type was declared

Template types are not resolved when:
- Referenced in a `@var` annotation
- Inherited from an outter method, function, or class
- Used inside the method, function, or class that declared it

