### PR TITLE
Update the function signature of ReflectionProperty::setValue

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9796,7 +9796,7 @@ return [
 'ReflectionProperty::isPublic' => ['bool'],
 'ReflectionProperty::isStatic' => ['bool'],
 'ReflectionProperty::setAccessible' => ['void', 'visible'=>'bool'],
-'ReflectionProperty::setValue' => ['void', 'object'=>'object', 'value'=>''],
+'ReflectionProperty::setValue' => ['void', 'object'=>'null|object', 'value'=>''],
 'ReflectionProperty::setValue\'1' => ['void', 'value'=>''],
 'ReflectionType::__toString' => ['string'],
 'ReflectionType::allowsNull' => ['bool'],


### PR DESCRIPTION
As the title says, little change that allows passing `null` values to the first argument of the `ReflectionProperty::setValue` function