### PR TITLE
Fix link to type aliases in config reference

### DIFF
--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -569,9 +569,9 @@ parameters:
 Type aliases
 -------------
 
-Learn more about type aliases in [Writing PHP Code](/writing-php-code/phpdoc-types#type-aliases).
+Learn more about type aliases in [Writing PHP Code](/writing-php-code/phpdoc-types#global-type-aliases).
 
-Related config key: [`typeAliases`](/writing-php-code/phpdoc-types#type-aliases).
+Related config key: [`typeAliases`](/writing-php-code/phpdoc-types#global-type-aliases).
 
 Parallel processing
 ----------------


### PR DESCRIPTION
There is no `#type-aliases` anymore, but there is `#global-type-aliases` and `#local-type-aliases`.
As `#global-type-aliases` is above `#local-type-aliases` I'd link to the former.