### PR TITLE
docs: Reflection - fix unintended changes

### DIFF
--- a/website/src/developing-extensions/reflection.md
+++ b/website/src/developing-extensions/reflection.md
@@ -53,7 +53,7 @@ $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$funcCall->getArgs(),
 	$functionReflection->getVariants(),
-	$functionReflection->getNamedArgumentsVariants()
+	$functionReflection->getNamedArgumentsVariants(),
 );
 ```
 
@@ -166,7 +166,7 @@ $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$methodCall->getArgs(),
 	$methodReflection->getVariants(),
-	$methodReflection->getNamedArgumentsVariants()
+	$methodReflection->getNamedArgumentsVariants(),
 );
 ```
 

--- a/website/src/developing-extensions/reflection.md
+++ b/website/src/developing-extensions/reflection.md
@@ -53,8 +53,9 @@ $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$funcCall->getArgs(),
 	$functionReflection->getVariants(),
-	$functionReflection->getNamedArgumentsVariants(),
+	$functionReflection->getNamedArgumentsVariants()
 );
+```
 
 <details>
     <summary class="font-bold">Show example</summary>
@@ -165,8 +166,9 @@ $variant = PHPStan\Reflection\ParametersAcceptorSelector::selectFromArgs(
 	$scope,
 	$methodCall->getArgs(),
 	$methodReflection->getVariants(),
-	$methodReflection->getNamedArgumentsVariants(),
+	$methodReflection->getNamedArgumentsVariants()
 );
+```
 
 <details>
     <summary class="font-bold">Show example</summary>


### PR DESCRIPTION
Thanks for merging #12567, @ondrejmirtes!

Unfortunately, the end result looks a bit weird. This PR will fix two small issues:


1. I think the last <code>```</code> after the PHP code block should not have been deleted. The collapsible section (`<details><summary>...`) became part of the code block now.
  
    ![grafik](https://github.com/user-attachments/assets/b1be8873-4ecd-40bb-953d-4c9970b5e3de)

3. Also, the **existing** code block did not have a trailing comma `,` after the last parameter. I removed it from the **new** code block as well.
  
    ![grafik](https://github.com/user-attachments/assets/0d3785ef-329a-4ddb-9083-5c7bade9f641)
    ![grafik](https://github.com/user-attachments/assets/cbb9f856-8848-4c7e-81ee-3a9ec4c69de7)


