### PR TITLE
"new" expression generic type inference

### DIFF
--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -9,6 +9,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
@@ -123,7 +124,7 @@ final class TemplateMixedType extends MixedType implements TemplateType
 		}
 
 		return new TemplateTypeMap([
-			$this->name => $receivedType,
+			$this->name => TypeUtils::generalizeType($receivedType),
 		]);
 	}
 

--- a/src/Type/Generic/TemplateObjectType.php
+++ b/src/Type/Generic/TemplateObjectType.php
@@ -8,6 +8,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
@@ -135,7 +136,7 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 		}
 		if ($isSuperType->yes()) {
 			return new TemplateTypeMap([
-				$this->name => $receivedType,
+				$this->name => TypeUtils::generalizeType($receivedType),
 			]);
 		}
 

--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -83,7 +83,7 @@ function testD($int, $float, $intFloat) {
 	assertType('float|int', d($int, $float));
 	assertType('DateTime|int', d($int, new \DateTime()));
 	assertType('DateTime|float|int', d($intFloat, new \DateTime()));
-	assertType('array()|DateTime', d([], new \DateTime()));
+	assertType('array|DateTime', d([], new \DateTime()));
 }
 
 /**
@@ -343,4 +343,68 @@ class C
 
 		assertType('T (class PHPStan\Generics\FunctionsAssertType\C, argument)', $a->g());
 	}
+}
+
+/**
+ * class A
+ *
+ * @template T
+ */
+class A {
+	/**
+	 * A::__construct()
+	 *
+	 * @param T $a
+	 */
+	public function __construct($a) {
+	}
+}
+
+/**
+ * class AOfDateTime
+ *
+ * @extends A<\DateTime>
+ */
+class AOfDateTime extends A {
+}
+
+/**
+ * class B
+ *
+ * @template T
+ *
+ * @extends A<T>
+ */
+class B extends A {
+	/**
+	 * B::__construct()
+	 *
+	 * @param T $a
+	 */
+	public function __construct($a) {
+	}
+}
+
+/**
+ * class NoConstructor
+ *
+ * @template T
+ *
+ * @extends A<T>
+ */
+class NoConstructor extends A {
+}
+
+function testClasses() {
+	$a = new A(1);
+	assertType('PHPStan\Generics\FunctionsAssertType\A<int>', $a);
+
+	$a = new AOfDateTime();
+	assertType('PHPStan\Generics\FunctionsAssertType\AOfDateTime', $a);
+
+	$b = new B(1);
+	assertType('PHPStan\Generics\FunctionsAssertType\B<int>', $b);
+
+	$noConstructor = new NoConstructor(1);
+	assertType('PHPStan\Generics\FunctionsAssertType\NoConstructor<T (class PHPStan\Generics\FunctionsAssertType\NoConstructor, parameter)>', $noConstructor);
 }

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -13,6 +13,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
@@ -314,11 +315,7 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 							'b',
 							new ArrayType(
 								new MixedType(),
-								new UnionType([
-									new ConstantIntegerType(1),
-									new ConstantIntegerType(2),
-									new ConstantIntegerType(3),
-								])
+								new IntegerType()
 							),
 							false,
 							PassedByReference::createNo(),
@@ -327,11 +324,7 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 						),
 					],
 					false,
-					new UnionType([
-						new ConstantIntegerType(1),
-						new ConstantIntegerType(2),
-						new ConstantIntegerType(3),
-					])
+					new IntegerType()
 				),
 			],
 			'missing args' => [
@@ -412,10 +405,10 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 					TemplateTypeMap::createEmpty(),
 					null,
 					[
-						new DummyParameter('str', new ConstantStringType('foo'), false, null, false, null),
+						new DummyParameter('str', new StringType(), false, null, false, null),
 					],
 					false,
-					new ConstantStringType('foo')
+					new StringType()
 				),
 			],
 		];


### PR DESCRIPTION
This adds support for generics when inferring the type of new expressions:

```
/**
 * @template T
 */
class C {
    /** @param T $a */
    public function __construct($a) {
    }
}

new C(new DateTime()) // C<DateTime>
```

