### PR TITLE
Note that resultcaches might be overwritten if `tmpDir` is not unique

### DIFF
--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -125,6 +125,8 @@ parameters:
 
 Relative path in the `tmpDir` key is resolved based on the directory of the config file is in. In this example PHPStan cache will be stored in `tmp` directory that's next to the configuration file.
 
+If you're analyzing multiple projects on one machine, you should change `tmpDir` for each of the projects (and config files) to not overwrite other projects' caches.
+
 Analysed files
 -----------------------
 

--- a/website/src/user-guide/result-cache.md
+++ b/website/src/user-guide/result-cache.md
@@ -10,7 +10,7 @@ You might notice the result cache isn't sometimes saved and PHPStan runs full an
 
 </div>
 
-The result cache is saved at `%tmpDir%/resultCache.php`. [Learn more about `tmpDir` configuration »](/config-reference#caching)
+The result cache is saved at `%tmpDir%/resultCache.php`. If you're analyzing multiple projects on one machine, you should set unique `tmpDir` for each of the projects (and config files) otherwise a result cache from one project will overwrite a cache from some other project. [Learn more about `tmpDir` configuration »](/config-reference#caching)
 
 Result cache contents
 --------------


### PR DESCRIPTION
So, uhh, this took me a really long time. Since the day the result cache has been introduced, I've had a feeling that something is not right but it was always just a feeling. Until today. (_Spoiler alert: my config wasn't perfect_)

I'm running PHPStan on different projects (sometimes even multiple PHPStan configs in one project) and finally I've realized that the result cache from one project was being overwritten by a result cache from some other project (or config file).

I've read the related documentation several times but only today it eventually occurred to me. This might help other people like me (*I know you're there, hello?*).