### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-/.github export-ignore
+/.* export-ignore
 /BACKERS.md export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /docker export-ignore
@@ -6,6 +6,5 @@
 /issue-bot export-ignore
 /playground-api export-ignore
 /playground-runner export-ignore
-/.travis.yml export-ignore
 /website export-ignore
 website/* linguist-vendored


### PR DESCRIPTION
Currently PHPStan installed looks like this:
![image](https://user-images.githubusercontent.com/9282069/134225394-40ed3d63-5349-49f4-b90d-b75095b8f5ee.png)
With these chages all `/.*` pathe will be excluded from dist.