### PR TITLE
Fix code example in type-specifying-extensions doc

### DIFF
--- a/website/src/developing-extensions/type-specifying-extensions.md
+++ b/website/src/developing-extensions/type-specifying-extensions.md
@@ -93,7 +93,7 @@ public function specifyTypes(
 
 	// Assuming extension implements \PHPStan\Analyser\TypeSpecifierAwareExtension
 
-	return $this->typeSpecifier->create($expr, $type, TypeSpecifierContext::createTruthy());
+	return $this->typeSpecifier->create($expr, $type, TypeSpecifierContext::createTruthy(), $scope);
 }
 ```
 


### PR DESCRIPTION
When fiddling around type specifying extension I have noticed docs aren't up to date with PHPStan 2.0 as `$scope` is now required parameter in `TypeSpecifier::create`. I'm not sure if this is right repo to contribute such change, but I have not found it anywhere else. 