### PR TITLE
[Docker] Building Docker images in GHA now uses layers cache

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -54,3 +54,5 @@ jobs:
           push: true
           tags: ghcr.io/phpstan/phpstan:nightly
           platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -53,3 +53,5 @@ jobs:
           push: true
           tags: ghcr.io/phpstan/phpstan:latest,ghcr.io/phpstan/phpstan:0.12,ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}
           platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Added missing arguments for action that runs `docker buildx build` under the hood.

When testing, times went from 13s to avg 3s, it was very fast already before 😄 with multi-arch builds the speedup will be more notable as QEMU is quite slow. 