### PR TITLE
infer php version from composer.json

### DIFF
--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -525,6 +525,8 @@ parameters:
     phpVersion: 70400 # PHP 7.4
 ```
 
+PHPStan will automatically infer the `composer.platform.php` version from the last `composer.json` file it can find, if not configured in the PHPStan configuration file.
+
 ### `inferPrivatePropertyTypeFromConstructor`
 
 **default**: `false`

--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -525,7 +525,7 @@ parameters:
     phpVersion: 70400 # PHP 7.4
 ```
 
-PHPStan will automatically infer the `composer.platform.php` version from the last `composer.json` file it can find, if not configured in the PHPStan configuration file.
+PHPStan will automatically infer the `config.platform.php` version from the last `composer.json` file it can find, if not configured in the PHPStan configuration file.
 
 ### `inferPrivatePropertyTypeFromConstructor`
 


### PR DESCRIPTION
the described behaviour is the one I read in this code:
https://github.com/phpstan/phpstan-src/blob/89af4e7db257750cdee5d4259ad312941b6b25e8/src/Php/PhpVersionFactoryFactory.php#L37-L51