### PR TITLE
[website] Add the link tag for the RSS feed

### DIFF
--- a/website/src/_layouts/_base.njk
+++ b/website/src/_layouts/_base.njk
@@ -16,6 +16,7 @@
 		<meta name="twitter:image" content="/tmp/images/logo-big.png" />
 	{% endif %}
 	<link rel="icon" type="image/png" href="/tmp/images/favicon.png">
+	<link rel="alternate" type="application/rss+xml" title="PHPStan Blog" href="/tmp/rss.xml">
 
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:site" content="@phpstan" />


### PR DESCRIPTION
This allows standard-based discovery of the feed URL (for instance, there are several Firefox addons that expose the feed URLs through a browser UI element)