### PR TITLE
Update phpdoc-types.md

### DIFF
--- a/website/src/writing-php-code/phpdoc-types.md
+++ b/website/src/writing-php-code/phpdoc-types.md
@@ -292,8 +292,9 @@ Array shapes
 This feature enables usage of strong types in codebases where arrays of various specific shapes are passed around functions and methods. PHPStan checks that the values in specified keys have the correct types:
 
 * `array{'foo': int, "bar": string}`
-* `array{0: int, 1?: int}` (key `1` is optional in the array)
+* `array{'foo': int, "bar"?: string}` (key `bar` is optional in the array)
 * `array{int, int}` (keys are `0` and `1`, also known as a tuple)
+* `array{0: int, 1?: int}` (key `1` is optional in the array)
 * `array{foo: int, bar: string}` (quotes around array keys for simple strings aren't necessary)
 
 This is different from [general arrays](#general-arrays) that mandate that all the keys and values must be of a specific homogeneous type. Array shapes allow each key and value to be different.


### PR DESCRIPTION
Added an example with string keys, because it's not so obvious that would work the same as with numeric keys.