### PR TITLE
Add CakePHP and Safe to extensions list

### DIFF
--- a/website/src/user-guide/extension-library.md
+++ b/website/src/user-guide/extension-library.md
@@ -71,6 +71,8 @@ Unofficial extensions
 * [Nextras ORM](https://github.com/nextras/orm-phpstan)
 * [Sonata](https://github.com/ekino/phpstan-sonata)
 * [Magento](https://github.com/bitExpert/phpstan-magento)
+* [CakePHP](https://github.com/CakeDC/cakephp-phpstan)
+* [Safe PHP](https://github.com/thecodingmachine/phpstan-safe-rule)
 
 3rd party rules
 -----------------


### PR DESCRIPTION
[CakeDC/cakephp-phpstan](https://github.com/CakeDC/cakephp-phpstan) and [thecodingmachine/phpstan-safe-rule](https://github.com/thecodingmachine/phpstan-safe-rule) are built by their communities and I am a user of both.