### PR TITLE
Mark Zend to Laminas transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Unofficial extensions for other frameworks and libraries are also available:
 * [moneyphp/money](https://github.com/JohnstonCode/phpstan-moneyphp)
 * [Drupal](https://github.com/mglaman/phpstan-drupal)
 * [WordPress](https://github.com/szepeviktor/phpstan-wordpress)
-* [Laminas](https://github.com/Slamdunk/phpstan-laminas-framework) (a.k.a. Zend Framework)
+* [Laminas](https://github.com/Slamdunk/phpstan-laminas-framework) (a.k.a. [Zend Framework](https://github.com/Slamdunk/phpstan-zend-framework))
 
 Unofficial extensions with third-party rules:
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Unofficial extensions for other frameworks and libraries are also available:
 * [moneyphp/money](https://github.com/JohnstonCode/phpstan-moneyphp)
 * [Drupal](https://github.com/mglaman/phpstan-drupal)
 * [WordPress](https://github.com/szepeviktor/phpstan-wordpress)
-* [Zend Framework](https://github.com/Slamdunk/phpstan-zend-framework)
+* [Laminas](https://github.com/Slamdunk/phpstan-laminas-framework) (a.k.a. Zend Framework)
 
 Unofficial extensions with third-party rules:
 


### PR DESCRIPTION
Zend Framework moved to Laminas, and I moved my extension as well: https://getlaminas.org/blog/2019-12-31-out-with-the-old-in-with-the-new.html