### PR TITLE
Do not add a message before locking a thread

### DIFF
--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -17,9 +17,6 @@ jobs:
           exclude-issue-created-before: ''
           exclude-any-issue-labels: ''
           add-issue-labels: ''
-          issue-comment: >
-            This thread has been automatically locked since there has not been
-            any recent activity after it was closed. Please open a new issue for
-            related bugs.
+          issue-comment: ''
           issue-lock-reason: 'resolved'
           process-only: 'issues'


### PR DESCRIPTION
Bot messages like https://github.com/phpstan/phpstan/issues/7391#issuecomment-1183794818 cannot be ignored from the notifications, the threads should be simply locked /wo a message.

ref https://github.com/dessant/lock-threads/issues/6