### PR TITLE
Fix getRelativePath when currentWorkingDirectory is root

### DIFF
--- a/src/File/SimpleRelativePathHelper.php
+++ b/src/File/SimpleRelativePathHelper.php
@@ -15,7 +15,7 @@ class SimpleRelativePathHelper implements RelativePathHelper
 
 	public function getRelativePath(string $filename): string
 	{
-		if ($this->currentWorkingDirectory !== '' && strpos($filename, $this->currentWorkingDirectory) === 0) {
+		if ($this->currentWorkingDirectory !== '/' && $this->currentWorkingDirectory !== '' && strpos($filename, $this->currentWorkingDirectory) === 0) {
 			return substr($filename, strlen($this->currentWorkingDirectory) + 1);
 		}
 


### PR DESCRIPTION
Since the code assumes the CWD doesn't contain the path separator (+ 1) this would previously produce incorrect paths.
/home/test.php -> ome/test.php
Now it will simply leave the path unchanged if CWD is the root.

An alternative would be to check if CWD ends with a path separator or not.