### PR TITLE
Include `discoveringSymbols` in tips example

### DIFF
--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -93,7 +93,8 @@ Discovering symbols
 Learn more about discovering symbols in the [user guide](/user-guide/discovering-symbols).
 
 Related config keys: [`scanFiles`](/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies),
-[`scanDirectories`](/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies).
+[`scanDirectories`](/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies),
+[`tips.discoveringSymbols`](/user-guide/discovering-symbols.md#disable-the-symbol-discovery-error-tip).
 
 Bootstrap
 ------------------
@@ -740,7 +741,6 @@ If you want to turn off a tip that PHPStan shows, you can do this in the tips se
 ```yaml
 parameters:
     tips:
-        discoveringSymbols: false
         treatPhpDocTypesAsCertain: false
 ```
 

--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -94,7 +94,7 @@ Learn more about discovering symbols in the [user guide](/user-guide/discovering
 
 Related config keys: [`scanFiles`](/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies),
 [`scanDirectories`](/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies),
-[`tips.discoveringSymbols`](/user-guide/discovering-symbolsdisable-the-symbol-discovery-error-tip).
+[`tips.discoveringSymbols`](/user-guide/discovering-symbols#disable-the-symbol-discovery-error-tip).
 
 Bootstrap
 ------------------

--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -94,7 +94,7 @@ Learn more about discovering symbols in the [user guide](/user-guide/discovering
 
 Related config keys: [`scanFiles`](/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies),
 [`scanDirectories`](/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies),
-[`tips.discoveringSymbols`](/user-guide/discovering-symbols.md#disable-the-symbol-discovery-error-tip).
+[`tips.discoveringSymbols`](/user-guide/discovering-symbolsdisable-the-symbol-discovery-error-tip).
 
 Bootstrap
 ------------------

--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -740,6 +740,7 @@ If you want to turn off a tip that PHPStan shows, you can do this in the tips se
 ```yaml
 parameters:
     tips:
+        discoveringSymbols: false
         treatPhpDocTypesAsCertain: false
 ```
 

--- a/website/src/user-guide/discovering-symbols.md
+++ b/website/src/user-guide/discovering-symbols.md
@@ -130,6 +130,8 @@ parameters:
 Disable the symbol discovery error tip
 ---------------------------
 
+<div class="text-xs inline-block border border-green-600 text-green-600 bg-green-100 rounded px-1 mb-4">Available in PHPStan 2.1.12</div>
+
 PHPStan provides a tip with a link to this article whenever it encounters symbol discovery errors.
 
 To disable that tip, add the following to your configuration:

--- a/website/src/user-guide/discovering-symbols.md
+++ b/website/src/user-guide/discovering-symbols.md
@@ -126,3 +126,15 @@ parameters:
     scanDirectories:
         - phar://%currentWorkingDirectory%/bin/robo.phar
 ```
+
+Disable the symbol discovery error tip
+---------------------------
+
+PHPStan provides a tip with a link to an article whenever it encounters symbol discovery errors.
+To disable that tip, add the following to your configuration:
+
+```yaml
+parameters:
+    tips:
+        discoveringSymbols: false
+```

--- a/website/src/user-guide/discovering-symbols.md
+++ b/website/src/user-guide/discovering-symbols.md
@@ -130,7 +130,8 @@ parameters:
 Disable the symbol discovery error tip
 ---------------------------
 
-PHPStan provides a tip with a link to an article whenever it encounters symbol discovery errors.
+PHPStan provides a tip with a link to this article whenever it encounters symbol discovery errors.
+
 To disable that tip, add the following to your configuration:
 
 ```yaml


### PR DESCRIPTION
Not the best section of the docs maybe, but it should be mentioned somehow.

for https://github.com/phpstan/phpstan-src/pull/3929