### PR TITLE
Clarify configurable rules definition documentation

### DIFF
--- a/website/src/developing-extensions/rules.md
+++ b/website/src/developing-extensions/rules.md
@@ -235,6 +235,7 @@ rules:
 This only works if the rule class doesn't have a constructor, or all the constructor parameters can be [autowired](/developing-extensions/dependency-injection-configuration#autowiring). If we have non-autowirable parameters in the constructor, we need to resort the rule as a service in the `services` section of the configuration file, specify the arguments, and the `phpstan.rules.rule` tag:
 
 ```yaml
+services:
 	-
 		class: App\MyRule
 		arguments:


### PR DESCRIPTION
Hi!

The previous paragraph mentions you should put your configurable rules under `services`. 
However some people (like me 😅) will just read the code example and won't understand why they face the following issue, because they are trying to put configurable rules under `rules`:
```
Invalid configuration:
The item 'rules › 142' expects to be string, array given.
```

Thanks!