### PR TITLE
Add new third party rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Unofficial extensions with third-party rules:
 * [pepakriz / phpstan-exception-rules](https://github.com/pepakriz/phpstan-exception-rules)
 * [Slamdunk / phpstan-extensions](https://github.com/Slamdunk/phpstan-extensions)
 * [ekino / phpstan-banned-code](https://github.com/ekino/phpstan-banned-code)
+* [taptima / phpstan-custom](https://github.com/taptima/phpstan-custom)
 
 New extensions are becoming available on a regular basis!
 


### PR DESCRIPTION
We wrote the following rules:
- checking for the presence of setters and getters for common entity fields
- getter naming conventions for boolean fields in predicate style (like `isField`, `hasField`)
- availability of `add*` and `remove*` methods for Doctrine ArrayCollection