### PR TITLE
Include `getAdditionalConfigFiles()` in the rule test example

### DIFF
--- a/website/src/developing-extensions/testing.md
+++ b/website/src/developing-extensions/testing.md
@@ -46,6 +46,12 @@ class MyRuleTest extends RuleTestCase
 		// or if there are other errors reported beside the expected one
 	}
 
+	public static function getAdditionalConfigFiles(): array
+	{
+		// path to your project's phpstan.neon, or extension.neon in case of custom extension packages
+		return [__DIR__ . '/../extension.neon'];
+	}
+
 }
 ```
 

--- a/website/src/developing-extensions/testing.md
+++ b/website/src/developing-extensions/testing.md
@@ -98,6 +98,7 @@ class MyContainerDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 	public static function getAdditionalConfigFiles(): array
 	{
 		// path to your project's phpstan.neon, or extension.neon in case of custom extension packages
+		// this is only necessary if your custom rule relies on some extra configuration and other extensions
 		return [__DIR__ . '/../extension.neon'];
 	}
 

--- a/website/src/developing-extensions/testing.md
+++ b/website/src/developing-extensions/testing.md
@@ -49,6 +49,7 @@ class MyRuleTest extends RuleTestCase
 	public static function getAdditionalConfigFiles(): array
 	{
 		// path to your project's phpstan.neon, or extension.neon in case of custom extension packages
+		// this is only necessary if your custom rule relies on some extra configuration and other extensions
 		return [__DIR__ . '/../extension.neon'];
 	}
 
@@ -98,7 +99,6 @@ class MyContainerDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
 	public static function getAdditionalConfigFiles(): array
 	{
 		// path to your project's phpstan.neon, or extension.neon in case of custom extension packages
-		// this is only necessary if your custom rule relies on some extra configuration and other extensions
 		return [__DIR__ . '/../extension.neon'];
 	}
 


### PR DESCRIPTION
I've just updated a custom rule to remove reliance on the soon-to-be-removed `parent` node attribute. The custom node visitor I implemented and registered with the `phpstan.parser.richParserNodeVisitor` tag wasn't being visited during the PHPUnit test suite run because my `RuleTestCase` class didn't implement the `getAdditionalConfigFiles()` method.

Hopefully adding it to this documentation will help others avoid this mystery problem. It's copied from the `TypeInferenceTestCase` further down the page.