### PR TITLE
docs: Reflection - add `getNamedArgumentsVariants()` as parameter

### DIFF
--- a/website/src/developing-extensions/reflection.md
+++ b/website/src/developing-extensions/reflection.md
@@ -38,12 +38,26 @@ If you have the `PhpParser\Node\Expr\FuncCall` expression, you can obtain the ri
 $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$funcCall->getArgs(),
-	$functionReflection->getVariants(),
-	$functionReflection->getNamedArgumentsVariants()
+	$functionReflection->getVariants()
 );
 $parameters = $variant->getParameters();
 $returnType = $variant->getReturnType();
 ```
+
+<div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 mb-4" role="alert">
+
+If you are writing a [Custom Rule](/developing-extensions/rules), working with multi-variant built-in functions, like [`strtok`](https://www.php.net/manual/en/function.strtok.php), and you need proper resolution of named parameters, be sure to pass the optional fourth parameter to `selectFromArgs()` like this:
+
+```php
+$variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
+	$scope,
+	$funcCall->getArgs(),
+	$functionReflection->getVariants(),
+	$functionReflection->getNamedArgumentsVariants()
+);
+```
+
+</div>
 
 Global constants
 ------------------
@@ -111,12 +125,26 @@ If you have the `PhpParser\Node\Expr\MethodCall` expression, you can obtain the 
 $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$methodCall->getArgs(),
-	$methodReflection->getVariants(),
-	$methodReflection->getNamedArgumentsVariants()
+	$methodReflection->getVariants()
 );
 $parameters = $variant->getParameters();
 $returnType = $variant->getReturnType();
 ```
+
+<div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 mb-4" role="alert">
+
+If you are writing a [Custom Rule](/developing-extensions/rules), working with multi-variant built-in functions, like [`PDO::query()`](https://www.php.net/manual/en/pdo.query.php), and you need proper resolution of named parameters, be sure to pass the optional fourth parameter to `selectFromArgs()` like this:
+
+```php
+$variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
+	$scope,
+	$methodCall->getArgs(),
+	$methodReflection->getVariants(),
+	$methodReflection->getNamedArgumentsVariants()
+);
+```
+
+</div>
 
 Class constants
 ------------------

--- a/website/src/developing-extensions/reflection.md
+++ b/website/src/developing-extensions/reflection.md
@@ -38,7 +38,8 @@ If you have the `PhpParser\Node\Expr\FuncCall` expression, you can obtain the ri
 $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$funcCall->getArgs(),
-	$functionReflection->getVariants()
+	$functionReflection->getVariants(),
+	$functionReflection->getNamedArgumentsVariants()
 );
 $parameters = $variant->getParameters();
 $returnType = $variant->getReturnType();

--- a/website/src/developing-extensions/reflection.md
+++ b/website/src/developing-extensions/reflection.md
@@ -57,6 +57,32 @@ $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 );
 ```
 
+<details>
+    <summary class="font-bold">Show example</summary>
+
+Function call to analyze:
+```php
+strtok(string: 'This is\tan example\nstring', token: " \n\t");
+```
+
+Get parameter names like this:
+```php
+$parameters = $variant->getParameters();
+$parameterNames = array_map(fn ($parameter) => $parameter->getName(), $parameters);
+```
+
+Without the optional fourth parameter, the resolved `$parameterNames` will be incorrect:
+```php
+$parameterNames = ['str', 'token'];
+```
+
+With the optional fourth parameter, the resolved `$parameterNames` will be correct:
+```php
+$parameterNames = ['string', 'token'];
+```
+
+</details>
+
 </div>
 
 Global constants
@@ -143,6 +169,32 @@ $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$methodReflection->getNamedArgumentsVariants()
 );
 ```
+
+<details>
+    <summary class="font-bold">Show example</summary>
+
+Function call to analyze:
+```php
+$pdo->query(query: 'SELECT * FROM users', fetchMode: PDO::FETCH_ASSOC);
+```
+
+Get parameter names like this:
+```php
+$parameters = $variant->getParameters();
+$parameterNames = array_map(fn ($parameter) => $parameter->getName(), $parameters);
+```
+
+Without the optional fourth parameter, the resolved `$parameterNames` will be incorrect:
+```php
+$parameterNames = ['query', 'fetchMode', 'fetchModeArgs', 'ctorargs'];
+```
+
+With the optional fourth parameter, the resolved `$parameterNames` will be correct:
+```php
+$parameterNames = ['query', 'fetchMode'];
+```
+
+</details>
 
 </div>
 

--- a/website/src/developing-extensions/reflection.md
+++ b/website/src/developing-extensions/reflection.md
@@ -46,16 +46,15 @@ $returnType = $variant->getReturnType();
 
 <div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 mb-4" role="alert">
 
-If you are writing a [Custom Rule](/developing-extensions/rules), working with multi-variant built-in functions, like [`strtok`](https://www.php.net/manual/en/function.strtok.php), and you need proper resolution of named parameters, be sure to pass the optional fourth parameter to `selectFromArgs()` like this:
+If you are writing a [custom rule](/developing-extensions/rules), working with multi-variant built-in functions, like [`strtok`](https://www.php.net/manual/en/function.strtok.php), and you need proper resolution of named parameters, be sure to pass the optional fourth parameter to `selectFromArgs()` like this:
 
 ```php
 $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$funcCall->getArgs(),
 	$functionReflection->getVariants(),
-	$functionReflection->getNamedArgumentsVariants()
+	$functionReflection->getNamedArgumentsVariants(),
 );
-```
 
 <details>
     <summary class="font-bold">Show example</summary>
@@ -159,16 +158,15 @@ $returnType = $variant->getReturnType();
 
 <div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 mb-4" role="alert">
 
-If you are writing a [Custom Rule](/developing-extensions/rules), working with multi-variant built-in functions, like [`PDO::query()`](https://www.php.net/manual/en/pdo.query.php), and you need proper resolution of named parameters, be sure to pass the optional fourth parameter to `selectFromArgs()` like this:
+If you are writing a [custom rule](/developing-extensions/rules), working with multi-variant built-in functions, like [`PDO::query()`](https://www.php.net/manual/en/pdo.query.php), and you need proper resolution of named parameters, be sure to pass the optional fourth parameter to `selectFromArgs()` like this:
 
 ```php
 $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$methodCall->getArgs(),
 	$methodReflection->getVariants(),
-	$methodReflection->getNamedArgumentsVariants()
+	$methodReflection->getNamedArgumentsVariants(),
 );
-```
 
 <details>
     <summary class="font-bold">Show example</summary>

--- a/website/src/developing-extensions/reflection.md
+++ b/website/src/developing-extensions/reflection.md
@@ -111,7 +111,8 @@ If you have the `PhpParser\Node\Expr\MethodCall` expression, you can obtain the 
 $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$methodCall->getArgs(),
-	$methodReflection->getVariants()
+	$methodReflection->getVariants(),
+	$methodReflection->getNamedArgumentsVariants()
 );
 $parameters = $variant->getParameters();
 $returnType = $variant->getReturnType();


### PR DESCRIPTION
The optional parameter `$namedArgumentsVariants` for `selectFromArgs()` was added here: 
- https://github.com/phpstan/phpstan-src/pull/2726

While creating some custom rules we've noticed that named arguments were not correctly identified (e.g. when using `join()`).

This PR adds the newly (2023) introduced parameter to the docs.

> [!NOTE]
> I did not find exact details/information about when exactly this parameter is necessary, but adding it to `selectFromArgs()` did improve parameter reflection in all of our cases.
> 
> You **may add some additional notes** to the docs if you think there's more explanation needed.