### PR TITLE
Fix broken link in blog article

### DIFF
--- a/website/src/_posts/phpstan-0-9-a-huge-leap-forward.md
+++ b/website/src/_posts/phpstan-0-9-a-huge-leap-forward.md
@@ -4,7 +4,7 @@ date: 2017-11-29
 tags: releases
 ---
 
-It's been a year since [I unveiled PHPStan to the world](/blog/find-bugs-in-your-code-without-writing-tests). After 19 releases, more than 480,000 downloads (clocking around 3,600 daily during the workweek), 2,500 stars on GitHub and countless saved hours of developers that use it every day, PHPStan does so much more and is flourishing how I couldn't have ever imagine. It feels like [comparing the original iPhone to iPhone X](http://mashable.com/2017/11/06/how-many-original-iphone-screens-fit-apple-iphone-x-super-retina-display) just after a single year.
+It's been a year since [I unveiled PHPStan to the world](/blog/find-bugs-in-your-code-without-writing-tests). After 19 releases, more than 480,000 downloads (clocking around 3,600 daily during the workweek), 2,500 stars on GitHub and countless saved hours of developers that use it every day, PHPStan does so much more and is flourishing how I couldn't have ever imagine. It feels like [comparing the original iPhone to iPhone X](https://mashable.com/article/how-many-original-iphone-screens-fit-apple-iphone-x-super-retina-display) just after a single year.
 
 > In case you've never heard about PHPStan: It's a static analyser for PHP that focuses on finding bugs in your code. You can find out more about its basics in this [introductory article](/blog/find-bugs-in-your-code-without-writing-tests).
 


### PR DESCRIPTION
The [Check Website Links ](https://github.com/phpstan/phpstan/actions/workflows/website-links.yml) pipeline is currently failing because there is a broken link (404) on this blog page.

![image](https://github.com/phpstan/phpstan/assets/12571895/f241bc70-7d0c-4503-a06c-202511ab25ea)


Blog: https://phpstan.org/blog/phpstan-0-9-a-huge-leap-forward
Linked page: https://mashable.com/2017/11/06/how-many-original-iphone-screens-fit-apple-iphone-x-super-retina-display
New link to page: https://mashable.com/article/how-many-original-iphone-screens-fit-apple-iphone-x-super-retina-display