### PR TITLE
Reenable shipmonk integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,7 +113,7 @@ jobs:
           - php-version: 8.1
             name: shipmonk/phpstan-rules tests
             script: |
-              git clone https://github.com/shipmonk-rnd/phpstan-rules.git -b 3.2.1 --depth 1 e2e/integration/repo
+              git clone https://github.com/shipmonk-rnd/phpstan-rules.git -b phpstan-20 --depth 1 e2e/integration/repo
               cd e2e/integration/repo
               composer install
               cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar
@@ -408,7 +408,7 @@ jobs:
             baseline-file: doctrine-persistence-baseline.neon
           - php-version: 8.1
             repo: shipmonk-rnd/phpstan-rules
-            ref: 3.2.1
+            ref: phpstan-20
             setup: |
               composer install
               cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -110,16 +110,16 @@ jobs:
               cp ../../../phpstan vendor/phpstan/phpstan/phpstan
               cp ../../../bootstrap.php vendor/phpstan/phpstan/bootstrap.php
               vendor/bin/phpunit tests/PHPStan
-#          - php-version: 8.1
-#            name: shipmonk/phpstan-rules tests
-#            script: |
-#              git clone https://github.com/shipmonk-rnd/phpstan-rules.git -b 3.1.0 --depth 1 e2e/integration/repo
-#              cd e2e/integration/repo
-#              composer install
-#              cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar
-#              cp ../../../phpstan vendor/phpstan/phpstan/phpstan
-#              cp ../../../bootstrap.php vendor/phpstan/phpstan/bootstrap.php
-#              vendor/bin/phpunit tests
+          - php-version: 8.1
+            name: shipmonk/phpstan-rules tests
+            script: |
+              git clone https://github.com/shipmonk-rnd/phpstan-rules.git -b 3.2.1 --depth 1 e2e/integration/repo
+              cd e2e/integration/repo
+              composer install
+              cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar
+              cp ../../../phpstan vendor/phpstan/phpstan/phpstan
+              cp ../../../bootstrap.php vendor/phpstan/phpstan/bootstrap.php
+              vendor/bin/phpunit tests
 #          - php-version: 8.1
 #            name: efabrica-team/phpstan-latte tests
 #            script: |
@@ -406,16 +406,16 @@ jobs:
               composer install
             phpstan-command: ../../../phpstan.phar analyse -c ../doctrine-persistence.neon
             baseline-file: doctrine-persistence-baseline.neon
-#          - php-version: 8.1
-#            repo: shipmonk-rnd/phpstan-rules
-#            ref: 3.1.0
-#            setup: |
-#              composer install
-#              cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar
-#              cp ../../../phpstan vendor/phpstan/phpstan/phpstan
-#              cp ../../../bootstrap.php vendor/phpstan/phpstan/bootstrap.php
-#            phpstan-command: ../../../phpstan.phar analyse -c ../shipmonk.neon
-#            baseline-file: shipmonk-rnd-baseline.neon
+          - php-version: 8.1
+            repo: shipmonk-rnd/phpstan-rules
+            ref: 3.2.1
+            setup: |
+              composer install
+              cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar
+              cp ../../../phpstan vendor/phpstan/phpstan/phpstan
+              cp ../../../bootstrap.php vendor/phpstan/phpstan/bootstrap.php
+            phpstan-command: ../../../phpstan.phar analyse -c ../shipmonk.neon
+            baseline-file: shipmonk-rnd-baseline.neon
           - php-version: 8.1
             repo: drupal/drupal
             ref: 10.0.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -408,7 +408,7 @@ jobs:
             baseline-file: doctrine-persistence-baseline.neon
           - php-version: 8.1
             repo: shipmonk-rnd/phpstan-rules
-            ref: phpstan-20
+            ref: 4.0.0
             setup: |
               composer install
               cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,7 +113,7 @@ jobs:
           - php-version: 8.1
             name: shipmonk/phpstan-rules tests
             script: |
-              git clone https://github.com/shipmonk-rnd/phpstan-rules.git -b phpstan-20 --depth 1 e2e/integration/repo
+              git clone https://github.com/shipmonk-rnd/phpstan-rules.git -b 4.0.0 --depth 1 e2e/integration/repo
               cd e2e/integration/repo
               composer install
               cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar

--- a/e2e/integration/shipmonk-rnd-baseline.neon
+++ b/e2e/integration/shipmonk-rnd-baseline.neon
@@ -1,5 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: '#^PHPDoc tag @var with type array\{list\<string\>, list\<string\>\} is not subtype of type array\{list\<string\>, list\<non\-empty\-string\>\}\.$#'
-			path: repo/tests/RuleTestCase.php


### PR DESCRIPTION
It is using our WIP branch that is already green for PHPStan 2.0 in our CI: https://github.com/shipmonk-rnd/phpstan-rules/pull/274/
