### PR TITLE
feat(docker): add patch cli support

### DIFF
--- a/docker/Dockerfile.php.8.0
+++ b/docker/Dockerfile.php.8.0
@@ -7,7 +7,7 @@ ENV COMPOSER_HOME="/composer" \
     PHPSTAN_PRO_WEB_PORT="11111"
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
-    && apk add --no-cache git
+    && apk add --no-cache git patch
 
 VOLUME ["/app"]
 

--- a/docker/Dockerfile.php.8.1
+++ b/docker/Dockerfile.php.8.1
@@ -7,7 +7,7 @@ ENV COMPOSER_HOME="/composer" \
     PHPSTAN_PRO_WEB_PORT="11111"
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
-    && apk add --no-cache git
+    && apk add --no-cache git patch
 
 VOLUME ["/app"]
 

--- a/docker/Dockerfile.php.8.2
+++ b/docker/Dockerfile.php.8.2
@@ -7,7 +7,7 @@ ENV COMPOSER_HOME="/composer" \
     PHPSTAN_PRO_WEB_PORT="11111"
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
-    && apk add --no-cache git
+    && apk add --no-cache git patch
 
 VOLUME ["/app"]
 

--- a/docker/Dockerfile.php.8.3
+++ b/docker/Dockerfile.php.8.3
@@ -7,7 +7,7 @@ ENV COMPOSER_HOME="/composer" \
     PHPSTAN_PRO_WEB_PORT="11111"
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
-    && apk add --no-cache git
+    && apk add --no-cache git patch
 
 VOLUME ["/app"]
 


### PR DESCRIPTION
Adds cli `patch` support to the docker image - for example when using `cweagans/composer-patches` that may or may not change stuff. But when running with enforcing patches are applied the current images fail as there is no patch support.

If I need to add more detail just ask!

Fixes https://github.com/phpstan/phpstan/issues/11499