### PR TITLE
Github Actions - use Github actions cache exporter for Docker images

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -39,14 +39,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to ghcr
         uses: docker/login-action@v2
         with:
@@ -65,5 +57,5 @@ jobs:
           push: true
           tags: "ghcr.io/phpstan/phpstan:nightly${{ matrix.image-tag-suffix }}"
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha, scope=${{ github.workflow }}
+          cache-to: type=gha, scope=${{ github.workflow }}

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -34,14 +34,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to ghcr
         uses: docker/login-action@v2
         with:
@@ -64,5 +56,5 @@ jobs:
           push: true
           tags: "ghcr.io/phpstan/phpstan:latest${{ matrix.image-tag-suffix }},ghcr.io/phpstan/phpstan:1${{ matrix.image-tag-suffix }},ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}${{ matrix.image-tag-suffix }}"
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha, scope=${{ github.workflow }}
+          cache-to: type=gha, scope=${{ github.workflow }}


### PR DESCRIPTION
Using local cache has some buggy behaviour with size and using github cache for docker images fixes it: https://github.com/docker/build-push-action/issues/252 

More about github cache: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache and https://github.com/moby/buildkit/tree/master#github-actions-cache-experimental 

On my testing repo, there was like 40% performance boost local cache vs github cache: https://github.com/peon-dev/peon/commit/dc9238f5841d202c5be74a329d09bbe5ac58488c