### PR TITLE
Add "magic numbers detector" rules

### DIFF
--- a/website/src/user-guide/extension-library.md
+++ b/website/src/user-guide/extension-library.md
@@ -87,5 +87,6 @@ Unofficial extensions
 * [voku / phpstan-rules](https://github.com/voku/phpstan-rules)
 * [shipmonk / phpstan-rules](https://github.com/shipmonk-rnd/phpstan-rules)
 * [jiripudil / phpstan-sealed-classes](https://github.com/jiripudil/phpstan-sealed-classes)
+* [sidz / phpstan-rules](https://github.com/sidz/phpstan-rules)
 
 [**Find more on Packagist!**](https://packagist.org/?type=phpstan-extension)


### PR DESCRIPTION
I propose to add a 3rd-party package to documentation about detecting Magic Numbers in the code: https://github.com/sidz/phpstan-rules

This is a replacement for https://github.com/povils/phpmnd (standalone CLI tool)

We have already integrated it in several projects at our company and I personally add it to @infection (https://github.com/infection/infection/pull/1861)

Would love to share this great package with more developers.