### PR TITLE
Move PSR-4 to build/PHPStan to require-dev (0.11.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,12 +52,16 @@
 	"autoload": {
 		"psr-4": {
 			"PHPStan\\": [
-				"src/",
-				"build/PHPStan"
+				"src/"
 			]
 		}
 	},
 	"autoload-dev": {
+		"psr-4": {
+			"PHPStan\\": [
+				"build/PHPStan"
+			]
+		},
 		"classmap": [
 			"tests/PHPStan"
 		]


### PR DESCRIPTION
Exactly the same as #2347 but didn't realise until `0.11.15` was released.