### PR TITLE
Fix example usage in docs of memory-limit

### DIFF
--- a/website/src/user-guide/command-line-usage.md
+++ b/website/src/user-guide/command-line-usage.md
@@ -51,7 +51,7 @@ Turns off the progress bar. Does not accept any value.
 
 Specifies the memory limit in the same format `php.ini` accepts.
 
-Example: `--memory-limit 1G`
+Example: `--memory-limit=1G`
 
 ### `--xdebug`
 


### PR DESCRIPTION
Fixes doc's example of usage --memory-limit
![image](https://user-images.githubusercontent.com/661654/207521706-7eb8d613-eb67-47b0-9738-cc6578b7c0fb.png)
