### PR TITLE
Document the signature for class-string subtypes

### DIFF
--- a/website/src/writing-php-code/phpdoc-types.md
+++ b/website/src/writing-php-code/phpdoc-types.md
@@ -97,7 +97,7 @@ Generics
 class-string
 -------------------------
 
-`class-string` type can be used wherever a valid class name string is expected. [Generic](/blog/generics-in-php-using-phpdocs) variant `class-string<T>` also works.
+`class-string` type can be used wherever a valid class name string is expected. [Generic](/blog/generics-in-php-using-phpdocs) variant `class-string<T>` also works, or you can use class-string<Foo> to only accept valid class names that are subtypes of Foo.
 
 ```php
 /**

--- a/website/src/writing-php-code/phpdoc-types.md
+++ b/website/src/writing-php-code/phpdoc-types.md
@@ -97,7 +97,7 @@ Generics
 class-string
 -------------------------
 
-`class-string` type can be used wherever a valid class name string is expected. [Generic](/blog/generics-in-php-using-phpdocs) variant `class-string<T>` also works, or you can use class-string<Foo> to only accept valid class names that are subtypes of Foo.
+`class-string` type can be used wherever a valid class name string is expected. [Generic](/blog/generics-in-php-using-phpdocs) variant `class-string<T>` also works, or you can use `class-string<Foo>` to only accept valid class names that are subtypes of Foo.
 
 ```php
 /**


### PR DESCRIPTION
As per https://phpstan.org/blog/phpstan-0-12-released#%E2%80%9Cclass-string%E2%80%9D-pseudotype the `class-string` type supports narrowing by class subtype too.