### PR TITLE
Test phpstan /w restricted php.ini conf

### DIFF
--- a/.github/workflows/other-tests.yml
+++ b/.github/workflows/other-tests.yml
@@ -290,6 +290,8 @@ jobs:
               cd e2e/bug7441
               composer install
               ../../phpstan analyse -c app/phpstan.neon
+              php -d disable_functions="pcntl_exec,pcntl_fork,exec,passthru,proc_open,shell_exec,system,popen" ../../phpstan analyse -c app/phpstan.neon
+              php -d open_basedir="$(pwd),/tmp" ../../phpstan analyse -c app/phpstan.neon
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3


### PR DESCRIPTION
test https://github.com/phpstan/phpstan/issues/4147 and also disabled `proc_open` (which imply no parallelization possible)

probably no need to run full phpstan with these configurations