### PR TITLE
Add NumberFormatter::parse() dynamic method return type extension

### DIFF
--- a/build/composer-require-checker.json
+++ b/build/composer-require-checker.json
@@ -15,6 +15,7 @@
     "SPL",
     "standard",
     "pcntl",
-    "mbstring"
+    "mbstring",
+    "intl"
   ]
 }

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -526,6 +526,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\NumberFormatterParseDynamicMethodReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\PathinfoFunctionDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/NumberFormatterParseDynamicMethodReturnTypeExtension.php
+++ b/src/Type/Php/NumberFormatterParseDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+class NumberFormatterParseDynamicMethodReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return \NumberFormatter::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return in_array($methodReflection->getName(), [
+			'parse',
+		], true);
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		if (count($methodCall->args) === 1) {
+			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+		}
+
+		$argType = $scope->getType($methodCall->args[1]->value);
+		if (!$argType instanceof ConstantIntegerType) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
+		switch ($argType->getValue()) {
+			case \NumberFormatter::TYPE_INT32:
+			case \NumberFormatter::TYPE_INT64:
+				return new UnionType([new IntegerType(), new ConstantBooleanType(false)]);
+			case \NumberFormatter::TYPE_DOUBLE:
+				return new UnionType([new FloatType(), new ConstantBooleanType(false)]);
+			default:
+				throw new \PHPStan\ShouldNotHappenException();
+		}
+	}
+
+}


### PR DESCRIPTION
Hello!

Here is a first attempt to add a dynamic return type extension for the `NumberFormatter::parse()` method.

I'm not sure if the tests have to be added to `NodeScopeResolverTest::testDynamicMethodReturnTypeExtensions()` or not.

Also this does not cover the procedural style `numfmt_parse`. Is it possible to cover both cases with only one dynamic return type extension? 🤔 

fixes #2459 