### PR TITLE
fix: prefer !cancelled() over always()

### DIFF
--- a/website/src/user-guide/result-cache.md
+++ b/website/src/user-guide/result-cache.md
@@ -81,7 +81,7 @@ Because GitHub Actions do not overwrite existing cache entries with the same key
 
   - name: "Save result cache"
     uses: actions/cache/save@v4
-    if: always()
+    if: {% raw %}${{ !cancelled() }}{% endraw %}
     with:
       path: tmp # same as in phpstan.neon
       key: "phpstan-result-cache-{% raw %}${{ github.run_id }}"{% endraw %}


### PR DESCRIPTION
see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions\#always

> Warning

> Avoid using always for any task that could suffer from a critical failure, for example: getting sources, otherwise the workflow may hang until it times out. If you want to run a job or step regardless of its success or failure, use the recommended alternative: if: ${{ !cancelled() }}

fixes: https://github.com/phpstan/phpstan/pull/12655#issuecomment-2688434715
renders correctly: 
<img width="720" alt="image" src="https://github.com/user-attachments/assets/11e2fcf4-552d-4d63-b015-a79bcfe195b2" />
