### PR TITLE
Fix bugs in SimpleRelativePathHelper

### DIFF
--- a/src/File/SimpleRelativePathHelper.php
+++ b/src/File/SimpleRelativePathHelper.php
@@ -8,15 +8,19 @@ class SimpleRelativePathHelper implements RelativePathHelper
 	/** @var string */
 	private $currentWorkingDirectory;
 
-	public function __construct(string $currentWorkingDirectory)
+	public function __construct(string $currentWorkingDirectory, string $directorySeparator = DIRECTORY_SEPARATOR)
 	{
-		$this->currentWorkingDirectory = $currentWorkingDirectory;
+		$this->currentWorkingDirectory = rtrim($currentWorkingDirectory, $directorySeparator);
+		if ($currentWorkingDirectory === '') {
+			return;
+		}
+		$this->currentWorkingDirectory .= $directorySeparator;
 	}
 
 	public function getRelativePath(string $filename): string
 	{
 		if ($this->currentWorkingDirectory !== '' && strpos($filename, $this->currentWorkingDirectory) === 0) {
-			return substr($filename, strlen($this->currentWorkingDirectory) + 1);
+			return substr($filename, strlen($this->currentWorkingDirectory));
 		}
 
 		return $filename;

--- a/tests/PHPStan/File/SimpleRelativePathHelperTest.php
+++ b/tests/PHPStan/File/SimpleRelativePathHelperTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+class SimpleRelativePathHelperTest extends \PHPUnit\Framework\TestCase
+{
+
+	public function dataGetRelativePath(): array
+	{
+		return [
+			[
+				'/usr',
+				'/',
+				'/usr/app/test.php',
+				'app/test.php',
+			],
+			[
+				'',
+				'/',
+				'/usr/app/test.php',
+				'/usr/app/test.php',
+			],
+			[
+				'/var',
+				'/',
+				'/usr/app/test.php',
+				'/usr/app/test.php',
+			],
+			[
+				'/usr/app',
+				'/',
+				'/usr/app/src/test.php',
+				'src/test.php',
+			],
+			[
+				'/',
+				'/',
+				'/usr/app/test.php',
+				'usr/app/test.php',
+			],
+			[
+				'/usr/',
+				'/',
+				'/usr/app/test.php',
+				'app/test.php',
+			],
+			[
+				'/usr/app',
+				'/',
+				'/usr/application/test.php',
+				'/usr/application/test.php',
+			],
+			[
+				'C:\\app',
+				'\\',
+				'C:\\app\\test.php',
+				'test.php',
+			],
+			[
+				'C:\\app\\',
+				'\\',
+				'C:\\app\\src\\test.php',
+				'src\\test.php',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetRelativePath
+	 * @param string $currentWorkingDirectory
+	 * @param string $directorySeparator
+	 * @param string $filenameToRelativize
+	 * @param string $expectedResult
+	 */
+	public function testGetRelativePathOnUnix(
+		string $currentWorkingDirectory,
+		string $directorySeparator,
+		string $filenameToRelativize,
+		string $expectedResult
+	): void
+	{
+		$helper = new SimpleRelativePathHelper($currentWorkingDirectory, $directorySeparator);
+		$this->assertSame(
+			$expectedResult,
+			$helper->getRelativePath($filenameToRelativize)
+		);
+	}
+
+}


### PR DESCRIPTION
I managed to get the integration for [CodeLite working](https://github.com/eranif/codelite/pull/2359) and also someone did a really nice contribution to DevilutionX, so I decided to pay it forward.

This fixes and adds tests for the following:
- If CWD ended in a directory separator path+1 was stripped ('/home' = 'ome' for '/')
- Even if CWD partially matched it would strip the path ('/homeFolder/test.php' = 'Folder/test.php' for '/home')
- getRelativePath didn't work with Windows paths ('C:\test.php')