### PR TITLE
Add = to --memory-limit example

### DIFF
--- a/website/src/user-guide/command-line-usage.md
+++ b/website/src/user-guide/command-line-usage.md
@@ -51,7 +51,7 @@ Turns off the progress bar. Does not accept any value.
 
 Specifies the memory limit in the same format `php.ini` accepts.
 
-Example: `--memory-limit 1G`
+Example: `--memory-limit=1G`
 
 ### `--xdebug`
 


### PR DESCRIPTION
This option seems to require an `=` symbol between the option name and value. It was failing until I added the `=` symbol.