### PR TITLE
Fix method caching with different template types of the same name

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -76,6 +76,9 @@ class ClassReflection implements ReflectionWithFilename
 	/** @var array<string,ClassReflection>|null */
 	private $ancestors;
 
+	/** @var string|null */
+	private $cacheKey;
+
 	/**
 	 * @param Broker $broker
 	 * @param \PHPStan\Type\FileTypeMapper $fileTypeMapper
@@ -191,6 +194,26 @@ class ClassReflection implements ReflectionWithFilename
 		return $name . '<' . implode(',', array_map(static function (Type $type): string {
 			return $type->describe(VerbosityLevel::typeOnly());
 		}, $this->resolvedTemplateTypeMap->getTypes())) . '>';
+	}
+
+	public function getCacheKey(): string
+	{
+		$cacheKey = $this->cacheKey;
+		if ($cacheKey !== null) {
+			return $this->cacheKey;
+		}
+
+		$cacheKey = $this->displayName;
+
+		if ($this->resolvedTemplateTypeMap !== null) {
+			$cacheKey .= '<' . implode(',', array_map(static function (Type $type): string {
+				return $type->describe(VerbosityLevel::precise());
+			}, $this->resolvedTemplateTypeMap->getTypes())) . '>';
+		}
+
+		$this->cacheKey = $cacheKey;
+
+		return $cacheKey;
 	}
 
 	/**

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -121,22 +121,22 @@ class PhpClassReflectionExtension
 
 	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
-		if (!isset($this->propertiesIncludingAnnotations[$classReflection->getDisplayName()][$propertyName])) {
-			$this->propertiesIncludingAnnotations[$classReflection->getDisplayName()][$propertyName] = $this->createProperty($classReflection, $propertyName, true);
+		if (!isset($this->propertiesIncludingAnnotations[$classReflection->getCacheKey()][$propertyName])) {
+			$this->propertiesIncludingAnnotations[$classReflection->getCacheKey()][$propertyName] = $this->createProperty($classReflection, $propertyName, true);
 		}
 
-		return $this->propertiesIncludingAnnotations[$classReflection->getDisplayName()][$propertyName];
+		return $this->propertiesIncludingAnnotations[$classReflection->getCacheKey()][$propertyName];
 	}
 
 	public function getNativeProperty(ClassReflection $classReflection, string $propertyName): PhpPropertyReflection
 	{
-		if (!isset($this->nativeProperties[$classReflection->getDisplayName()][$propertyName])) {
+		if (!isset($this->nativeProperties[$classReflection->getCacheKey()][$propertyName])) {
 			/** @var \PHPStan\Reflection\Php\PhpPropertyReflection $property */
 			$property = $this->createProperty($classReflection, $propertyName, false);
-			$this->nativeProperties[$classReflection->getDisplayName()][$propertyName] = $property;
+			$this->nativeProperties[$classReflection->getCacheKey()][$propertyName] = $property;
 		}
 
-		return $this->nativeProperties[$classReflection->getDisplayName()][$propertyName];
+		return $this->nativeProperties[$classReflection->getCacheKey()][$propertyName];
 	}
 
 	private function createProperty(
@@ -272,20 +272,20 @@ class PhpClassReflectionExtension
 			$classReflection = $this->broker->getClass(\ReflectionNamedType::class);
 		}
 
