### PR TITLE
Don't traverse resolved type

### DIFF
--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -22,7 +22,7 @@ class TemplateTypeHelper
 					$newType = $type->getBound();
 				}
 
-				return $traverse($newType);
+				return $newType;
 			}
 
 			return $traverse($type);


### PR DESCRIPTION
Currently, in resolveTemplateTypes(), while traversing the generic type, we also traverse the resolved types.

This causes infinite recursions (and seg faults) when the generic type is referenced in the template type map:

```
$type = TemplateTypeFactory::create($scope, 'T');
$map = new TemplateTypeMap([
    'T' => TemplateTypeHelper::toArgument($type),
]);
```