### PR TITLE
Fix for menu in dark mode (2nd try)

### DIFF
--- a/website/src/app.pcss
+++ b/website/src/app.pcss
@@ -11,11 +11,18 @@ html.dark {
 	background-color: #000 !important;
 	color-scheme: dark;
 	@apply min-h-full;
-	@apply invert hue-rotate-180;
 
 	body {
 		color: #000;
 		color-scheme: auto;
+	}
+
+	body > div {
+		background-color: #000 !important;
+	}
+
+	body > div > * {
+		@apply invert hue-rotate-180;
 	}
 
 	img, video {

--- a/website/src/app.pcss
+++ b/website/src/app.pcss
@@ -11,11 +11,11 @@ html.dark {
 	background-color: #000 !important;
 	color-scheme: dark;
 	@apply min-h-full;
+	@apply invert hue-rotate-180;
 
 	body {
 		color: #000;
 		color-scheme: auto;
-		@apply invert hue-rotate-180;
 	}
 
 	img, video {

--- a/website/src/app.pcss
+++ b/website/src/app.pcss
@@ -18,7 +18,7 @@ html.dark {
 	}
 
 	body > div {
-		background-color: #000 !important;
+		background-color: #060504 !important;
 	}
 
 	body > div > * {


### PR DESCRIPTION
Adding CSS filters causes a change in page containers, in this case causing the (usually) sticky menu to become static.

More information about this: https://stackoverflow.com/a/52937920/314056

In principle, using filters has some limits and/or side effects. This could be such a case. I've managed to find a workable solution in this PR, (that I tested a bit more than the last), but it's not exactly pretty. :)