### PR TITLE
Bump the version of Rector used in the integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -53,7 +53,7 @@ jobs:
             script: |
               git clone https://github.com/rectorphp/rector-src.git e2e/integration/repo
               cd e2e/integration/repo
-              git checkout a82a18edd366575db60151880ca44f1a8c2a0120
+              git checkout 303ecc342da1484619c4f875ad67850feeb4b52b
               cp ../rector-composer.lock composer.lock
               composer install
               ../../../phpstan.phar analyse -c ../rector.neon


### PR DESCRIPTION
To make the CI of phpstan/phpstan-src#914 pass I had to open a PR in the repository of Rector which got merged in commit [`303ecc3`](https://github.com/rectorphp/rector-src/commit/303ecc342da1484619c4f875ad67850feeb4b52b). Side note: this is not the latest commit on their `master` branch, but I didn't want to take the risk of bumping it to a more recent one