### PR TITLE
docs: fix typos

### DIFF
--- a/website/src/_posts/detecting-unused-private-properties-methods-constants.md
+++ b/website/src/_posts/detecting-unused-private-properties-methods-constants.md
@@ -211,7 +211,7 @@ class Foo
 }
 ```
 
-The only way to reliably prevent this error is to always assign typed properties in the constructor. But there's a catch: PHP doesn't require this. The only language requirement is that you assign the property before you access it. You can also ask about unitialized state using `isset($this->count)` - that doesn't trigger the error.
+The only way to reliably prevent this error is to always assign typed properties in the constructor. But there's a catch: PHP doesn't require this. The only language requirement is that you assign the property before you access it. You can also ask about uninitialized state using `isset($this->count)` - that doesn't trigger the error.
 
 So it doesn't feel right to require the property assignment in the constructor in every case. PHPStan doesn't know the object's lifecycle, it's possible it's used correctly from the outside and that the code isn't actually broken. But for those who want to enforce typed properties being assigned in the constructor, there's a setting:
 

--- a/website/src/_posts/phpstan-0-9-a-huge-leap-forward.md
+++ b/website/src/_posts/phpstan-0-9-a-huge-leap-forward.md
@@ -58,11 +58,11 @@ Until now, the only fallback that could be used for values like this was `mixed[
 
 It's also possible to say what types of keys are in an array or an iterable, inspired by generics syntax from other languages: `array<KeyType, ValueType>`, `iterable<KeyType, ValueType>`.
 
-I believe that these possibilities will allow to move the ecosystem of PHP applications forward. I'd like to position PHPStan as the driver of innovation — thanks to less baggage, shorter feedback loops and rapid releases, it's able to fullfil real world needs faster than the language itself and even than IDEs. Let's hope they will follow suit and the support for intersection types and complex array notation comes sooner rather than later.
+I believe that these possibilities will allow to move the ecosystem of PHP applications forward. I'd like to position PHPStan as the driver of innovation — thanks to less baggage, shorter feedback loops and rapid releases, it's able to fulfil real world needs faster than the language itself and even than IDEs. Let's hope they will follow suit and the support for intersection types and complex array notation comes sooner rather than later.
 
 ## PHPUnit support
 
-If you've already used PHPStan along with PHPUnit, you might be familar with these errors:
+If you've already used PHPStan along with PHPUnit, you might be familiar with these errors:
 
 ```
 Parameter #3 $foo of class App\FooService constructor expects App\Foo, PHPUnit_Framework_MockObject_MockObject given.
@@ -79,7 +79,7 @@ I love deleting dead code. Having less code means there's less to maintain and r
 PHPStan is in a unique position of knowing the type of each variable so it can do advanced analysis of what code can be safely deleted. In 0.9, it's now able to detect:
 
 - Always false/always true calls to type-checking functions like `is_int`, `is_bool`, `is_array`.
-- Always false/always true occurences of `instanceof` with incompatible types and unknown classes on the right side.
+- Always false/always true occurrences of `instanceof` with incompatible types and unknown classes on the right side.
 - Always false comparison of different types on both sides of `===`and `!==`operators.
 - Variables in `isset()` that can never be defined, or they're always defined and non-nullable. This is especially useful if you use it for checking whether an array contains a specific key. Call to`isset($foo['key'])`might hide the fact that `$foo`does not exist at all, but PHPStan can tell you about it.
 

--- a/website/src/_posts/phpstan-1-9-0-with-phpdoc-asserts-list-type.md
+++ b/website/src/_posts/phpstan-1-9-0-with-phpdoc-asserts-list-type.md
@@ -6,7 +6,7 @@ tags: releases
 
 [PHPStan 1.9.0](https://github.com/phpstan/phpstan/releases/tag/1.9.0) has been a real community effort. You'll notice that every headlining feature of this release has been contributed by someone other than me, the maintainer. It's not that I don't like writing code anymore, but others get around to implementing new features faster while I'm down in the weeds hunting mysterious bugs.
 
-I'm now pressing the green "merge" button multiple times a day. My role has shifted from the main code contributor to quality assurance, project vision [^sayno], and taking care of the continous integration pipeline. I acknowledged this in [a recent letter to contributors](https://github.com/phpstan/phpstan/discussions/8228) which is well worth your read even if you don't contribute code yourself.
+I'm now pressing the green "merge" button multiple times a day. My role has shifted from the main code contributor to quality assurance, project vision [^sayno], and taking care of the continuous integration pipeline. I acknowledged this in [a recent letter to contributors](https://github.com/phpstan/phpstan/discussions/8228) which is well worth your read even if you don't contribute code yourself.
 
 [^sayno]: [A thousand No's for every Yes](https://www.youtube.com/watch?v=XAEPqUtra6E).
 

--- a/website/src/_posts/solving-phpstan-error-unsafe-usage-of-new-static.md
+++ b/website/src/_posts/solving-phpstan-error-unsafe-usage-of-new-static.md
@@ -4,7 +4,7 @@ date: 2021-01-13
 tags: guides
 ---
 
-This error is reported for `new static()` calls that might break once the class is extended, and the constructor is overriden with different parameters.
+This error is reported for `new static()` calls that might break once the class is extended, and the constructor is overridden with different parameters.
 
 Consider this example:
 

--- a/website/src/developing-extensions/collectors.md
+++ b/website/src/developing-extensions/collectors.md
@@ -6,7 +6,7 @@ title: Collectors
 
 If you want to write [custom rules](/developing-extensions/rules) that take a look at the whole codebase instead of a single AST node, you can take advantage of collectors.
 
-PHPStan rules are executed in isolation across multiple processess so it's not possible to share information from all the executions.
+PHPStan rules are executed in isolation across multiple processes so it's not possible to share information from all the executions.
 
 In order to write a specific category of rules like unused code detection, we need to use collectors.
 

--- a/website/src/developing-extensions/reflection.md
+++ b/website/src/developing-extensions/reflection.md
@@ -176,4 +176,4 @@ $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
 );
 ```
 
-It returns the `ResolvedPhpDocBlock` object. The [phpstan/phpdoc-parser](https://github.com/phpstan/phpdoc-parser) AST can be obtained by calling `getPhpDocNodes(): PhpDocNode[]` method. The whole PHPDoc is represented by a single root node. So why it returns an array of nodes? Because PHPStan merges PHPDocs from overriden methods to get the complete picture, so all of these nodes are available as a returned value from the `getPhpDocNodes()` method.
+It returns the `ResolvedPhpDocBlock` object. The [phpstan/phpdoc-parser](https://github.com/phpstan/phpdoc-parser) AST can be obtained by calling `getPhpDocNodes(): PhpDocNode[]` method. The whole PHPDoc is represented by a single root node. So why it returns an array of nodes? Because PHPStan merges PHPDocs from overridden methods to get the complete picture, so all of these nodes are available as a returned value from the `getPhpDocNodes()` method.

--- a/website/src/developing-extensions/rules.md
+++ b/website/src/developing-extensions/rules.md
@@ -315,7 +315,7 @@ Collectors
 
 If you want to write custom rules that take a look at the whole codebase instead of a single AST node, you can take advantage of collectors.
 
-PHPStan rules are executed in isolation across multiple processess so it's not possible to share information from all the executions.
+PHPStan rules are executed in isolation across multiple processes so it's not possible to share information from all the executions.
 
 In order to write a specific category of rules like unused code detection, we need to use collectors. [Learn more »](/developing-extensions/collectors)
 

--- a/website/src/writing-php-code/phpdocs-basics.md
+++ b/website/src/writing-php-code/phpdocs-basics.md
@@ -300,7 +300,7 @@ class Foo
 
 Install [`phpstan-deprecation-rules`](https://github.com/phpstan/phpstan-deprecation-rules) extension to have usages of deprecated symbols reported.
 
-The `@deprecated` PHPDoc tag is inherited to implicitly mark overriden methods in child classes also as deprecated:
+The `@deprecated` PHPDoc tag is inherited to implicitly mark overridden methods in child classes also as deprecated:
 
 ```php
 class Foo


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `website/src/_posts/detecting-unused-private-properties-methods-constants.md`
3 typos in `website/src/_posts/phpstan-0-9-a-huge-leap-forward.md`
1 typo in `website/src/_posts/phpstan-1-9-0-with-phpdoc-asserts-list-type.md`
1 typo in `website/src/_posts/solving-phpstan-error-unsafe-usage-of-new-static.md`
1 typo in `website/src/developing-extensions/collectors.md`
1 typo in `website/src/developing-extensions/reflection.md`
1 typo in `website/src/developing-extensions/rules.md`
1 typo in `website/src/writing-php-code/phpdocs-basics.md`


Best!