### PR TITLE
Updating password_hash signature for PHP 7.4

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -8238,7 +8238,7 @@ return [
 'parsekit_func_arginfo' => ['array', 'function'=>'mixed'],
 'passthru' => ['void', 'command'=>'string', '&w_return_value='=>'int'],
 'password_get_info' => ['array', 'hash'=>'string'],
-'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'int', 'options='=>'array'],
+'password_hash' => ['string|false', 'password'=>'string', 'algo='=>'int|string', 'options='=>'array'],
 'password_make_salt' => ['bool', 'password'=>'string', 'hash'=>'string'],
 'password_needs_rehash' => ['bool', 'hash'=>'string', 'algo'=>'int', 'options='=>'array'],
 'password_verify' => ['bool', 'password'=>'string', 'hash'=>'string'],


### PR DESCRIPTION
Starting with PHP 7.4, password_hash "algo" parameter is now a string and not an int.
Also, it is now optional (default value = null)

See: https://wiki.php.net/rfc/password_registry