### PR TITLE
visual clues for documentation Links

### DIFF
--- a/website/src/app.pcss
+++ b/website/src/app.pcss
@@ -147,3 +147,15 @@
 .content details summary {
 	@apply cursor-pointer;
 }
+
+html {
+    scroll-behavior: smooth;
+    scroll-padding-top: 80px;
+}
+
+h1:target,
+h2:target,
+h3:target code {
+    background-color: green;
+    color: white;
+}


### PR DESCRIPTION
currently links get cut off by the navbar and its not very clear, which paragraph one was linked to.
so i added color indicator aswell as smooth scrolling and offset, to get a better idea, whats going on :)
feel free to adjust the colors to your liking.

![image](https://user-images.githubusercontent.com/1136869/138590483-9aaea2ac-8136-45f9-97db-9de2b35c89dd.png)
