### PR TITLE
Do not count directory "website" into language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,6 @@
 /e2e export-ignore
 /playground-api export-ignore
 /playground-runner export-ignore
-/website export-ignore linguist-vendored
+/website/ export-ignore
+
+/website/** -linguist-detectable


### PR DESCRIPTION
It has to be separate entries:

- `export-ignore` cannot have anything after `/`
- `linguist-detectable` will not work with nothing after `/`

Apparently, it does not refresh statistics on a fork, but if I push to new repo it does: https://github.com/werlos/phpstan-not-as-fork (after creating a new release/tag, for some reason).

