### PR TITLE
Lock phpstan-beberlei-assert

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -66,7 +66,7 @@ jobs:
           - "phpstan-nette"
           - "phpstan-dibi"
           - "phpstan-webmozart-assert a1dfe1fef24e8ca78b79a2f16f82d4083fcafb10"
-          - "phpstan-beberlei-assert"
+          - "phpstan-beberlei-assert 94f5f0f59fa5744868f9830046c7d365f1ecd448"
         exclude:
           - extension-name: "phpstan-mockery"
             php-version: "7.2"


### PR DESCRIPTION
should unbreak the 1.9.x CI again (a little at least) :)