### PR TITLE
Support infering template types from generic type

### DIFF
--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -589,6 +589,19 @@ class SomeRule implements GenericRule
     }
 }
 
+/**
+ * Infer from generic
+ *
+ * @template T of \DateTimeInterface
+ *
+ * @param A<A<T>> $x
+ *
+ * @return A<T>
+ */
+function inferFromGeneric($x) {
+	return $x->get();
+}
+
 function testClasses() {
 	$a = new A(1);
 	assertType('PHPStan\Generics\FunctionsAssertType\A<int>', $a);
@@ -626,4 +639,7 @@ function testClasses() {
 
 	$rule = new SomeRule();
 	assertType(StaticCall::class, $rule->getNodeInstance());
+
+	$a = inferFromGeneric(new A(new A(new \DateTime())));
+	assertType('PHPStan\Generics\FunctionsAssertType\A<DateTime>', $a);
 }

--- a/tests/PHPStan/Type/Generic/data/generic-classes-a.php
+++ b/tests/PHPStan/Type/Generic/data/generic-classes-a.php
@@ -13,3 +13,9 @@ class AOfDateTime extends A {}
  * @extends A<U>
  */
 class SubA extends A {}
+
+/**
+ * @template K
+ * @template V
+ */
+class A2 {}


### PR DESCRIPTION
This adds support for template type inference in the GenericObjectType:

```
/**
 * @template Foo<T>
 * @param T $f
 * @return T
 */
function f($f) {
}

f(new Foo(1)); // int
f(new Foo(new DateTime()); // DateTime
```