### PR TITLE
Document new `errorFormat` parameter

### DIFF
--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -566,6 +566,17 @@ This might not be what you want in case you're writing a library whose users mig
 
 From time to time, PHPStan shows "💡 Tips of the Day" at the end of a successful analysis. You can turn this off by setting `tipsOfTheDay` key to `false`.
 
+### `errorFormat`
+
+**default**: `null`
+
+If you want to change the default [error formatter](/user-guide/output-format), you can specify that using:
+
+```yaml
+parameters:
+    errorFormat: json
+```
+
 Expanding paths
 -------------
 

--- a/website/src/user-guide/output-format.md
+++ b/website/src/user-guide/output-format.md
@@ -18,6 +18,8 @@ You can pass the following keywords to the `--error-format=X` CLI option of the 
 
 You can also implement your own custom error formatter. [Learn how »](/developing-extensions/error-formatters)
 
+You can change the default error format in the configuration. [Learn how »](/config-reference#errorformat)
+
 Opening file in an editor
 --------------
 


### PR DESCRIPTION
Somehow I had troubles checking out this (big?) repository so I had to edit it on GitHub Web UI. Please squash my commits.