### PR TITLE
Add excludes neon formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ You can pass the following keywords to the `--error-format=X` parameter in order
 - `checkstyle`: Creates a checkstyle.xml compatible output. Note that you'd have to redirect output into a file in order to capture the results for later processing.
 - `json`: Creates minified .json output without whitespaces. Note that you'd have to redirect output into a file in order to capture the results for later processing.
 - `prettyJson`: Creates human readable .json output with whitespaces and indentations. Note that you'd have to redirect output into a file in order to capture the results for later processing.
+- `NeonExcludes`: Creates a .neon output for including in your config. This allows a baseline for existing errors. Note that you'd have to redirect output into a file in order to capture the results for later processing.
 
 ## Class reflection extensions
 

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -760,6 +760,9 @@ services:
 	errorFormatter.raw:
 		class: PHPStan\Command\ErrorFormatter\RawErrorFormatter
 
+	errorFormatter.neonExcludes:
+		class: PHPStan\Command\ErrorFormatter\NeonExcludesErrorFormatter
+
 	errorFormatter.table:
 		class: PHPStan\Command\ErrorFormatter\TableErrorFormatter
 		arguments:

--- a/src/Command/ErrorFormatter/NeonExcludesErrorFormatter.php
+++ b/src/Command/ErrorFormatter/NeonExcludesErrorFormatter.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Style\OutputStyle;
 
 class NeonExcludesErrorFormatter implements ErrorFormatter
 {
+
 	public function formatErrors(
 		AnalysisResult $analysisResult,
 		OutputStyle $style

--- a/src/Command/ErrorFormatter/NeonExcludesErrorFormatter.php
+++ b/src/Command/ErrorFormatter/NeonExcludesErrorFormatter.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use Symfony\Component\Console\Style\OutputStyle;
+
+class NeonExcludesErrorFormatter implements ErrorFormatter
+{
+	public function formatErrors(
+		AnalysisResult $analysisResult,
+		OutputStyle $style
+	): int
+	{
+		if (!$analysisResult->hasErrors()) {
+			return 0;
+		}
+
+		$allMessages = [];
+		foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
+			$allMessages[] = $notFileSpecificError;
+		}
+		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+			$allMessages[] = $fileSpecificError->getMessage();
+		}
+		$allMessages = array_unique($allMessages);
+
+		$style->writeln('parameters:');
+		$style->writeln("\t" . 'ignoreErrors:');
+		foreach ($allMessages as $message) {
+			$style->writeln("\t\t- '''\n#" . preg_quote($message, '#') . "#\n'''");
+		}
+
+		return 1;
+	}
+
+}

--- a/tests/PHPStan/Command/ErrorFormatter/NeonExcludesErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/NeonExcludesErrorFormatterTest.php
@@ -2,6 +2,9 @@
 
 namespace PHPStan\Command\ErrorFormatter;
 
+use PHPStan\Analyser\Error;
+use PHPStan\Command\AnalysisResult;
+
 class NeonExcludesErrorFormatterTest extends TestBaseFormatter
 {
 
@@ -121,6 +124,37 @@ class NeonExcludesErrorFormatterTest extends TestBaseFormatter
 		), sprintf('%s: response code do not match', $message));
 
 		$this->assertEquals($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
+	}
+
+
+	public function testFormatErrorMessagesRegexEscape(): void
+	{
+		$formatter = new NeonExcludesErrorFormatter();
+
+		$result  = new AnalysisResult(
+			[new Error('Escape Regex with file # ~ <> \' ()', 'Testfile')],
+			['Escape Regex without file # ~ <> \' ()'],
+			false,
+			false,
+			null
+		);
+		$formatter->formatErrors(
+			$result,
+			$this->getErrorConsoleStyle()
+		);
+
+		self::assertSame(
+			"parameters:
+	ignoreErrors:
+		- '''
+#Escape Regex without file \# ~ <\> ' \(\)#
+'''
+		- '''
+#Escape Regex with file \# ~ <\> ' \(\)#
+'''
+",
+			$this->getOutputContent()
+		);
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/NeonExcludesErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/NeonExcludesErrorFormatterTest.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+class NeonExcludesErrorFormatterTest extends TestBaseFormatter
+{
+
+	public function dataFormatterOutputProvider(): iterable
+	{
+		yield [
+			'No errors',
+			0,
+			0,
+			0,
+			'',
+		];
+
+		yield [
+			'One file error',
+			1,
+			1,
+			0,
+			"parameters:
+	ignoreErrors:
+		- '''
+#Foo#
+'''
+",
+		];
+
+		yield [
+			'One generic error',
+			1,
+			0,
+			1,
+			"parameters:
+	ignoreErrors:
+		- '''
+#first generic error#
+'''
+",
+		];
+
+		yield [
+			'Multiple file errors',
+			1,
+			4,
+			0,
+			"parameters:
+	ignoreErrors:
+		- '''
+#Bar#
+'''
+		- '''
+#Foo#
+'''
+",
+		];
+
+		yield [
+			'Multiple generic errors',
+			1,
+			0,
+			2,
+			"parameters:
+	ignoreErrors:
+		- '''
+#first generic error#
+'''
+		- '''
+#second generic error#
+'''
+",
+		];
+
+		yield [
+			'Multiple file, multiple generic errors',
+			1,
+			4,
+			2,
+			"parameters:
+	ignoreErrors:
+		- '''
+#first generic error#
+'''
+		- '''
+#second generic error#
+'''
+		- '''
+#Bar#
+'''
+		- '''
+#Foo#
+'''
+",
+		];
+	}
+
+	/**
+	 * @dataProvider dataFormatterOutputProvider
+	 *
+	 * @param string $message
+	 * @param int    $exitCode
+	 * @param int    $numFileErrors
+	 * @param int    $numGenericErrors
+	 * @param string $expected
+	 */
+	public function testFormatErrors(
+		string $message,
+		int $exitCode,
+		int $numFileErrors,
+		int $numGenericErrors,
+		string $expected
+	): void
+	{
+		$formatter = new NeonExcludesErrorFormatter();
+
+		$this->assertSame($exitCode, $formatter->formatErrors(
+			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
+			$this->getErrorConsoleStyle()
+		), sprintf('%s: response code do not match', $message));
+
+		$this->assertEquals($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
+	}
+
+}


### PR DESCRIPTION
Hi,

i have created a `NeonExcludes` Error Formatter to create a exludes.neon file. This file could be used as a baseline for a higher PHPStan level.
We can upgrade to phpstan level max and create the excludes.neon file. This file should be included and the new code could be validated with the higher level. 