### PR TITLE
Fix double scroll bar causing navigation issues

### DIFF
--- a/website/src/_layouts/_base.njk
+++ b/website/src/_layouts/_base.njk
@@ -22,8 +22,8 @@
 </head>
 <body>
 
-<div class="h-screen bg-white flex flex-col main-area">
-	<nav class="bg-white border-b border-gray-200 flex-shrink z-10">
+<div class="bg-white flex flex-col main-area">
+	<nav class="bg-white border-b border-gray-200 flex-shrink z-10 nav-header">
 		<!-- ko with: mainMenu -->
 			<div class="max-w-5xl mx-auto px-4 md:px-6">
 				<div class="flex justify-between h-16">
@@ -86,7 +86,7 @@
 			</div>
 		<!-- /ko -->
 	</nav>
-	<div class="overflow-y-auto">
+	<div>
 		<main>
 			<div class="max-w-5xl mx-auto md:px-6">
 				{% block content %}{% endblock %}

--- a/website/src/app.pcss
+++ b/website/src/app.pcss
@@ -121,3 +121,13 @@
 .content hr {
 	@apply w-4/5 mx-auto mt-8 mb-8 border-dashed border-2
 }
+
+.nav-header {
+    position: fixed;
+    align-content: center;
+    width: 100%;
+}
+
+.content {
+    margin-top: 4em;
+}


### PR DESCRIPTION
* Remove .h-screen and .overflow-y-auto, which constrain the main content area to be only the height of the browser window, which causes a secondary scroll bar that only scrolls that content. Now, the main content area flows as part of the entire page.
* Add styling to explicitly fix the nav header to the top, and increase the content area top margin to account for the nav header being taken out of the normal layout flow.

I'm not familiar with how Tailwinds is supposed to be used, so there may be a more "tailwindy" way of doing this. This should work, though. I've tested several pages in both Safari and Chrome, and it looks good. The spacing between the bottom of the nav bar and the top of the content is not _exactly_ the same as it was, but it's only a pixel or two off, so I doubt anyone would notice.