### PR TITLE
fix for notices + custom error reporting + @mkdir

### DIFF
--- a/src/Cache/FileCacheStorage.php
+++ b/src/Cache/FileCacheStorage.php
@@ -12,7 +12,7 @@ class FileCacheStorage implements CacheStorage
 	{
 		$this->directory = $directory;
 
-		if (@mkdir($this->directory) && !is_dir($this->directory)) {
+		if (!is_dir($this->directory) && !mkdir($this->directory) && !is_dir($this->directory)) {
 			throw new \InvalidArgumentException(sprintf('Directory "%s" doesn\'t exist.', $this->directory));
 		}
 	}

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -192,7 +192,7 @@ class CommandHelper
 
 		if (!isset($tmpDir)) {
 			$tmpDir = sys_get_temp_dir() . '/phpstan';
-			if (!@mkdir($tmpDir, 0777, true) && !is_dir($tmpDir)) {
+			if (!is_dir($tmpDir) && !mkdir($tmpDir, 0777, true) && !is_dir($tmpDir)) {
 				$errorOutput->writeln(sprintf('Cannot create a temp directory %s', $tmpDir));
 				throw new \PHPStan\Command\InceptionNotSuccessfulException();
 			}

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -46,7 +46,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 	{
 		if (self::$container === null) {
 			$tmpDir = sys_get_temp_dir() . '/phpstan-tests';
-			if (!@mkdir($tmpDir, 0777, true) && !is_dir($tmpDir)) {
+			if (!is_dir($tmpDir) && !mkdir($tmpDir, 0777, true) && !is_dir($tmpDir)) {
 				self::fail(sprintf('Cannot create temp directory %s', $tmpDir));
 			}
 


### PR DESCRIPTION
I have a custom error handler in a project, where also notices with "@" are reported. Maybe not the best idea?! But here is a fix for "@mkdir".

"If you have set a custom error handler function with set_error_handler() then it will still get called, but this custom error handler can (and should) call error_reporting() which will return 0 when the call that triggered the error was preceded by an @." - https://www.php.net/manual/en/language.operators.errorcontrol.php

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpstan/phpstan/2546)
<!-- Reviewable:end -->
