### PR TITLE
Generic object type acceptance

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -650,6 +650,18 @@ class ClassReflection implements ReflectionWithFilename
 		return new TemplateTypeMap($map);
 	}
 
+	/** @return Type[] */
+	public function typeMapToList(TemplateTypeMap $map): array
+	{
+		$types = [];
+
+		foreach ($this->getTemplateTags() as $tag) {
+			$types[] = $map->getType($tag->getName()) ?? new ErrorType();
+		}
+
+		return $types;
+	}
+
 	/**
 	 * @param Type[] $types
 	 */

--- a/src/Type/Generic/TemplateTypeMap.php
+++ b/src/Type/Generic/TemplateTypeMap.php
@@ -34,6 +34,11 @@ class TemplateTypeMap
 		return $empty;
 	}
 
+	public function isEmpty(): bool
+	{
+		return count($this->types) === 0;
+	}
+
 	/** @return array<string,\PHPStan\Type\Type> */
 	public function getTypes(): array
 	{

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Test\A;
+use PHPStan\Type\Test\B;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+class GenericObjectTypeTest extends \PHPStan\Testing\TestCase
+{
+
+	public function dataIsSuperTypeOf(): array
+	{
+		return [
+			'equal type' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'sub-class with static @extends with same type args' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				new ObjectType(A\AOfDateTime::class),
+				TrinaryLogic::createYes(),
+			],
+			'sub-class with @extends with same type args' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(A\SubA::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'same class, different type args' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTimeInterface')]),
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createNo(),
+			],
+			'same class, one naked' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTimeInterface')]),
+				new ObjectType(A\A::class),
+				TrinaryLogic::createMaybe(),
+			],
+			'implementation with @extends with same type args' => [
+				new GenericObjectType(B\I::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(B\IImpl::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'implementation with @extends with different type args' => [
+				new GenericObjectType(B\I::class, [new ObjectType('DateTimeInteface')]),
+				new GenericObjectType(B\IImpl::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataIsSuperTypeOf
+	 */
+	public function testIsSuperTypeOf(Type $type, Type $otherType, TrinaryLogic $expectedResult): void
+	{
+		$actualResult = $type->isSuperTypeOf($otherType);
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise()))
+		);
+	}
+
+	public function dataAccepts(): array
+	{
+		return [
+			'equal type' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'sub-class with static @extends with same type args' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				new ObjectType(A\AOfDateTime::class),
+				TrinaryLogic::createYes(),
+			],
+			'sub-class with @extends with same type args' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(A\SubA::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'same class, different type args' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTimeInterface')]),
+				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createNo(),
+			],
+			'same class, one naked' => [
+				new GenericObjectType(A\A::class, [new ObjectType('DateTimeInterface')]),
+				new ObjectType(A\A::class),
+				TrinaryLogic::createMaybe(),
+			],
+			'implementation with @extends with same type args' => [
+				new GenericObjectType(B\I::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(B\IImpl::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'implementation with @extends with different type args' => [
+				new GenericObjectType(B\I::class, [new ObjectType('DateTimeInteface')]),
+				new GenericObjectType(B\IImpl::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataAccepts
+	 */
+	public function testAccepts(
+		Type $acceptingType,
+		Type $acceptedType,
+		TrinaryLogic $expectedResult
+	): void
+	{
+		$actualResult = $acceptingType->accepts($acceptedType, true);
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> accepts(%s)', $acceptingType->describe(VerbosityLevel::precise()), $acceptedType->describe(VerbosityLevel::precise()))
+		);
+	}
+
+}

--- a/tests/PHPStan/Type/Generic/data/generic-classes-a.php
+++ b/tests/PHPStan/Type/Generic/data/generic-classes-a.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Type\Test\A;
+
+/** @template T */
+class A {}
+
+/** @extends A<\DateTime> */
+class AOfDateTime extends A {}
+
+/**
+ * @template U
+ * @extends A<U>
+ */
+class SubA extends A {}

--- a/tests/PHPStan/Type/Generic/data/generic-classes-b.php
+++ b/tests/PHPStan/Type/Generic/data/generic-classes-b.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Type\Test\B;
+
+/** @template T */
+interface I {}
+
+/**
+ * @template T
+ * @implements I<T>
+ */
+class IImpl implements I {}


### PR DESCRIPTION
This implements `isSuperTypeOf()` / `accepts()` for `GenericObjecType`.

A GenericObjectType (A) accepts an ObjectType (B) if all these conditions are met:

 - B is accepted by A, according to ObjectType::accept()
 - B is a GenericObjectType
 - B is of the exact same class, or B has a parent that is accepted by A
 - A and B have the same number of type parameters (template types)
 - A and B's type parameters equal each other

Otherwise, we fallback on `ObjectType::accept()`

