### PR TITLE
Separate template types from resolved template types in reflection

### DIFF
--- a/src/Broker/Broker.php
+++ b/src/Broker/Broker.php
@@ -400,6 +400,7 @@ class Broker
 					}
 					$variants[] = new FunctionVariant(
 						TemplateTypeMap::createEmpty(),
+						null,
 						array_map(static function (ParameterSignature $parameterSignature) use ($lowerCasedFunctionName): NativeParameterReflection {
 							$type = $parameterSignature->getType();
 							if (

--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -98,6 +98,7 @@ class AnnotationMethodReflection implements MethodReflection
 			$this->variants = [
 				new FunctionVariant(
 					TemplateTypeMap::createEmpty(),
+					null,
 					$this->parameters,
 					$this->isVariadic,
 					$this->returnType
@@ -135,6 +136,12 @@ class AnnotationMethodReflection implements MethodReflection
 	public function hasSideEffects(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
+	}
+
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
 	}
 
 }

--- a/src/Reflection/Annotations/AnnotationPropertyReflection.php
+++ b/src/Reflection/Annotations/AnnotationPropertyReflection.php
@@ -95,4 +95,10 @@ class AnnotationPropertyReflection implements PropertyReflection
 		return TrinaryLogic::createNo();
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/ClassConstantReflection.php
+++ b/src/Reflection/ClassConstantReflection.php
@@ -89,4 +89,10 @@ class ClassConstantReflection implements ConstantReflection
 		return TrinaryLogic::createFromBoolean($this->isInternal);
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return $this->reflection->getDocComment();
+	}
+
 }

--- a/src/Reflection/ClassMemberReflection.php
+++ b/src/Reflection/ClassMemberReflection.php
@@ -13,4 +13,7 @@ interface ClassMemberReflection
 
 	public function isPublic(): bool;
 
+	/** @return string|false */
+	public function getDocComment();
+
 }

--- a/src/Reflection/Dummy/DummyConstantReflection.php
+++ b/src/Reflection/Dummy/DummyConstantReflection.php
@@ -69,4 +69,10 @@ class DummyConstantReflection implements ConstantReflection
 		return TrinaryLogic::createMaybe();
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/Dummy/DummyConstructorReflection.php
+++ b/src/Reflection/Dummy/DummyConstructorReflection.php
@@ -57,6 +57,7 @@ class DummyConstructorReflection implements MethodReflection
 		return [
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[],
 				false,
 				new VoidType()
@@ -92,6 +93,12 @@ class DummyConstructorReflection implements MethodReflection
 	public function hasSideEffects(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
+	}
+
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
 	}
 
 }

--- a/src/Reflection/Dummy/DummyMethodReflection.php
+++ b/src/Reflection/Dummy/DummyMethodReflection.php
@@ -93,4 +93,10 @@ class DummyMethodReflection implements MethodReflection
 		return TrinaryLogic::createMaybe();
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/Dummy/DummyPropertyReflection.php
+++ b/src/Reflection/Dummy/DummyPropertyReflection.php
@@ -74,4 +74,10 @@ class DummyPropertyReflection implements PropertyReflection
 		return TrinaryLogic::createMaybe();
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/FunctionVariant.php
+++ b/src/Reflection/FunctionVariant.php
@@ -11,6 +11,9 @@ class FunctionVariant implements ParametersAcceptor
 	/** @var TemplateTypeMap */
 	private $templateTypeMap;
 
+	/** @var TemplateTypeMap|null */
+	private $resolvedTemplateTypeMap;
+
 	/** @var array<int, ParameterReflection> */
 	private $parameters;
 
