### PR TITLE
WIP - Generics (class ancestors check) - resolve template types before checking

### DIFF
--- a/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
@@ -57,6 +57,14 @@ class ClassAncestorsRuleTest extends RuleTestCase
 				'PHPDoc tag @extends has invalid type ClassAncestors\Zazzuuuu.',
 				99,
 			],
+			[
+				'aaa',
+				108,
+			],
+			[
+				'aaa',
+				117,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Generics/data/class-ancestors.php
+++ b/tests/PHPStan/Rules/Generics/data/class-ancestors.php
@@ -100,3 +100,58 @@ class FooUnknownClass extends FooGeneric
 {
 
 }
+
+/**
+ * @template T
+ * @extends FooGeneric<int, T>
+ */
+class FooGenericGeneric extends FooGeneric
+{
+
+}
+
+/**
+ * @template T of \Throwable
+ * @extends FooGeneric<int, T>
+ */
+class FooGenericGeneric2 extends FooGeneric
+{
+
+}
+
+
+/**
+ * @template T of \Exception
+ * @extends FooGeneric<int, T>
+ */
+class FooGenericGeneric3 extends FooGeneric
+{
+
+}
+
+/**
+ * @template T of \InvalidArgumentException
+ * @extends FooGeneric<int, T>
+ */
+class FooGenericGeneric4 extends FooGeneric
+{
+
+}
+
+/**
+ * @template T
+ * @extends FooGeneric<T, \Exception>
+ */
+class FooGenericGeneric5 extends FooGeneric
+{
+
+}
+
+/**
+ * @template T of \stdClass
+ * @extends FooGeneric<T, \Exception>
+ */
+class FooGenericGeneric6 extends FooGeneric
+{
+
+}


### PR DESCRIPTION
I'd like to solve these cases: https://phpstan.org/r/e7b396ef-faa6-4841-beff-d1a370d05c9d

The rule should report lines 16 (`T` should have bound `\Exception`) and line 25 (`T` has bound `\Throwable` but that's not a subtype of `\Exception` from `U` above `FooGeneric`) and line 62.

I tried to solve it with `resolveTemplateTypes` but it resolves the extended type in:

```php
/**
 * @template T of \Exception
 * @extends FooGeneric<int, T>
 */
class FooGenericGeneric3 extends FooGeneric
{

}
```

to `FooGeneric<T of Exception>` instead of `FooGeneric<int, T of Exception>` :(