### PR TITLE
Add GitHub issue configuration file for support question redirect

### DIFF
--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -1,8 +1,0 @@
----
-name: Support question ❓ 
-about: Please open a new discussion instead. Thank you.
----
-
-# Support question
-
-<!-- Please use Discussions for support questions instead. Thank you. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Support question ❓
+    url: https://github.com/phpstan/phpstan/discussions/new
+    about: Please open a new discussion instead. Thank you.


### PR DESCRIPTION
Today, when a GitHub user opens the link https://github.com/phpstan/phpstan/issues/new/choose he has 5 choices:

- choose a "Bug report" issue template
- choose a "Feature request" issue template
- choose a "Function signature mismatch" issue template
- choose a "Support question" issue template
- view security policy

However there is no real "Support question" issue template. This is rather a message to redirect the github user to Discussions: the template is used as a way to carry this information.

According to https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser a configuration file enables the use of `contact_links` to _redirect_ users looking for help to some page. This PR enables it and removes the fake issue template.