### PR TITLE
Stick to conventional semver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "PHPStan - PHP Static Analysis Tool",
 	"license": ["MIT"],
 	"require": {
-		"php": "~7.1",
+		"php": "^7.1",
 		"nikic/php-parser": "^4.3.0"
 	},
 	"bin": [


### PR DESCRIPTION
They are both exactly the same in this context.
Thus I recommend using a single semver version/usage here.