### PR TITLE
Disable extensions not running with 1.9.x anymore

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -55,24 +55,16 @@ jobs:
           - "8.1"
           - "8.2"
         extension-name:
-          - "phpstan-phpunit"
-          - "phpstan-strict-rules"
           - "phpstan-mockery"
-          - "phpstan-doctrine"
           - "phpstan-symfony"
           - "phpstan-php-parser"
           - "phpstan-deprecation-rules"
           - "phpdoc-parser"
           - "phpstan-nette"
           - "phpstan-dibi"
-          - "phpstan-webmozart-assert"
           - "phpstan-beberlei-assert"
         exclude:
           - extension-name: "phpstan-mockery"
-            php-version: "7.2"
-          - extension-name: "phpstan-phpunit"
-            php-version: "7.2"
-          - extension-name: "phpstan-doctrine"
             php-version: "7.2"
 
     steps:


### PR DESCRIPTION
similar as https://github.com/phpstan/phpstan/commit/3e10ce4c929e9eec1ca759d98019b6bc083f5707

the idea is to make 1.9.x PRs green again, e.g. https://github.com/phpstan/phpstan-src/pull/2146

an alternative to this approach might be to lock extensions to an old commit maybe that is still compatible with 1.9.x? in the matrix this could be something like `phpstan-strict-rules:<commit-hash>` or so..