### PR TITLE
Fix URL change in playground when editing code

### DIFF
--- a/website/src/js/PlaygroundViewModel.ts
+++ b/website/src/js/PlaygroundViewModel.ts
@@ -86,7 +86,7 @@ export class PlaygroundViewModel {
 	setId(id: string | null): void {
 		this.id = id;
 		if (id === null) {
-			window.history.replaceState({}, '', '/');
+			window.history.replaceState({}, '', '/try');
 		} else{
 			window.history.replaceState({}, '', '/r/' + id);
 		}


### PR DESCRIPTION
How to reproduce the bug:

1) Go to https://phpstan.org/try or a shared link such as https://phpstan.org/r/4d66176a-9897-4d33-a84f-5bd2743aa8bb .
2) Start editing the example.
3) See that the URL now points to https://phpstan.org/ .

Disclaimer:

I did not try to build & verify this change locally, hope it will be ok 🤞 .