### PR TITLE
Add precious reference as project implementing PHPStan extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Unofficial extensions for other frameworks and libraries are also available:
 * [Drupal](https://github.com/mglaman/phpstan-drupal)
 * [WordPress](https://github.com/szepeviktor/phpstan-wordpress)
 * [Zend Framework](https://github.com/Slamdunk/phpstan-zend-framework)
+* [Precious](https://github.com/gabrielelana/precious)
 
 Unofficial extensions with third-party rules:
 


### PR DESCRIPTION
It's a library to implement value objects with a properties class extension for the declared fields and in the process to make them read only to make the object immutable without writing accessor methods.