### PR TITLE
Reproduce deprecation warning

### DIFF
--- a/.github/workflows/other-tests.yml
+++ b/.github/workflows/other-tests.yml
@@ -343,7 +343,12 @@ jobs:
             script: |
               cd e2e/bug8610
               ../../phpstan
-
+          - php-version: 8.2
+            ini-values: memory_limit=256M
+            operating-system: ubuntu-latest
+            script: |
+              cd e2e/bug8610
+              ../../phpstan
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3

--- a/.github/workflows/other-tests.yml
+++ b/.github/workflows/other-tests.yml
@@ -347,7 +347,7 @@ jobs:
             ini-values: memory_limit=256M
             operating-system: ubuntu-latest
             script: |
-              cd e2e/bug8610
+              cd e2e/bug8610b
               ../../phpstan
     steps:
       - name: "Checkout"

--- a/e2e/bug8610b/autoloader.php
+++ b/e2e/bug8610b/autoloader.php
@@ -1,0 +1,8 @@
+<?php
+
+spl_autoload_register(function() {
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(__DIR__ . '/classes'));
+    foreach ($iterator as $path => $file) {
+        // ...
+    }
+});

--- a/e2e/bug8610b/classes/A.php
+++ b/e2e/bug8610b/classes/A.php
@@ -1,0 +1,9 @@
+<?php
+
+class A
+{
+    public function foo(): void
+    {
+    }
+
+}

--- a/e2e/bug8610b/phpstan.neon
+++ b/e2e/bug8610b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: max
+    paths:
+        - .
+    bootstrapFiles:
+            - autoloader.php

--- a/e2e/bug8610b/phpstan.neon
+++ b/e2e/bug8610b/phpstan.neon
@@ -4,3 +4,6 @@ parameters:
         - .
     bootstrapFiles:
             - autoloader.php
+
+    ignoreErrors:
+        - '#Instantiated class DoesNotExist not found.#'

--- a/e2e/bug8610b/trigger-autoload.php
+++ b/e2e/bug8610b/trigger-autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+new A();
+
+new DoesNotExist();


### PR DESCRIPTION
the warning we want to reproduce is

```

 -- --------------------------------------------------------------------------- 
     Error                                                                      
 -- --------------------------------------------------------------------------- 
     Internal error: Internal error:                                            
     RecursiveDirectoryIterator::__construct(/home/runner/work/phpstan/phpstan  
     /e2e/bug8610b/classes): Failed to open directory:                          
     "PHPStan\Reflection\BetterReflection\SourceLocator\FileReadTrapStreamWrap  
     per::dir_opendir" call failed in file                                      
     /home/runner/work/phpstan/phpstan/e2e/bug8610b/trigger-autoload.php        
     Run PHPStan with -v option and post the stack trace to:                    
     https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md       
     Child process error (exit code 1): PHP Deprecated:  
     
     Creation of dynamic    
     property                                                                   
     PHPStan\Reflection\BetterReflection\SourceLocator\FileReadTrapStreamWrapp  
     er::$context is deprecated in                                              
     /home/runner/work/phpstan/phpstan/e2e/bug8610b/autoloader.php on line 4    
     
     Deprecated: Creation of dynamic property                                   
     PHPStan\Reflection\BetterReflection\SourceLocator\FileReadTrapStreamWrapp  
     er::$context is deprecated in                                              
     /home/runner/work/phpstan/phpstan/e2e/bug8610b/autoloader.php on line 4    
                                                                                
 -- --------------------------------------------------------------------------- 
 ```