@@ -27,12 +30,14 @@ class FunctionVariant implements ParametersAcceptor
 	 */
 	public function __construct(
 		TemplateTypeMap $templateTypeMap,
+		?TemplateTypeMap $resolvedTemplateTypeMap,
 		array $parameters,
 		bool $isVariadic,
 		Type $returnType
 	)
 	{
 		$this->templateTypeMap = $templateTypeMap;
+		$this->resolvedTemplateTypeMap = $resolvedTemplateTypeMap;
 		$this->parameters = $parameters;
 		$this->isVariadic = $isVariadic;
 		$this->returnType = $returnType;
@@ -41,6 +46,11 @@ class FunctionVariant implements ParametersAcceptor
 	public function getTemplateTypeMap(): TemplateTypeMap
 	{
 		return $this->templateTypeMap;
+	}
+
+	public function getResolvedTemplateTypeMap(): TemplateTypeMap
+	{
+		return $this->resolvedTemplateTypeMap ?? TemplateTypeMap::createEmpty();
 	}
 
 	/**

--- a/src/Reflection/FunctionVariantWithPhpDocs.php
+++ b/src/Reflection/FunctionVariantWithPhpDocs.php
@@ -24,6 +24,7 @@ class FunctionVariantWithPhpDocs extends FunctionVariant implements ParametersAc
 	 */
 	public function __construct(
 		TemplateTypeMap $templateTypeMap,
+		?TemplateTypeMap $resolvedTemplateTypeMap,
 		array $parameters,
 		bool $isVariadic,
 		Type $returnType,
@@ -33,6 +34,7 @@ class FunctionVariantWithPhpDocs extends FunctionVariant implements ParametersAc
 	{
 		parent::__construct(
 			$templateTypeMap,
+			$resolvedTemplateTypeMap,
 			$parameters,
 			$isVariadic,
 			$returnType

--- a/src/Reflection/Generic/ResolvedFunctionVariant.php
+++ b/src/Reflection/Generic/ResolvedFunctionVariant.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Generic;
+
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\Reflection\Php\DummyParameter;
+use PHPStan\Type\Generic\TemplateTypeHelper;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Type;
+
+class ResolvedFunctionVariant implements ParametersAcceptor
+{
+
+	/** @var ParametersAcceptor */
+	private $parametersAcceptor;
+
+	/** @var TemplateTypeMap */
+	private $resolvedTemplateTypeMap;
+
+	/** @var ParameterReflection[]|null */
+	private $parameters;
+
+	/** @var Type|null */
+	private $returnType;
+
+	public function __construct(
+		ParametersAcceptor $parametersAcceptor,
+		TemplateTypeMap $resolvedTemplateTypeMap
+	)
+	{
+		$this->parametersAcceptor = $parametersAcceptor;
+		$this->resolvedTemplateTypeMap = $resolvedTemplateTypeMap;
+	}
+
+	public function getTemplateTypeMap(): TemplateTypeMap
+	{
+		return $this->parametersAcceptor->getTemplateTypeMap();
+	}
+
+	public function getResolvedTemplateTypeMap(): TemplateTypeMap
+	{
+		return $this->resolvedTemplateTypeMap;
+	}
+
+	public function getParameters(): array
+	{
+		$parameters = $this->parameters;
+
+		if ($parameters === null) {
+			$parameters = array_map(function (ParameterReflection $param): ParameterReflection {
+				return new DummyParameter(
+					$param->getName(),
+					TemplateTypeHelper::resolveTemplateTypes($param->getType(), $this->resolvedTemplateTypeMap),
+					$param->isOptional(),
+					$param->passedByReference(),
+					$param->isVariadic(),
+					$param->getDefaultValue()
+				);
+			}, $this->parametersAcceptor->getParameters());
+
+			$this->parameters = $parameters;
+		}
+
+		return $parameters;
+	}
+
+	public function isVariadic(): bool
+	{
+		return $this->parametersAcceptor->isVariadic();
+	}
+
+	public function getReturnType(): Type
+	{
+		$type = $this->returnType;
+
+		if ($type === null) {
+			$type = TemplateTypeHelper::resolveTemplateTypes(
+				$this->parametersAcceptor->getReturnType(),
+				$this->resolvedTemplateTypeMap
+			);
+
+			$this->returnType = $type;
+		}
+
+		return $type;
+	}
+
+}

--- a/src/Reflection/InaccessibleMethod.php
+++ b/src/Reflection/InaccessibleMethod.php
@@ -27,6 +27,11 @@ class InaccessibleMethod implements ParametersAcceptor
 		return TemplateTypeMap::createEmpty();
 	}
 
+	public function getResolvedTemplateTypeMap(): TemplateTypeMap
+	{
+		return TemplateTypeMap::createEmpty();
+	}
+
 	/**
 	 * @return array<int, \PHPStan\Reflection\ParameterReflection>
 	 */

--- a/src/Reflection/MethodPrototypeReflection.php
+++ b/src/Reflection/MethodPrototypeReflection.php
@@ -50,4 +50,10 @@ class MethodPrototypeReflection implements ClassMemberReflection
 		return $this->isPublic;
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/Native/NativeMethodReflection.php
+++ b/src/Reflection/Native/NativeMethodReflection.php
@@ -131,4 +131,10 @@ class NativeMethodReflection implements MethodReflection
 		return $this->hasSideEffects;
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return $this->reflection->getDocComment();
+	}
+
 }

--- a/src/Reflection/ParametersAcceptor.php
+++ b/src/Reflection/ParametersAcceptor.php
@@ -16,6 +16,8 @@ interface ParametersAcceptor
 
 	public function getTemplateTypeMap(): TemplateTypeMap;
 
+	public function getResolvedTemplateTypeMap(): TemplateTypeMap;
+
 	/**
 	 * @return array<int, \PHPStan\Reflection\ParameterReflection>
 	 */

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -248,7 +248,13 @@ class ParametersAcceptorSelector
 			}
 		}
 
