### PR TITLE
Updating Redis::exists return type

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9262,7 +9262,7 @@ return [
 'Redis::evaluate' => ['mixed', 'script'=>'string', 'args='=>'array', 'numKeys='=>'int'],
 'Redis::evaluateSha' => ['', 'scriptSha'=>'string', 'args='=>'array', 'numKeys='=>'int'],
 'Redis::exec' => ['array'],
-'Redis::exists' => ['bool', 'key'=>'string'],
+'Redis::exists' => ['int', 'key'=>'string'],
 'Redis::expire' => ['bool', 'key'=>'string', 'ttl'=>'int'],
 'Redis::expireAt' => ['bool', 'key'=>'string', 'expiry'=>'int'],
 'Redis::flushAll' => ['bool'],


### PR DESCRIPTION
Redis official docs indicates that exists return integer 0 or 1:
https://redis.io/commands/exists

Also in the library (most recent version, and even from 4.0 till now) also it return 0 or 1 for the exists method.
https://github.com/phpredis/phpredis/tree/5.0.2#exists

Updated the functionMap to return the correct type. Cause I'm getting the following error:
Strict comparison using === between bool and 1 will always evaluate to false.  