### PR TITLE
Fix `#[\Deprecated]` headline in phpstan-2-1-support-for-php-8-4-property-hooks-more.md

### DIFF
--- a/website/src/_posts/phpstan-2-1-support-for-php-8-4-property-hooks-more.md
+++ b/website/src/_posts/phpstan-2-1-support-for-php-8-4-property-hooks-more.md
@@ -105,7 +105,7 @@ This feature is much [easier to grasp](https://wiki.php.net/rfc/asymmetric-visib
 
 Similarly to property hooks, I also have a few nice-to-have todos [left for later](https://github.com/phpstan/phpstan/issues/12347).
 
-`[#Deprecated]` attribute
+`#[\Deprecated]` attribute
 ---------------------
 
 [This attribute](https://wiki.php.net/rfc/deprecated_attribute) allows the PHP engine [trigger deprecated warnings](https://3v4l.org/MEJTq).


### PR DESCRIPTION
see also #10136.