### PR TITLE
Add exception config in playground

### DIFF
--- a/playground-runner/bref.php
+++ b/playground-runner/bref.php
@@ -59,6 +59,13 @@ return function ($event) use ($phpstanVersion) {
 			'featureToggles' => [
 				'disableRuntimeReflectionProvider' => true,
 			],
+            'exceptions' => [
+                'check' => [
+                    'missingCheckedExceptionInThrows' => $event['exceptions'] ?? false,
+                    'tooWideThrowType' => $event['exceptions'] ?? false,
+                    'implicitThrows' => $event['exceptions'] ?? true,
+                ]
+            ]
 		],
 		'services' => [
 			'currentPhpVersionSimpleParser!' => [

--- a/website/src/js/PlaygroundViewModel.ts
+++ b/website/src/js/PlaygroundViewModel.ts
@@ -19,6 +19,7 @@ export class PlaygroundViewModel {
 	upToDateTabs: ko.Observable<PlaygroundTabViewModel[] | null>;
 
 	level: ko.Observable<string>;
+	exceptions: ko.Observable<boolean>;
 	strictRules: ko.Observable<boolean>;
 	bleedingEdge: ko.Observable<boolean>;
 	treatPhpDocTypesAsCertain: ko.Observable<boolean>;
@@ -57,6 +58,7 @@ export class PlaygroundViewModel {
 		this.upToDateTabs = ko.observable(null);
 
 		this.level = ko.observable('9');
+		this.exceptions = ko.observable<boolean>(false);
 		this.strictRules = ko.observable<boolean>(false);
 		this.bleedingEdge = ko.observable<boolean>(false);
 		this.treatPhpDocTypesAsCertain = ko.observable<boolean>(true);
@@ -115,6 +117,7 @@ export class PlaygroundViewModel {
 			data: JSON.stringify({
 				code: this.code(),
 				level: this.level(),
+				exceptions: this.exceptions(),
 				strictRules: this.strictRules(),
 				bleedingEdge: this.bleedingEdge(),
 				treatPhpDocTypesAsCertain: this.treatPhpDocTypesAsCertain(),
@@ -184,6 +187,7 @@ export class PlaygroundViewModel {
 			this.analyse(false);
 		};
 		this.level.subscribe(instantAnalyse);
+		this.exceptions.subscribe(instantAnalyse);
 		this.strictRules.subscribe(instantAnalyse);
 		this.bleedingEdge.subscribe(instantAnalyse);
 		this.treatPhpDocTypesAsCertain.subscribe(instantAnalyse);
@@ -248,6 +252,7 @@ export class PlaygroundViewModel {
 					this.upToDateTabs(this.createTabs(data.upToDateTabs));
 				}
 				this.level(data.level);
+				this.exceptions(data.config.exceptions);
 				this.strictRules(data.config.strictRules);
 				this.bleedingEdge(data.config.bleedingEdge);
 				this.treatPhpDocTypesAsCertain(data.config.treatPhpDocTypesAsCertain);

--- a/website/src/try.njk
+++ b/website/src/try.njk
@@ -96,6 +96,11 @@ permalink: "/try.html"
 					<input type="checkbox" data-bind="checked: treatPhpDocTypesAsCertain" class="border-gray-300 rounded">
 					<span class="ml-2">Treat PHPDoc types as certain</span>
 				</label>
+
+				<label class="inline-flex items-center px-4 mt-4 md:mt-0">
+					<input type="checkbox" data-bind="checked: exceptions" class="border-gray-300 rounded">
+					<span class="ml-2">Check exceptions</span>
+				</label>
 			</div>
 		</form>
 


### PR DESCRIPTION
Hi @ondrejmirtes,

I saw multiple issues which were related to exceptions checks:
- implicitThrows
- tooWideThrowType
- missingCheckedExceptionInThrows

When opening an issue, it's not the best experience since the playground is not doing those checks.
What do you think about adding a new option ?

(I tried to copy the others options but I don't know how to test the result)