### PR TITLE
CustomDeprecationExtension: fix typehint

### DIFF
--- a/website/src/developing-extensions/custom-deprecations.md
+++ b/website/src/developing-extensions/custom-deprecations.md
@@ -33,7 +33,10 @@ use PHPStan\Reflection\Deprecation\ClassDeprecationExtension;
 class CustomDeprecationExtension implements ClassDeprecationExtension
 {
 
-	public function getClassDeprecation(ReflectionClass|ReflectionEnum $reflection): ?Deprecation
+	/**
+	 * @param ReflectionClass|ReflectionEnum $reflection
+	 */
+	public function getClassDeprecation($reflection): ?Deprecation
 	{
 		foreach ($reflection->getAttributes(MyDeprecated::class) as $attribute) {
 			$description = $attribute->getArguments()[0] ?? $attribute->getArguments()['description'] ?? null;


### PR DESCRIPTION
Native typehint is in phpstan-src, but it gets downgraded in phar.