### PR TITLE
Fixed PHP8.2 Docker Image Tag

### DIFF
--- a/docker/Dockerfile.php.8.2
+++ b/docker/Dockerfile.php.8.2
@@ -1,4 +1,4 @@
-FROM php:8.2-rc-cli-alpine
+FROM php:8.2-cli-alpine
 
 RUN php --version
 


### PR DESCRIPTION
Use the stable PHP 8.2 Version instead of the RC Version