### PR TITLE
Support instanceof $expression 

### DIFF
--- a/tests/PHPStan/Analyser/data/instanceof.php
+++ b/tests/PHPStan/Analyser/data/instanceof.php
@@ -4,6 +4,7 @@ namespace InstanceOfNamespace;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
+use function PHPStan\Analyser\assertType;
 
 interface BarInterface
 {
@@ -36,7 +37,18 @@ class Foo extends BarParent
 							if ($intersected instanceof BarInterface) {
 								if ($this instanceof BarInterface) {
 									if ($parent instanceof parent) {
-										die;
+										assertType('PhpParser\Node\Expr\ArrayDimFetch', $foo);
+										assertType('PhpParser\Node\Expr', $bar);
+										assertType('*ERROR*', $baz);
+										assertType('InstanceOfNamespace\Lorem', $lorem);
+										assertType('InstanceOfNamespace\Dolor', $dolor);
+										assertType('InstanceOfNamespace\Sit', $sit);
+										assertType('InstanceOfNamespace\Foo', $self);
+										assertType('static(InstanceOfNamespace\Foo)', $static);
+										assertType('static(InstanceOfNamespace\Foo)', clone $static);
+										assertType('InstanceOfNamespace\BarInterface&InstanceOfNamespace\Foo', $intersected);
+										assertType('$this(InstanceOfNamespace\Foo)&InstanceOfNamespace\BarInterface', $this);
+										assertType('InstanceOfNamespace\BarParent', $parent);
 									}
 								}
 							}

--- a/tests/PHPStan/Analyser/data/instanceof.php
+++ b/tests/PHPStan/Analyser/data/instanceof.php
@@ -59,4 +59,142 @@ class Foo extends BarParent
 		}
 	}
 
+	/**
+	 * @template ObjectT of BarInterface
+	 * @template MixedT
+	 *
+	 * @param class-string<Foo> $classString
+	 * @param class-string<Foo>|class-string<BarInterface> $union
+	 * @param class-string<Foo>&class-string<BarInterface> $intersection
+	 * @param BarInterface $instance
+	 * @param ObjectT $objectT
+	 * @param class-string<ObjectT> $objectTString
+	 * @param object $object
+	 */
+	public function testExprInstanceof($subject, string $classString, $union, $intersection, string $other, $instance, $objectT, $objectTString, string $string, $object)
+	{
+		if ($subject instanceof $classString) {
+			assertType('InstanceOfNamespace\Foo', $subject);
+			assertType('true', $subject instanceof Foo);
+			assertType('true', $subject instanceof $classString);
+		} else {
+			assertType('mixed~InstanceOfNamespace\Foo', $subject);
+			assertType('false', $subject instanceof Foo);
+			assertType('false', $subject instanceof $classString);
+		}
+
+		$constantString = 'InstanceOfNamespace\BarParent';
+
+		if ($subject instanceof $constantString) {
+			assertType('InstanceOfNamespace\BarParent', $subject);
+			assertType('true', $subject instanceof BarParent);
+			assertType('true', $subject instanceof $constantString);
+		} else {
+			assertType('mixed~InstanceOfNamespace\BarParent', $subject);
+			assertType('false', $subject instanceof BarParent);
+			assertType('false', $subject instanceof $constantString);
+		}
+
+		if ($subject instanceof $union) {
+			assertType('InstanceOfNamespace\BarInterface|InstanceOfNamespace\Foo', $subject);
+			assertType('true', $subject instanceof $union);
+			assertType('bool', $subject instanceof BarInterface);
+			assertType('bool', $subject instanceof Foo);
+			assertType('true', $subject instanceof Foo || $subject instanceof BarInterface);
+		}
+
+		if ($subject instanceof $intersection) {
+			assertType('InstanceOfNamespace\BarInterface&InstanceOfNamespace\Foo', $subject);
+			assertType('true', $subject instanceof $intersection);
+			assertType('true', $subject instanceof BarInterface);
+			assertType('true', $subject instanceof Foo);
+		}
+
+		if ($subject instanceof $instance) {
+			assertType('InstanceOfNamespace\BarInterface', $subject);
+			assertType('true', $subject instanceof $instance);
+			assertType('true', $subject instanceof BarInterface);
+		}
+
+		if ($subject instanceof $other) {
+			assertType('object', $subject);
+			assertType('bool', $subject instanceof $other);
+		} else {
+			assertType('mixed', $subject);
+			assertType('bool', $subject instanceof $other);
+		}
+
+		if ($subject instanceof $objectT) {
+			assertType('ObjectT of InstanceOfNamespace\BarInterface (method InstanceOfNamespace\Foo::testExprInstanceof(), argument)', $subject);
+			assertType('true', $subject instanceof $objectT);
+		} else {
+			assertType('mixed~ObjectT of InstanceOfNamespace\BarInterface (method InstanceOfNamespace\Foo::testExprInstanceof(), argument)', $subject);
+			assertType('false', $subject instanceof $objectT);
+		}
+
+		if ($subject instanceof $objectTString) {
+			assertType('ObjectT of InstanceOfNamespace\BarInterface (method InstanceOfNamespace\Foo::testExprInstanceof(), argument)', $subject);
+			assertType('true', $subject instanceof $objectT);
+		} else {
+			assertType('mixed~ObjectT of InstanceOfNamespace\BarInterface (method InstanceOfNamespace\Foo::testExprInstanceof(), argument)', $subject);
+			assertType('false', $subject instanceof $objectT);
+		}
+
+		if ($subject instanceof $string) {
+			assertType('object', $subject);
+			assertType('bool', $subject instanceof $string);
+		} else {
+			assertType('mixed', $subject);
+			assertType('bool', $subject instanceof $string);
+		}
+
+		if ($object instanceof $string) {
+			assertType('object', $object);
+			assertType('bool', $object instanceof $string);
+		} else {
+			assertType('object', $object);
+			assertType('bool', $object instanceof $string);
+		}
+
+		if ($object instanceof $object) {
+			assertType('object', $object);
+			assertType('bool', $object instanceof $object);
+		} else {
+			assertType('object', $object);
+			assertType('bool', $object instanceof $object);
+		}
+
+		if ($object instanceof $classString) {
+			assertType('InstanceOfNamespace\Foo', $object);
+			assertType('true', $object instanceof $classString);
+		} else {
+			assertType('object~InstanceOfNamespace\Foo', $object);
+			assertType('false', $object instanceof $classString);
+		}
+
+		if ($instance instanceof $string) {
+			assertType('InstanceOfNamespace\BarInterface', $instance);
+			assertType('bool', $instance instanceof $string);
+		} else {
+			assertType('InstanceOfNamespace\BarInterface', $instance);
+			assertType('bool', $instance instanceof $string);
+		}
+
+		if ($instance instanceof $object) {
+			assertType('InstanceOfNamespace\BarInterface', $instance);
+			assertType('bool', $instance instanceof $object);
+		} else {
+			assertType('InstanceOfNamespace\BarInterface', $instance);
+			assertType('bool', $object instanceof $object);
+		}
+
+		if ($instance instanceof $classString) {
+			assertType('InstanceOfNamespace\BarInterface&InstanceOfNamespace\Foo', $instance);
+			assertType('true', $instance instanceof $classString);
+		} else {
+			assertType('InstanceOfNamespace\BarInterface', $instance);
+			assertType('bool', $instance instanceof $classString);
+		}
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -127,6 +127,14 @@ class ImpossibleInstanceOfRuleTest extends \PHPStan\Testing\RuleTestCase
 					'Instanceof between ImpossibleInstanceOf\Bar and ImpossibleInstanceOf\BarGrandChild will always evaluate to false.',
 					322,
 				],
