### PR TITLE
Infer from generic ancestor

### DIFF
--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -55,6 +55,11 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return $this->objectType->getClassName();
 	}
 
+	public function getAncestorWithClassName(string $className): ?TypeWithClassName
+	{
+		return $this->objectType->getAncestorWithClassName($className);
+	}
+
 	/**
 	 * @return string[]
 	 */

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -749,7 +749,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return $broker->getClass($this->className);
 	}
 
-	protected function getAncestorWithClassName(string $className): ?ObjectType
+	public function getAncestorWithClassName(string $className): ?TypeWithClassName
 	{
 		$broker = Broker::getInstance();
 		$theirReflection = $broker->getClass($className);

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -33,6 +33,11 @@ class StaticType implements TypeWithClassName
 		return $this->baseClass;
 	}
 
+	public function getAncestorWithClassName(string $className): ?TypeWithClassName
+	{
+		return $this->staticObjectType->getAncestorWithClassName($className);
+	}
+
 	protected function getStaticObjectType(): ObjectType
 	{
 		return $this->staticObjectType;

--- a/src/Type/TypeWithClassName.php
+++ b/src/Type/TypeWithClassName.php
@@ -7,4 +7,6 @@ interface TypeWithClassName extends Type
 
 	public function getClassName(): string;
 
+	public function getAncestorWithClassName(string $className): ?self;
+
 }

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -217,6 +217,13 @@ class GenericObjectTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				[],
 			],
+			'sub type' => [
+				new ObjectType(A\AOfDateTime::class),
+				new GenericObjectType(A\A::class, [
+					$templateType('T'),
+				]),
+				['T' => 'DateTime'],
+			],
 		];
 	}
 


### PR DESCRIPTION
This improves on https://github.com/phpstan/phpstan/pull/2473, by also looking at generic ancestors of the received type.

```
/** @template T */
interface A {
}

/** @implements A<DateTime> */
class B {
}

/**
 * @template T
 * @param A<T> $f
 * @return T
 */
function f($f) {
}

f(new B()); // DateTime
```