### PR TITLE
Fully qualify the name of the `#[\Override]` attribute in documentation

### DIFF
--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -545,7 +545,7 @@ This effectively means that inline `@var` cast can only be used to narrow down o
 
 **default**: `false`
 
-When set to `true`, PHPStan reports missing `#[Override]` attribute above methods that override a method coming from their parent classes, implemented interfaces, or abstract method from a used trait.
+When set to `true`, PHPStan reports missing `#[\Override]` attribute above methods that override a method coming from their parent classes, implemented interfaces, or abstract method from a used trait.
 
 ```php
 class Foo
@@ -560,7 +560,7 @@ class Bar extends Foo
 {
 	public function doFoo(): void
 	{
-		// missing #[Override] above this method
+		// missing #[\Override] above this method
 	}
 }
 ```


### PR DESCRIPTION
see phpstan/phpstan-src@69176bcfc6ab1de112ef7ab0a6d94c704681fe96