### PR TITLE
Allow template types to be inferred to a received template type with compatible bound

### DIFF
--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -115,13 +115,22 @@ final class TemplateMixedType extends MixedType implements TemplateType
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 
-		if ($this->isSuperTypeOf($receivedType)->no()) {
-			return TemplateTypeMap::createEmpty();
+		if (
+			$receivedType instanceof TemplateType
+			&& $this->getBound()->isSuperTypeOf($receivedType->getBound())->yes()
+		) {
+			return new TemplateTypeMap([
+				$this->name => $receivedType,
+			]);
 		}
 
-		return new TemplateTypeMap([
-			$this->name => TypeUtils::generalizeType($receivedType),
-		]);
+		if ($this->getBound()->isSuperTypeOf($receivedType)->yes()) {
+			return new TemplateTypeMap([
+				$this->name => TypeUtils::generalizeType($receivedType),
+			]);
+		}
+
+		return TemplateTypeMap::createEmpty();
 	}
 
 	public function isArgument(): bool

--- a/src/Type/Generic/TemplateObjectType.php
+++ b/src/Type/Generic/TemplateObjectType.php
@@ -135,25 +135,22 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 
-		$isSuperType = $this->isSuperTypeOf($receivedType);
-		if ($isSuperType->no()) {
-			return TemplateTypeMap::createEmpty();
+		if (
+			$receivedType instanceof TemplateType
+			&& $this->getBound()->isSuperTypeOf($receivedType->getBound())->yes()
+		) {
+			return new TemplateTypeMap([
+				$this->name => $receivedType,
+			]);
 		}
-		if ($isSuperType->yes()) {
+
+		if ($this->getBound()->isSuperTypeOf($receivedType)->yes()) {
 			return new TemplateTypeMap([
 				$this->name => TypeUtils::generalizeType($receivedType),
 			]);
 		}
 
-		$isBoundSuperType = $this->getBound()->isSuperTypeOf($receivedType);
-		$resultType = $receivedType;
-		if ($isBoundSuperType->maybe()) {
-			$resultType = $this->getBound();
-		}
-
-		return new TemplateTypeMap([
-			$this->name => $resultType,
-		]);
+		return TemplateTypeMap::createEmpty();
 	}
 
 	public function isArgument(): bool

--- a/tests/PHPStan/Generics/data/functions.php
+++ b/tests/PHPStan/Generics/data/functions.php
@@ -38,3 +38,24 @@ function testF($arrayOfInt, $callableOrNull) {
 	f($arrayOfInt, null);
 	f($arrayOfInt, '');
 }
+
+/**
+ * Function passthru
+ *
+ * @template T of \DateTimeInterface
+ *
+ * @param T $t
+ */
+function passthru($t): void {
+	passthru2($t);
+}
+
+/**
+ * Function passthru2
+ *
+ * @template T of \DateTimeInterface
+ *
+ * @param T $t
+ */
+function passthru2($t): void {
+}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -441,6 +441,10 @@ class CallMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Parameter #2 $object of method Test\ClassStringWithUpperBounds::doFoo() expects Exception, Throwable given.',
 				1490,
 			],
+			[
+				'Unable to resolve the template type T in call to method Test\ClassStringWithUpperBounds::doFoo()',
+				1490,
+			],
 		]);
 	}
 
@@ -688,6 +692,10 @@ class CallMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 			],
 			[
 				'Parameter #2 $object of method Test\ClassStringWithUpperBounds::doFoo() expects Exception, Throwable given.',
+				1490,
+			],
+			[
+				'Unable to resolve the template type T in call to method Test\ClassStringWithUpperBounds::doFoo()',
 				1490,
 			],
 		]);

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -199,7 +199,7 @@ class GenericObjectTypeTest extends \PHPStan\Testing\TestCase
 					$templateType('K', new ObjectType(\DateTimeInterface::class)),
 					$templateType('V', new ObjectType(\DateTimeInterface::class)),
 				]),
-				['K' => 'DateTime', 'V' => 'DateTimeInterface'],
+				['K' => 'DateTime'],
 			],
 			'wrong class' => [
 				new GenericObjectType(B\I::class, [


### PR DESCRIPTION
This makes sure that we can pass a `X of DateTimeInterface` to a `Y of DateTimeInterface`, and that `Y` is inferred to be a `X of DateTimeInterface`, as long as the bounds are compatible.

This also changes `TemplateType::inferTemplateTypes()` such that we return an empty `TemplateTypeMap` when we receive an invalid type. This allows Rules to detect which types was not successfully inferred. From the user PoV, types that fail to infer still default to their bound - this is done by `TemplateTypeHelper`.