### PR TITLE
Fix implicit return type from inherited doc block

### DIFF
--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -2,6 +2,10 @@
 
 namespace PHPStan\Generics\FunctionsAssertType;
 
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PHPStan\Generics\FunctionsAssertType\GenericRule;
 use function PHPStan\Analyser\assertType;
 
 /**
@@ -562,6 +566,29 @@ function acceptsClassStringUpperBound($string)
 	return new $string;
 }
 
+
+/**
+ * @template TNodeType of \PhpParser\Node
+ */
+interface GenericRule
+{
+    /**
+     * @return TNodeType
+     */
+    public function getNodeInstance(): Node;
+}
+
+/**
+ * @implements GenericRule<\PhpParser\Node\Expr\StaticCall>
+ */
+class SomeRule implements GenericRule
+{
+    public function getNodeInstance(): Node
+    {
+        return new StaticCall(new Name(\stdClass::class), '__construct');
+    }
+}
+
 function testClasses() {
 	$a = new A(1);
 	assertType('PHPStan\Generics\FunctionsAssertType\A<int>', $a);
@@ -596,4 +623,7 @@ function testClasses() {
 	assertType('Exception', acceptsClassStringUpperBound(\Exception::class));
 	assertType('Exception', acceptsClassStringUpperBound(\Throwable::class));
 	assertType('InvalidArgumentException', acceptsClassStringUpperBound(\InvalidArgumentException::class));
+
+	$rule = new SomeRule();
+	assertType(StaticCall::class, $rule->getNodeInstance());
 }

--- a/tests/PHPStan/Generics/data/classes-3.json
+++ b/tests/PHPStan/Generics/data/classes-3.json
@@ -1,7 +1,7 @@
 [
     {
         "message": "Method PHPStan\\Generics\\Classes\\A::get() should return T but returns int.",
-        "line": 31,
+        "line": 34,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Generics/data/classes-5.json
+++ b/tests/PHPStan/Generics/data/classes-5.json
@@ -1,27 +1,27 @@
 [
     {
         "message": "Parameter #1 $a of method PHPStan\\Generics\\Classes\\A<int>::set() expects int, string given.",
-        "line": 229,
+        "line": 242,
         "ignorable": true
     },
     {
         "message": "Parameter #1 $a of method PHPStan\\Generics\\Classes\\A<DateTime>::set() expects DateTime, int given.",
-        "line": 234,
+        "line": 247,
         "ignorable": true
     },
     {
         "message": "Parameter #1 $a of method PHPStan\\Generics\\Classes\\A<int>::set() expects int, string given.",
-        "line": 239,
+        "line": 252,
         "ignorable": true
     },
     {
         "message": "Parameter #1 $a of method PHPStan\\Generics\\Classes\\C::set() expects int, string given.",
-        "line": 244,
+        "line": 257,
         "ignorable": true
     },
     {
         "message": "Parameter #1 $a of function PHPStan\\Generics\\Classes\\acceptSuperIFaceBOfInt expects PHPStan\\Generics\\Classes\\SuperIfaceB<int>, PHPStan\\Generics\\Classes\\ABImpl given.",
-        "line": 249,
+        "line": 262,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Generics/data/classes.php
+++ b/tests/PHPStan/Generics/data/classes.php
@@ -2,6 +2,9 @@
 
 namespace PHPStan\Generics\Classes;
 
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleError;
 
@@ -196,6 +199,11 @@ interface GenericRule
 	public function getNodeType(): string;
 
 	/**
+	 * @return TNodeType
+	 */
+	public function getNodeInstance(): Node;
+
+	/**
 	 * @param TNodeType $node
 	 * @param \PHPStan\Analyser\Scope $scope
 	 * @return RuleError[] errors
@@ -213,6 +221,11 @@ class SomeRule implements GenericRule
 	public function getNodeType(): string
 	{
 		return \PhpParser\Node\Expr\StaticCall::class;
+	}
+
+	public function getNodeInstance(): Node
+	{
+		return new StaticCall(new Name(\stdClass::class), '__construct');
 	}
 
 	public function processNode(\PhpParser\Node $node, Scope $scope): array
@@ -247,4 +260,6 @@ function testClasses(): void {
 	acceptSuperIFaceAOfInt($ab);
 	acceptSuperIFaceBOfDateTime($ab);
 	acceptSuperIFaceBOfInt($ab);
+
+	new SomeRule();
 }

--- a/tests/PHPStan/Generics/generics.neon
+++ b/tests/PHPStan/Generics/generics.neon
@@ -1,2 +1,4 @@
+parameters:
+	reportMaybesInMethodSignatures: true
 includes:
 	- ../../../conf/bleedingEdge.neon


### PR DESCRIPTION
When we inherit a method doc block from a parent class, we use the return type from the doc block only if it is a sub type of the native return type.

We were doing this check _before_ resolving template types, so it was always false.

