### PR TITLE
Analyse specified source codes

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -130,10 +130,11 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 		/** @var Parser $parser */
 		$parser = $container->getByType(Parser::class);
 		$files = $inceptionResult->getFiles();
-		if (method_exists($parser, 'setCachedSourceCodesByFile') && $sourceCodes) {
+		if (method_exists($parser, 'setCachedSourceCodesByFile') && is_array($sourceCodes)) {
+			$sourceCodesNum = count($sourceCodes);
 			$cachedSourceCodes = [];
 			foreach ($files as $index => $file) {
-				if ($index >= count($sourceCodes)) {
+				if ($index >= $sourceCodesNum) {
 					break;
 				}
 				if (!is_file($file)) {

--- a/src/Parser/CachedParser.php
+++ b/src/Parser/CachedParser.php
@@ -26,6 +26,9 @@ class CachedParser implements Parser
 	/** @var int */
 	private $cachedNodesByStringCountMax;
 
+	/** @var mixed[] */
+	private $cachedSourceCodesByFile = [];
+
 	public function __construct(
 		Parser $originalParser,
 		int $cachedNodesByFileCountMax,
@@ -55,7 +58,11 @@ class CachedParser implements Parser
 		}
 
 		if (!isset($this->cachedNodesByFile[$file])) {
-			$this->cachedNodesByFile[$file] = $this->originalParser->parseFile($file);
+			if (isset($this->cachedSourceCodesByFile[$file])) {
+				$this->cachedNodesByFile[$file] = $this->parseString($this->cachedSourceCodesByFile[$file]);
+			} else {
+				$this->cachedNodesByFile[$file] = $this->originalParser->parseFile($file);
+			}
 			$this->cachedNodesByFileCount++;
 		}
 
@@ -115,6 +122,15 @@ class CachedParser implements Parser
 	public function getCachedNodesByString(): array
 	{
 		return $this->cachedNodesByString;
+	}
+
+	/**
+	 * @param mixed[] $cachedSourceCodesByFile
+	 * @return void
+	 */
+	public function setCachedSourceCodesByFile(array $cachedSourceCodesByFile): void
+	{
+		$this->cachedSourceCodesByFile = $cachedSourceCodesByFile;
 	}
 
 }

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -66,6 +66,23 @@ class CachedParserTest extends \PHPUnit\Framework\TestCase
 		);
 	}
 
+	public function testCachedSourceCodes(): void
+	{
+		$parser = new CachedParser(
+			$this->getParserMock(),
+			10,
+			10
+		);
+		$parser->setCachedSourceCodesByFile([
+			'file1' => '<?php echo 1;',
+		]);
+		$parser->parseFile('file1');
+		$cachedNodesByFile = $parser->getCachedNodesByFile();
+		$cachedNodesByString = $parser->getCachedNodesByString();
+		$this->assertEquals(true, isset($cachedNodesByFile['file1']));
+		$this->assertEquals(true, isset($cachedNodesByString['<?php echo 1;']));
+	}
+
 	public function dataParseFileClearCache(): \Generator
 	{
 		yield 'even' => [


### PR DESCRIPTION
re #2455 

For Example:

```cmd
$ phpstan analyse ./test.php --source-code="<?php some php codes... "
```

At last, the conent being analyzed is `<?php some php codes... `, not the real content of the `./test.php`.