### PR TITLE
Clarify consumption of custom parameters

### DIFF
--- a/website/src/developing-extensions/dependency-injection-configuration.md
+++ b/website/src/developing-extensions/dependency-injection-configuration.md
@@ -114,6 +114,7 @@ parameters:
 
 services:
 	-
+		# App\MyExtension has "myOwnParameter" constructor parameter
 		class: App\MyExtension
 		arguments:
 			myOwnParameter: %myExtension.myOwnParameter%


### PR DESCRIPTION
The "autowiring" section describes how parameters are consumed, but the "custom parameters" section didn't, which had me confused because I didn't think the autowiring docs were related to what I was working on