### PR TITLE
Fix: Rename reference after move to @ergebnis

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Unofficial extensions for other frameworks and libraries are also available:
 Unofficial extensions with third-party rules:
 
 * [thecodingmachine / phpstan-strict-rules](https://github.com/thecodingmachine/phpstan-strict-rules)
-* [localheinz / phpstan-rules](https://github.com/localheinz/phpstan-rules)
+* [ergebnis / phpstan-rules](https://github.com/ergebnis/phpstan-rules)
 * [pepakriz / phpstan-exception-rules](https://github.com/pepakriz/phpstan-exception-rules)
 * [Slamdunk / phpstan-extensions](https://github.com/Slamdunk/phpstan-extensions)
 * [ekino / phpstan-banned-code](https://github.com/ekino/phpstan-banned-code)


### PR DESCRIPTION
This PR

* [x] renames a reference after moving `localheinz/phpstan-rules` to `ergebnis/phpstan-rules`

💁‍♂ For reference, see https://github.com/ergebnis/phpstan-rules/pull/157.