### PR TITLE
Bump the version of PHPUnit used in the integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,8 +64,8 @@ jobs:
             script: |
               git clone https://github.com/sebastianbergmann/phpunit.git e2e/integration/repo
               cd e2e/integration/repo
-              git checkout 9.5.6
-              export COMPOSER_ROOT_VERSION=9.5.6
+              git checkout 9.5.12
+              export COMPOSER_ROOT_VERSION=9.5.12
               composer install
               ../../../phpstan.phar analyse -l 8 -c ../phpunit.neon src tests
           - php-version: 8.0


### PR DESCRIPTION
To make the CI of phpstan/phpstan-src#914 pass I had to open a PR in PHPUnit which was released in version `9.5.12`