### PR TITLE
Lock Broken Links Crawler Action to v3

### DIFF
--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Check for broken links"
-        uses: ScholliYT/Broken-Links-Crawler-Action@master
+        uses: ScholliYT/Broken-Links-Crawler-Action@v3
         with:
           website_url: 'https://phpstan.org/'
           resolve_before_filtering: 'true'


### PR DESCRIPTION
Locking to the latest major release, which is v3, prevents errors from using the latest version from master.  

Unfortunately, a false positive error from unstable code happened in run [3840562243](https://github.com/phpstan/phpstan/actions/runs/3840562243/jobs/6539775709) not long ago.
This repository doesn't need the latest features and is fine if it runs on the latest stable release.

@ondrejmirtes 