### PR TITLE
Added settings for symfony/thanks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,10 @@
 	"extra": {
 		"branch-alias": {
 			"dev-master": "0.12-dev"
+		},
+		"thanks": {
+			"name": "phpstan/phpstan-src",
+			"url": "https://github.com/phpstan/phpstan-src"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
[symfony/thanks](https://github.com/symfony/thanks) is a Composer plugin that enables you to star the GitHub repositories of all the packages your project depends on. This PR adds a setting to the composer.json file of this repository that tells symfony/thanks to give a star to the `phpstan-src` repository as well.