### PR TITLE
Update class-reflection-extensions.md

### DIFF
--- a/website/src/developing-extensions/class-reflection-extensions.md
+++ b/website/src/developing-extensions/class-reflection-extensions.md
@@ -29,6 +29,8 @@ Most likely you will also have to implement a new class implementing the `Proper
 ```php
 namespace PHPStan\Reflection;
 
+use PHPStan\Type\Type;
+
 interface PropertyReflection
 {
 
@@ -77,6 +79,8 @@ Most likely you will also have to implement a new class implementing the `Method
 
 ```php
 namespace PHPStan\Reflection;
+
+use PHPStan\Type\Type;
 
 interface MethodReflection
 {


### PR DESCRIPTION
All types mentioned in the examples except `Type` come from `PHPStan\Reflection`, which means they don't need to be imported. I personally tripped over Type not being in the place where I expected it to be. This PR aims to make the copy, paste, implement cycle a bit easier for the developer.