### PR TITLE
Fixing PSR-12

### DIFF
--- a/website/src/writing-php-code/phpdocs-basics.md
+++ b/website/src/writing-php-code/phpdocs-basics.md
@@ -18,7 +18,7 @@ This is how a valid PHPDoc above a function or a method can look like:
  * @param Foo $param
  * @return Bar
  */
-function foo ($param) { ... }
+function foo($param) { ... }
 ```
 
 Properties


### PR DESCRIPTION
See https://www.php-fig.org/psr/psr-12/#44-methods-and-functions

> Method and function names MUST NOT be declared with space after the method name.