### PR TITLE
Add a note about native parameter/return types in stubs

### DIFF
--- a/website/src/user-guide/stub-files.md
+++ b/website/src/user-guide/stub-files.md
@@ -4,7 +4,11 @@ title: Stub Files
 
 PHPStan depends on [PHPDocs](/writing-php-code/phpdocs-basics) in the analysed and used code. You might encounter a PHPDoc in your `vendor/` that's imprecise and causes an error in the analysis of your project that's a false positive.
 
-To mitigate this, you can write a stub file with the right PHPDoc. It's like source code, but PHPStan only reads PHPDocs from it. So the namespace and class/interface/trait/method/function names must match with the original source you're describing. Method bodies can stay empty, PHPStan is only interested in the PHPDocs. Native parameter types and return types added in stubs are also not considered. Get inspired by [the stubs PHPStan itself uses](https://github.com/phpstan/phpstan-src/tree/1.10.x/stubs) or by [the stubs from the phpstan-doctrine extension](https://github.com/phpstan/phpstan-doctrine/tree/1.3.x/stubs).
+To mitigate this, you can write a stub file with the right PHPDoc. It's like source code, but PHPStan only reads PHPDocs from it. So the namespace and class/interface/trait/method/function names must match with the original source you're describing. Method bodies can stay empty, PHPStan is only interested in the PHPDocs.
+
+Native parameter types and return types added in stubs are not considered.
+
+Get inspired by [the stubs PHPStan itself uses](https://github.com/phpstan/phpstan-src/tree/1.10.x/stubs) or by [the stubs from the phpstan-doctrine extension](https://github.com/phpstan/phpstan-doctrine/tree/1.3.x/stubs).
 
 Stub files aren't a replacement for [discovering symbols](/user-guide/discovering-symbols) so if you're trying to fix errors like "Function not found" or "Class not found", check out the [discovering symbols](/user-guide/discovering-symbols) guide instead.
 

--- a/website/src/user-guide/stub-files.md
+++ b/website/src/user-guide/stub-files.md
@@ -4,7 +4,7 @@ title: Stub Files
 
 PHPStan depends on [PHPDocs](/writing-php-code/phpdocs-basics) in the analysed and used code. You might encounter a PHPDoc in your `vendor/` that's imprecise and causes an error in the analysis of your project that's a false positive.
 
-To mitigate this, you can write a stub file with the right PHPDoc. It's like source code, but PHPStan only reads PHPDocs from it. So the namespace and class/interface/trait/method/function names must match with the original source you're describing. But method bodies can stay empty, PHPStan is only interested in the PHPDocs. Get inspired by [the stubs PHPStan itself uses](https://github.com/phpstan/phpstan-src/tree/1.10.x/stubs) or by [the stubs from the phpstan-doctrine extension](https://github.com/phpstan/phpstan-doctrine/tree/1.3.x/stubs).
+To mitigate this, you can write a stub file with the right PHPDoc. It's like source code, but PHPStan only reads PHPDocs from it. So the namespace and class/interface/trait/method/function names must match with the original source you're describing. Method bodies can stay empty, PHPStan is only interested in the PHPDocs. Native parameter types and return types added in stubs are also not considered. Get inspired by [the stubs PHPStan itself uses](https://github.com/phpstan/phpstan-src/tree/1.10.x/stubs) or by [the stubs from the phpstan-doctrine extension](https://github.com/phpstan/phpstan-doctrine/tree/1.3.x/stubs).
 
 Stub files aren't a replacement for [discovering symbols](/user-guide/discovering-symbols) so if you're trying to fix errors like "Function not found" or "Class not found", check out the [discovering symbols](/user-guide/discovering-symbols) guide instead.
 


### PR DESCRIPTION
> PHPStan is only interested in the PHPDocs

Already covers this, but I just spend a bunch of time debugging why my stub file where I added `: int` return types to a method wasn't considered.