+				[
+					'Instanceof between mixed and int results in an error.',
+					353,
+				],
+				[
+					'Instanceof between mixed and ImpossibleInstanceOf\InvalidTypeTest|int results in an error.',
+					362,
+				],
 			]
 		);
 	}
@@ -192,6 +200,14 @@ class ImpossibleInstanceOfRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					'Instanceof between ImpossibleInstanceOf\Bar and ImpossibleInstanceOf\BarGrandChild will always evaluate to false.',
 					322,
+				],
+				[
+					'Instanceof between mixed and int results in an error.',
+					353,
+				],
+				[
+					'Instanceof between mixed and ImpossibleInstanceOf\InvalidTypeTest|int results in an error.',
+					362,
 				],
 			]
 		);

--- a/tests/PHPStan/Rules/Classes/data/impossible-instanceof.php
+++ b/tests/PHPStan/Rules/Classes/data/impossible-instanceof.php
@@ -330,3 +330,48 @@ class BarGrandChild implements BarChild
 {
 
 }
+
+class InvalidTypeTest
+{
+	/**
+	 * @template ObjectT of InvalidTypeTest
+	 * @template MixedT
+	 *
+	 * @param mixed $subject
+	 * @param int $int
+	 * @param object $objectWithoutClass
+	 * @param InvalidTypeTest $object
+	 * @param int|InvalidTypeTest $intOrObject
+	 * @param string $string
+	 * @param mixed $mixed
+	 * @param mixed $mixed
+	 * @param ObjectT $objectT
+	 * @param MixedT $mixedT
+	 */
+	public function doTest($int, $objectWithoutClass, $object, $intOrObject, $string, $mixed, $objectT, $mixedT)
+	{
+		if ($mixed instanceof $int) {
+		}
+
+		if ($mixed instanceof $objectWithoutClass) {
+		}
+
+		if ($mixed instanceof $object) {
+		}
+
+		if ($mixed instanceof $intOrObject) {
+		}
+
+		if ($mixed instanceof $string) {
+		}
+
+		if ($mixed instanceof $mixed) {
+		}
+
+		if ($mixed instanceof $objectT) {
+		}
+
+		if ($mixed instanceof $mixedT) {
+		}
+	}
+}


### PR DESCRIPTION
This adds support for `$a instanceof $b` where `$b` is an expression (especially a class-string<> or a constant string), in TypeSpecifier.