### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-issue-bot.yml
+++ b/.github/workflows/build-issue-bot.yml
@@ -14,6 +14,9 @@ on:
       - '.github/workflows/build-issue-bot.yml'
       - 'issue-bot/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build"

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -14,6 +14,9 @@ on:
       - 'playground-api/**'
       - 'playground-runner/**'
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -9,6 +9,9 @@ on:
     tags:
       - '1.*'
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/extension-tests-run.yml
+++ b/.github/workflows/extension-tests-run.yml
@@ -18,6 +18,9 @@ on:
       - 'playground-api/**'
       - 'playground-runner/**'
 
+permissions:
+  contents: read
+
 jobs:
   upload-phar:
     runs-on: "ubuntu-latest"
@@ -30,6 +33,8 @@ jobs:
           name: phar-file
           path: phpstan.phar
   extension-tests:
+    permissions:
+      contents: none
     needs: upload-phar
     uses: phpstan/phpstan/.github/workflows/extension-tests.yml@1.7.x
     with:

--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   check-phar-checksum:
     name: "Check PHAR checksum"

--- a/.github/workflows/integration-tests-run.yml
+++ b/.github/workflows/integration-tests-run.yml
@@ -18,6 +18,9 @@ on:
       - 'playground-api/**'
       - 'playground-runner/**'
 
+permissions:
+  contents: read
+
 jobs:
   upload-phar:
     runs-on: "ubuntu-latest"
@@ -30,6 +33,8 @@ jobs:
           name: phar-file
           path: phpstan.phar
   integration-tests:
+    permissions:
+      contents: none
     needs: upload-phar
     uses: phpstan/phpstan/.github/workflows/integration-tests.yml@1.7.x
     with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   check-phar-checksum:
     name: "Check PHAR checksum"

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -6,8 +6,13 @@ on:
 
 concurrency: lock_issues
 
+permissions:
+  contents: read
+
 jobs:
   lock:
+    permissions:
+      issues: write  # for dessant/lock-threads to lock issues
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/other-tests-run.yml
+++ b/.github/workflows/other-tests-run.yml
@@ -18,6 +18,9 @@ on:
       - 'playground-api/**'
       - 'playground-runner/**'
 
+permissions:
+  contents: read
+
 jobs:
   upload-phar:
     runs-on: "ubuntu-latest"
@@ -30,6 +33,8 @@ jobs:
           name: phar-file
           path: phpstan.phar
   other-tests:
+    permissions:
+      contents: none
     needs: upload-phar
     uses: phpstan/phpstan/.github/workflows/other-tests.yml@1.7.x
     with:

--- a/.github/workflows/other-tests.yml
+++ b/.github/workflows/other-tests.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   check-phar-checksum:
     name: "Check PHAR checksum"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,13 @@ on:
 
 concurrency: release
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     name: "Deploy"
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/run-issue-bot.yml
+++ b/.github/workflows/run-issue-bot.yml
@@ -8,6 +8,9 @@ on:
 
 concurrency: issue_bot
 
+permissions:
+  contents: read
+
 jobs:
   issue-bot:
     name: "Issue bot"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,9 @@ on:
       - 'playground-api/**'
       - 'playground-runner/**'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: "Tests"

--- a/.github/workflows/update-playground-api.yml
+++ b/.github/workflows/update-playground-api.yml
@@ -12,6 +12,9 @@ on:
 
 concurrency: playground_api
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build"


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
