### PR TITLE
website: add link to faker extension

### DIFF
--- a/website/src/user-guide/extension-library.md
+++ b/website/src/user-guide/extension-library.md
@@ -71,6 +71,7 @@ Unofficial extensions
 * [CakePHP](https://github.com/CakeDC/cakephp-phpstan)
 * [Safe PHP](https://github.com/thecodingmachine/phpstan-safe-rule)
 * [psr/log](https://github.com/struggle-for-php/sfp-phpstan-psr-log)
+* [Faker](https://github.com/calebdw/fakerstan)
 
 3rd party rules
 -----------------


### PR DESCRIPTION
Hello!

I just created an extension for [Faker](https://fakerphp.org) and thought it would be helpful to link to it.

Thanks!