### PR TITLE
Improve constant array is callable with union of constant strings

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -172,6 +172,18 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function isCallable(): TrinaryLogic
 	{
+		if (count($this->valueTypes) === 2) {
+			[$objectOrClass, $methods] = $this->valueTypes;
+			if ($methods instanceof UnionType) {
+				return TrinaryLogic::extremeIdentity(...array_map(
+					function (Type $method) use ($objectOrClass): TrinaryLogic {
+						return (new ConstantArrayType($this->keyTypes, [$objectOrClass, $method]))->isCallable();
+					},
+					$methods->getTypes()
+				));
+			}
+		}
+
 		$typeAndMethod = $this->findTypeAndMethodName();
 		if ($typeAndMethod === null) {
 			return TrinaryLogic::createNo();

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -133,6 +133,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends \PHPStan\Testing\RuleTestC
 					'Call to function is_callable() with mixed will always evaluate to false.',
 					571,
 				],
+				[
+					'Call to function is_callable() with array($this(CheckTypeFunctionCall\CheckIsCallableWithStringUnion), \'bar\'|\'foo\') will always evaluate to true.',
+					594,
+				],
 			]
 		);
 	}

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -574,3 +574,26 @@ class CheckIsStringOnSubtractedMixed
 	}
 
 }
+
+final class CheckIsCallableWithStringUnion
+{
+
+	public function foo()
+	{
+
+	}
+
+	public function bar()
+	{
+
+	}
+
+	public function test()
+	{
+		foreach (['foo', 'bar'] as $method) {
+			if (!is_callable([$this, $method])) {
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Fix #2343 

BTW, I was wondering why we needed a `TypeSpecifier` to raise error, and why `Type::isCallable()` returning `Yes` was not sufficient ?