### PR TITLE
Allow string in abs

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -60,6 +60,7 @@ return [
 '__halt_compiler' => ['void'],
 'abs' => ['int', 'number'=>'int'],
 'abs\'1' => ['float', 'number'=>'float'],
+'abs\'2' => ['string', 'number'=>'float|int'],
 'accelerator_get_configuration' => ['array'],
 'accelerator_get_scripts' => ['array'],
 'accelerator_get_status' => ['array', 'fetch_scripts'=>'bool'],


### PR DESCRIPTION
Playground (breaking): https://phpstan.org/r/b744c701-0050-46c9-a82d-0cf89bb41380

This is useful when working with bcmath functions.

`abs` on [php.net](https://www.php.net/manual/en/function.abs.php)

The [original FunctionSignatureMap](https://raw.githubusercontent.com/phan/phan/master/src/Phan/Language/Internal/FunctionSignatureMap.php) also supports strings via `numeric` (Does phpstan have numeric?):

```
'abs\'2' => ['numeric', 'number'=>'numeric'],
```