-		return new FunctionVariant(TemplateTypeMap::createEmpty(), $parameters, $isVariadic, $returnType);
+		return new FunctionVariant(
+			TemplateTypeMap::createEmpty(),
+			null,
+			$parameters,
+			$isVariadic,
+			$returnType
+		);
 	}
 
 }

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -343,6 +343,7 @@ class PhpClassReflectionExtension
 				$methodSignature = $this->signatureMapProvider->getFunctionSignature($variantName, $declaringClassName);
 				$variants[] = new FunctionVariant(
 					TemplateTypeMap::createEmpty(),
+					null,
 					array_map(static function (ParameterSignature $parameterSignature): NativeParameterReflection {
 						return new NativeParameterReflection(
 							$parameterSignature->getName(),

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -128,6 +128,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 			$this->variants = [
 				new FunctionVariantWithPhpDocs(
 					$this->templateTypeMap,
+					null,
 					$this->getParameters(),
 					$this->isVariadic(),
 					$this->getReturnType(),

--- a/src/Reflection/Php/PhpFunctionReflection.php
+++ b/src/Reflection/Php/PhpFunctionReflection.php
@@ -132,6 +132,7 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 			$this->variants = [
 				new FunctionVariantWithPhpDocs(
 					$this->templateTypeMap,
+					null,
 					$this->getParameters(),
 					$this->isVariadic(),
 					$this->getReturnType(),

--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -132,4 +132,10 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 		return parent::getReturnType();
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -223,6 +223,7 @@ class PhpMethodReflection implements MethodReflection
 			$this->variants = [
 				new FunctionVariantWithPhpDocs(
 					$this->templateTypeMap,
+					null,
 					$this->getParameters(),
 					$this->isVariadic(),
 					$this->getReturnType(),

--- a/src/Reflection/Php/SimpleXMLElementProperty.php
+++ b/src/Reflection/Php/SimpleXMLElementProperty.php
@@ -96,4 +96,10 @@ class SimpleXMLElementProperty implements PropertyReflection
 		return TrinaryLogic::createNo();
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/Php/UniversalObjectCrateProperty.php
+++ b/src/Reflection/Php/UniversalObjectCrateProperty.php
@@ -84,4 +84,10 @@ class UniversalObjectCrateProperty implements \PHPStan\Reflection\PropertyReflec
 		return TrinaryLogic::createNo();
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/PhpDefect/PhpDefectPropertyReflection.php
+++ b/src/Reflection/PhpDefect/PhpDefectPropertyReflection.php
@@ -85,4 +85,10 @@ class PhpDefectPropertyReflection implements PropertyReflection
 		return TrinaryLogic::createNo();
 	}
 
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/TrivialParametersAcceptor.php
+++ b/src/Reflection/TrivialParametersAcceptor.php
@@ -14,6 +14,11 @@ class TrivialParametersAcceptor implements ParametersAcceptor
 		return TemplateTypeMap::createEmpty();
 	}
 
+	public function getResolvedTemplateTypeMap(): TemplateTypeMap
+	{
+		return TemplateTypeMap::createEmpty();
+	}
+
 	/**
 	 * @return array<int, \PHPStan\Reflection\ParameterReflection>
 	 */

--- a/src/Reflection/Type/IntersectionTypeMethodReflection.php
+++ b/src/Reflection/Type/IntersectionTypeMethodReflection.php
@@ -90,6 +90,7 @@ class IntersectionTypeMethodReflection implements MethodReflection
 		return array_map(static function (ParametersAcceptor $acceptor) use ($returnType): ParametersAcceptor {
 			return new FunctionVariant(
 				$acceptor->getTemplateTypeMap(),
+				$acceptor->getResolvedTemplateTypeMap(),
 				$acceptor->getParameters(),
 				$acceptor->isVariadic(),
 				$returnType
@@ -153,6 +154,12 @@ class IntersectionTypeMethodReflection implements MethodReflection
 		return TrinaryLogic::maxMin(...array_map(static function (MethodReflection $method): TrinaryLogic {
 			return $method->hasSideEffects();
 		}, $this->methods));
+	}
+
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
 	}
 
 }

--- a/src/Reflection/Type/UnionTypeMethodReflection.php
+++ b/src/Reflection/Type/UnionTypeMethodReflection.php
@@ -90,6 +90,7 @@ class UnionTypeMethodReflection implements MethodReflection
 		return array_map(static function (ParametersAcceptor $acceptor) use ($returnType): ParametersAcceptor {
 			return new FunctionVariant(
 				$acceptor->getTemplateTypeMap(),
+				$acceptor->getResolvedTemplateTypeMap(),
 				$acceptor->getParameters(),
 				$acceptor->isVariadic(),
 				$returnType
@@ -153,6 +154,12 @@ class UnionTypeMethodReflection implements MethodReflection
 		return TrinaryLogic::extremeIdentity(...array_map(static function (MethodReflection $method): TrinaryLogic {
 			return $method->hasSideEffects();
 		}, $this->methods));
+	}
+
+	/** @return string|false */
+	public function getDocComment()
+	{
+		return false;
 	}
 
 }

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -196,7 +196,7 @@ class FunctionCallParametersCheck
 			);
 		}
 
-		foreach ($parametersAcceptor->getTemplateTypeMap()->getTypes() as $name => $type) {
+		foreach ($parametersAcceptor->getResolvedTemplateTypeMap()->getTypes() as $name => $type) {
 			if (!($type instanceof ErrorType) && !($type instanceof NeverType)) {
 				continue;
 			}

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -186,6 +186,11 @@ class CallableType implements CompoundType, ParametersAcceptor
 		return TemplateTypeMap::createEmpty();
 	}
 
+	public function getResolvedTemplateTypeMap(): TemplateTypeMap
+	{
+		return TemplateTypeMap::createEmpty();
+	}
+
 	/**
 	 * @return array<int, \PHPStan\Reflection\ParameterReflection>
 	 */

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -269,6 +269,11 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return TemplateTypeMap::createEmpty();
 	}
 
+	public function getResolvedTemplateTypeMap(): TemplateTypeMap
+	{
+		return TemplateTypeMap::createEmpty();
+	}
+
 	/**
 	 * @return array<int, \PHPStan\Reflection\Native\NativeParameterReflection>
 	 */

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type\Generic;
 
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 
@@ -15,9 +16,9 @@ class TemplateTypeHelper
 	{
 		return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($standins): Type {
 			if ($type instanceof TemplateType && !$type->isArgument()) {
-				$newType = $standins->getType($type->getName());
+				$newType = $standins->getType($type->getName()) ?? $type;
 
-				if ($newType === null) {
+				if ($newType instanceof ErrorType) {
 					$newType = $type->getBound();
 				}
 

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -39,7 +39,10 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					new ObjectType('DateTime'),
 				],
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -54,7 +57,10 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					new NullType()
 				),
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -75,7 +81,11 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					new IntegerType(),
 				],
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+						'U' => $templateType('U'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -98,7 +108,11 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					$templateType('U')
 				),
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+						'U' => $templateType('U'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -127,7 +141,10 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					new IntegerType(),
 				],
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -150,7 +167,10 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					$templateType('T')
 				),
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -187,7 +207,11 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					new ObjectType('DateTime'),
 				],
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+						'U' => $templateType('U'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -203,14 +227,18 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 							true,
 							PassedByReference::createNo(),
 							false,
-							new ConstantIntegerType(42)
+							new IntegerType()
 						),
 					],
 					false,
 					new NullType()
 				),
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+						'U' => $templateType('U'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -222,7 +250,7 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 						),
 						new DummyParameter(
 							'b',
-							new ConstantIntegerType(42),
+							new IntegerType(),
 							false,
 							PassedByReference::createNo(),
 							false,
@@ -241,7 +269,11 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					new ConstantIntegerType(3),
 				],
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+						'U' => $templateType('U'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -264,7 +296,11 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					$templateType('U')
 				),
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+						'U' => $templateType('U'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -303,7 +339,11 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					new ObjectType('DateTime'),
 				],
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+						'U' => $templateType('U'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -326,7 +366,11 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					new NullType()
 				),
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+						'U' => $templateType('U'),
+					]),
+					null,
 					[
 						new DummyParameter(
 							'a',
@@ -354,7 +398,10 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					new ConstantStringType('foo'),
 				],
 				new FunctionVariant(
-					TemplateTypeMap::createEmpty(),
+					new TemplateTypeMap([
+						'T' => $templateType('T'),
+					]),
+					null,
 					[
 						new DummyParameter('str', $templateType('T'), false, null, false, null),
 					],
@@ -363,6 +410,7 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 				),
 				new FunctionVariant(
 					TemplateTypeMap::createEmpty(),
+					null,
 					[
 						new DummyParameter('str', new ConstantStringType('foo'), false, null, false, null),
 					],

--- a/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
+++ b/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
@@ -111,6 +111,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 			false,
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new NativeParameterReflection(
 						'link_identifier|event',
@@ -163,6 +164,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 			false,
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new NativeParameterReflection(
 						'str|token',
@@ -197,6 +199,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 		$variadicVariants = [
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new NativeParameterReflection(
 						'int',
@@ -220,6 +223,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 			),
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new NativeParameterReflection(
 						'int',
@@ -255,6 +259,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 		$defaultValuesVariants1 = [
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new DummyParameter(
 						'a',
@@ -270,6 +275,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 			),
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new DummyParameter(
 						'a',
@@ -293,6 +299,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 			true,
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new DummyParameter(
 						'a',
@@ -314,6 +321,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 		$defaultValuesVariants2 = [
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new DummyParameter(
 						'a',
@@ -329,6 +337,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 			),
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new DummyParameter(
 						'a',
@@ -352,6 +361,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 			true,
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new DummyParameter(
 						'a',
@@ -370,6 +380,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 		$genericVariants = [
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new DummyParameter(
 						'a',
@@ -397,6 +408,7 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 			true,
 			new FunctionVariant(
 				TemplateTypeMap::createEmpty(),
+				null,
 				[
 					new DummyParameter(
 						'a',


### PR DESCRIPTION
This separates template types from resolved template types in reflection, this makes things clearer.

This also adds `ResolvedFunctionVariant`, a `FunctionReflection` whose template types are resolved by a given template type map.

And this also moves `getDeclaringTrait()` and `getDocComment()` to `ClassMemberReflection` / `FunctionReflection`, to make reflections more substituteable. 