-		if (isset($this->methodsIncludingAnnotations[$classReflection->getDisplayName()][$methodName])) {
-			return $this->methodsIncludingAnnotations[$classReflection->getDisplayName()][$methodName];
+		if (isset($this->methodsIncludingAnnotations[$classReflection->getCacheKey()][$methodName])) {
+			return $this->methodsIncludingAnnotations[$classReflection->getCacheKey()][$methodName];
 		}
 
 		$nativeMethodReflection = new NativeBuiltinMethodReflection($classReflection->getNativeReflection()->getMethod($methodName));
-		if (!isset($this->methodsIncludingAnnotations[$classReflection->getDisplayName()][$nativeMethodReflection->getName()])) {
+		if (!isset($this->methodsIncludingAnnotations[$classReflection->getCacheKey()][$nativeMethodReflection->getName()])) {
 			$method = $this->createMethod($classReflection, $nativeMethodReflection, true);
-			$this->methodsIncludingAnnotations[$classReflection->getDisplayName()][$nativeMethodReflection->getName()] = $method;
+			$this->methodsIncludingAnnotations[$classReflection->getCacheKey()][$nativeMethodReflection->getName()] = $method;
 			if ($nativeMethodReflection->getName() !== $methodName) {
-				$this->methodsIncludingAnnotations[$classReflection->getDisplayName()][$methodName] = $method;
+				$this->methodsIncludingAnnotations[$classReflection->getCacheKey()][$methodName] = $method;
 			}
 		}
 
-		return $this->methodsIncludingAnnotations[$classReflection->getDisplayName()][$nativeMethodReflection->getName()];
+		return $this->methodsIncludingAnnotations[$classReflection->getCacheKey()][$nativeMethodReflection->getName()];
 	}
 
 	public function hasNativeMethod(ClassReflection $classReflection, string $methodName): bool
@@ -308,8 +308,8 @@ class PhpClassReflectionExtension
 
 	public function getNativeMethod(ClassReflection $classReflection, string $methodName): MethodReflection
 	{
-		if (isset($this->nativeMethods[$classReflection->getDisplayName()][$methodName])) {
-			return $this->nativeMethods[$classReflection->getDisplayName()][$methodName];
+		if (isset($this->nativeMethods[$classReflection->getCacheKey()][$methodName])) {
+			return $this->nativeMethods[$classReflection->getCacheKey()][$methodName];
 		}
 
 		if ($classReflection->getNativeReflection()->hasMethod($methodName)) {
@@ -333,12 +333,12 @@ class PhpClassReflectionExtension
 			);
 		}
 
-		if (!isset($this->nativeMethods[$classReflection->getDisplayName()][$nativeMethodReflection->getName()])) {
+		if (!isset($this->nativeMethods[$classReflection->getCacheKey()][$nativeMethodReflection->getName()])) {
 			$method = $this->createMethod($classReflection, $nativeMethodReflection, false);
-			$this->nativeMethods[$classReflection->getDisplayName()][$nativeMethodReflection->getName()] = $method;
+			$this->nativeMethods[$classReflection->getCacheKey()][$nativeMethodReflection->getName()] = $method;
 		}
 
-		return $this->nativeMethods[$classReflection->getDisplayName()][$nativeMethodReflection->getName()];
+		return $this->nativeMethods[$classReflection->getCacheKey()][$nativeMethodReflection->getName()];
 	}
 
 	private function createMethod(

--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -844,3 +844,53 @@ class GenericThis
 	{
 	}
 }
+
+/**
+ * Class Cache
+ *
+ * @template T
+ */
+class Cache
+{
+	/**
+	 * Function Cache::__construct
+	 *
+	 * @param T $t
+	 */
+	public function __construct($t)
+	{
+	}
+
+	/**
+	 * Function Cache::get
+	 *
+	 * @return T
+	 */
+	public function get()
+	{
+	}
+}
+
+/**
+ * Function cache0
+ *
+ * @template T
+ *
+ * @param T $t
+ */
+function cache0($t): void {
+	$c = new Cache($t);
+	assertType('T (function PHPStan\Generics\FunctionsAssertType\cache0(), argument)', $c->get());
+}
+
+/**
+ * Function cache1
+ *
+ * @template T
+ *
+ * @param T $t
+ */
+function cache1($t): void {
+	$c = new Cache($t);
+	assertType('T (function PHPStan\Generics\FunctionsAssertType\cache1(), argument)', $c->get());
+}


### PR DESCRIPTION
This fixes this: https://phpstan.org/r/970a09ce-f4d4-4300-b970-228f8f4ed050

We use the display name of a ClassReflection as a cache key, when caching method. However, it is possible ClassReflections with different template types have the same display name (when the template types are template types themselves, but from different scopes).