### PR TITLE
Move PSR-4 to build/PHPStan to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,12 +52,16 @@
 	"autoload": {
 		"psr-4": {
 			"PHPStan\\": [
-				"src/",
-				"build/PHPStan"
+				"src/"
 			]
 		}
 	},
 	"autoload-dev": {
+		"psr-4": {
+			"PHPStan\\": [
+				"build/PHPStan"
+			]
+		},
 		"classmap": [
 			"tests/PHPStan"
 		]


### PR DESCRIPTION
Ran into an issue while working on https://github.com/maglnet/ComposerRequireChecker/pull/115 that the `build/PHPStan` directory doesn't exits on tagged releases because it's ignored on export https://github.com/phpstan/phpstan/blob/274726c0ba2a48a03608502ab309984f116fcbeb/.gitattributes#L1 

This PR proposes to move the PSR-4 autoloading of that directory to `require-dev` because it's obviously not meant for production.