### PR TITLE
[Docker] Support for multi-arch Docker builds

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -50,3 +53,4 @@ jobs:
             PHPSTAN_VERSION=dev-master#${{ github.sha }}
           push: true
           tags: ghcr.io/phpstan/phpstan:nightly
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -49,3 +52,4 @@ jobs:
             PHPSTAN_VERSION=${{ steps.get_version.outputs.VERSION }}
           push: true
           tags: ghcr.io/phpstan/phpstan:latest,ghcr.io/phpstan/phpstan:0.12,ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This is result (https://github.com/users/JanMikes/packages/container/package/phpstan):

<img width="773" alt="Screenshot 2021-03-04 at 19 12 32" src="https://user-images.githubusercontent.com/3995003/110010214-56949100-7d1e-11eb-8fb3-be14efacd2e0.png">


To verify run:
```
docker pull ghcr.io/janmikes/phpstan
docker manifest inspect --verbose ghcr.io/janmikes/phpstan | grep architecture
```

You should see output:
```
				"architecture": "amd64",
				"architecture": "arm64",
```