### PR TITLE
Specify where `phpstan-import-type` is valid

### DIFF
--- a/website/src/writing-php-code/phpdoc-types.md
+++ b/website/src/writing-php-code/phpdoc-types.md
@@ -243,7 +243,7 @@ class User
 }
 ```
 
-To use a local type alias elsewhere, you can import it using the `@phpstan-import-type` annotation:
+To use a local type alias elsewhere, you can import it using the `@phpstan-import-type` annotation in another class' PHPDocs:
 
 ```php
 /**


### PR DESCRIPTION
Using the `@phpstan-import-type` attribute in other PHPDocs for functions or variables doesn't work. So specify in the docs that this needs to exist at the class level docs.