### PR TITLE
Documentation about Generics: add things about @use

### DIFF
--- a/website/src/_posts/generics-by-examples.md
+++ b/website/src/_posts/generics-by-examples.md
@@ -288,3 +288,31 @@ $d = foo(new MyOriginal());
 ```
 
 [Link to this example on the playground »](https://phpstan.org/r/a2f3ac06-8daf-4d59-a5da-4ef4f0a1ebe8)
+
+Specify template type variable of a generic trait when using it
+------------------------
+
+Traits can be generic too:
+
+```php
+/** @template T of Foo */
+trait Part
+{
+    /** @param T $item */
+    public function bar(Foo $item): void
+    {
+        // ...
+    }
+}
+```
+
+Into a class using a generic trait, the `@use` tag can be defined on the PHPDoc of the use clause:
+
+```php
+/** @template T of Foo */
+class Bar
+{
+    /** @use Part<T> */
+    use Part;
+}
+```

--- a/website/src/_posts/generics-in-php-using-phpdocs.md
+++ b/website/src/_posts/generics-in-php-using-phpdocs.md
@@ -147,7 +147,7 @@ When implementing a generic interface or extending a generic class, you have two
 - Preserve the genericness of the parent, the child class will also be generic
 - Specify the type variable of the interface/parent class. The child class will not be generic.
 
-Preserving the genericness is done by repeating the same `@template` tags above the child class and passing it to `@extends` and `@implements` tags:
+Preserving the genericness is done by repeating the same `@template` tags above the child class and passing it to `@extends`, `@implements` and `@use` tags:
 
 ```php
 /**

--- a/website/src/_posts/solving-phpstan-no-value-type-specified-in-iterable-type.md
+++ b/website/src/_posts/solving-phpstan-no-value-type-specified-in-iterable-type.md
@@ -81,7 +81,7 @@ public function getIterator(): \Traversable
 }
 ```
 
-The error can also be solved by using [generics](/blog/generics-in-php-using-phpdocs) with the help of `@extends` and `@implements` annotations. All three basic iterable types (`Iterator`, `IteratorAggregate`, `Traversable`) accept two type variables:
+The error can also be solved by using [generics](/blog/generics-in-php-using-phpdocs) with the help of `@extends`, `@implements` and `@use` annotations. All three basic iterable types (`Iterator`, `IteratorAggregate`, `Traversable`) accept two type variables:
 
 * `Iterator<TKey, TValue>`
 * `IteratorAggregate<TKey, TValue>`

--- a/website/src/writing-php-code/phpdocs-basics.md
+++ b/website/src/writing-php-code/phpdocs-basics.md
@@ -221,7 +221,7 @@ function foo($arg, ...$additional)
 Generics
 ---------------
 
-PHPDoc tags `@template`, `@template-covariant`, `@template-contravariant`, `@extends`, `@implements`, and `@uses` are reserved for generics. Learn more about [generics »](/blog/generics-in-php-using-phpdocs), [covariance »](/blog/whats-up-with-template-covariant), [contravariance »](https://jiripudil.cz/blog/contravariant-template-types), and [type projections »](/blog/guide-to-call-site-generic-variance). Also check out [Generics By Examples »](/blog/generics-by-examples).
+PHPDoc tags `@template`, `@template-covariant`, `@template-contravariant`, `@extends`, `@implements`, and `@use` are reserved for generics. Learn more about [generics »](/blog/generics-in-php-using-phpdocs), [covariance »](/blog/whats-up-with-template-covariant), [contravariance »](https://jiripudil.cz/blog/contravariant-template-types), and [type projections »](/blog/guide-to-call-site-generic-variance). Also check out [Generics By Examples »](/blog/generics-by-examples).
 
 Narrowing types after function call
 ----------------


### PR DESCRIPTION
Documentation about `@use` generics was missing. Added it.