### PR TITLE
Add a notice message about settings being cached

### DIFF
--- a/website/src/developing-extensions/core-concepts.md
+++ b/website/src/developing-extensions/core-concepts.md
@@ -8,6 +8,18 @@ Please note that this website section is under development as of June 2020. The 
 
 </div>
 
+<div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4" role="alert">
+
+Be aware that PHPStan configuration settings are being cached. You might need to clear this cache when working on an extension in order for your phpstan instance to acknowledge your changes.
+
+This cache is stored in the directory path used for temporary files, available through the use of `sys_get_temp_dir()`.
+
+This cache can be cleared the `clear-result-cache` command. [Learn more »](/user-guide/command-line-usage#clearing-the-result-cache)
+
+Result cache also gets disabled when running with [`--debug`](/user-guide/command-line-usage#--debug).
+
+</div>
+
 Reflection
 -----------------
 


### PR DESCRIPTION
Add a notice message about settings being cached and the need to refresh.

So far I clear the cache by deleting the `phpstan` folder inside `sys_get_temp_dir/phpstan` maybe there is a better solution?