### PR TITLE
Allow another psr/cache version

### DIFF
--- a/e2e/symfony-event/composer.json
+++ b/e2e/symfony-event/composer.json
@@ -2,10 +2,10 @@
     "type": "project",
     "license": "proprietary",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3|^8.0",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "psr/cache": "1.0.1",
+        "psr/cache": "1.0.1|^2.0|^3.0",
         "symfony/console": "4.4.*",
         "symfony/dotenv": "4.4.*",
         "symfony/flex": "^1.3.1",


### PR DESCRIPTION
I made the experience as a Laravel user that Laravel 8 installs psr/cache version 2. However, if I update a dependency that contains phpstan, psr/cache is set back to version 1. Now I would like to change this behavior.