### PR TITLE
playground: add user config editor

### DIFF
--- a/playground-api/handler.ts
+++ b/playground-api/handler.ts
@@ -36,6 +36,7 @@ async function analyseResultInternal(
 	runStrictRules: boolean,
 	runBleedingEdge: boolean,
 	treatPhpDocTypesAsCertain: boolean,
+	userConfig: string,
 	phpVersions: number[],
 ): Promise<any[]> {
 	const lambdaPromises: [Promise<PromiseResult<Lambda.InvocationResponse, AWSError>>, number][] = [];
@@ -48,6 +49,7 @@ async function analyseResultInternal(
 				strictRules: runStrictRules,
 				bleedingEdge: runBleedingEdge,
 				treatPhpDocTypesAsCertain: treatPhpDocTypesAsCertain,
+				userConfig: userConfig,
 				phpVersion: phpVersion,
 			}),
 		}).promise(), phpVersion]);
@@ -200,6 +202,7 @@ async function analyseResult(request: HttpRequest): Promise<HttpResponse> {
 		const runStrictRules = typeof json.strictRules !== 'undefined' ? json.strictRules : false;
 		const runBleedingEdge = typeof json.bleedingEdge !== 'undefined' ? json.bleedingEdge : false;
 		const treatPhpDocTypesAsCertain = typeof json.treatPhpDocTypesAsCertain !== 'undefined' ? json.treatPhpDocTypesAsCertain : true;
+		const userConfig = typeof json.userConfig !== 'undefined' ? json.userConfig : '';
 		const saveResult: boolean = typeof json.saveResult !== 'undefined' ? json.saveResult : true;
 
 		const versionedErrors = await analyseResultInternal(
@@ -208,6 +211,7 @@ async function analyseResult(request: HttpRequest): Promise<HttpResponse> {
 			runStrictRules,
 			runBleedingEdge,
 			treatPhpDocTypesAsCertain,
+			userConfig,
 			[70200, 70300, 70400, 80000, 80100, 80200, 80300, 80400],
 		);
 		const response: any = {
@@ -230,6 +234,7 @@ async function analyseResult(request: HttpRequest): Promise<HttpResponse> {
 						strictRules: runStrictRules,
 						bleedingEdge: runBleedingEdge,
 						treatPhpDocTypesAsCertain: treatPhpDocTypesAsCertain,
+						userConfig: userConfig,
 					},
 				}),
 			}).promise();
@@ -259,6 +264,7 @@ async function retrieveResult(request: HttpRequest): Promise<HttpResponse> {
 		const strictRules = typeof json.config.strictRules !== 'undefined' ? json.config.strictRules : false;
 		const bleedingEdge = typeof json.config.bleedingEdge !== 'undefined' ? json.config.bleedingEdge : false;
 		const treatPhpDocTypesAsCertain = typeof json.config.treatPhpDocTypesAsCertain !== 'undefined' ? json.config.treatPhpDocTypesAsCertain : true;
+		const userConfig = typeof json.config.userConfig !== 'undefined' ? json.config.userConfig : '';
 
 		let phpVersionsToAnalyse: number[] = [70200, 70300, 70400, 80000];
 		if (typeof json.versionedErrors !== 'undefined') {
@@ -286,6 +292,7 @@ async function retrieveResult(request: HttpRequest): Promise<HttpResponse> {
 			strictRules,
 			bleedingEdge,
 			treatPhpDocTypesAsCertain,
+			userConfig,
 			phpVersionsToAnalyse,
 		);
 		const newTabs = createTabs(newResult);
@@ -299,6 +306,7 @@ async function retrieveResult(request: HttpRequest): Promise<HttpResponse> {
 				strictRules,
 				bleedingEdge,
 				treatPhpDocTypesAsCertain,
+				userConfig,
 			},
 			upToDateTabs: newTabs,
 			upToDateVersionedErrors: newResult,
@@ -382,6 +390,7 @@ async function retrieveSample(request: HttpRequest): Promise<HttpResponse> {
 		const strictRules = typeof json.config.strictRules !== 'undefined' ? json.config.strictRules : false;
 		const bleedingEdge = typeof json.config.bleedingEdge !== 'undefined' ? json.config.bleedingEdge : false;
 		const treatPhpDocTypesAsCertain = typeof json.config.treatPhpDocTypesAsCertain !== 'undefined' ? json.config.treatPhpDocTypesAsCertain : true;
+		const userConfig = typeof json.config.userConfig !== 'undefined' ? json.config.userConfig : '';
 
 		const bodyJson: any = {
 			code: json.code,
@@ -392,6 +401,7 @@ async function retrieveSample(request: HttpRequest): Promise<HttpResponse> {
 				strictRules,
 				bleedingEdge,
 				treatPhpDocTypesAsCertain,
+				userConfig,
 			},
 		};
 		if (typeof json.versionedErrors !== 'undefined') {
@@ -448,6 +458,7 @@ async function retrieveLegacyResult(request: HttpRequest): Promise<HttpResponse>
 					strictRules: false,
 					bleedingEdge: false,
 					treatPhpDocTypesAsCertain: true,
+					userConfig: '',
 				},
 			}),
 		});

--- a/playground-runner/bref.php
+++ b/playground-runner/bref.php
@@ -37,12 +37,18 @@ return function ($event) use ($phpstanVersion) {
 	$level = $event['level'];
 	$codePath = '/tmp/tmp.php';
 	file_put_contents($codePath, $code);
+        $userConfigPath = '/tmp/user-config.neon';
+        $userConfig = $event['userConfig'] ?? null;
+        if ($userConfig) {
+            file_put_contents($userConfigPath, $event['userConfig']);
+        }
 
 	$rootDir = getenv('LAMBDA_TASK_ROOT');
 	$configFiles = [
 		$rootDir . '/playground.neon',
 	];
 	foreach ([
+                'userConfig' => $userConfigPath,
 		'strictRules' => $rootDir . '/vendor/phpstan/phpstan-strict-rules/rules.neon',
 		'bleedingEdge' => 'phar://' . $rootDir . '/vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon',
 	] as $key => $file) {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@codemirror/commands": "^6.2.2",
 				"@codemirror/lang-php": "^6.0.1",
+				"@codemirror/lang-yaml": "^6.1.2",
 				"@codemirror/language": "^6.6.0",
 				"@codemirror/state": "^6.2.0",
 				"@codemirror/view": "^6.9.2",
@@ -850,6 +851,21 @@
 				"@lezer/php": "^1.0.0"
 			}
 		},
+		"node_modules/@codemirror/lang-yaml": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.2.tgz",
+			"integrity": "sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.0.0",
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@lezer/common": "^1.2.0",
+				"@lezer/highlight": "^1.2.0",
+				"@lezer/lr": "^1.0.0",
+				"@lezer/yaml": "^1.0.0"
+			}
+		},
 		"node_modules/@codemirror/language": {
 			"version": "6.11.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
@@ -1273,9 +1289,10 @@
 			}
 		},
 		"node_modules/@lezer/lr": {
-			"version": "1.3.14",
-			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.14.tgz",
-			"integrity": "sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+			"integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.0.0"
 			}
@@ -1288,6 +1305,17 @@
 				"@lezer/common": "^1.2.0",
 				"@lezer/highlight": "^1.0.0",
 				"@lezer/lr": "^1.1.0"
+			}
+		},
+		"node_modules/@lezer/yaml": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.3.tgz",
+			"integrity": "sha512-GuBLekbw9jDBDhGur82nuwkxKQ+a3W5H0GfaAthDXcAu+XdpS43VlnxA9E9hllkpSP5ellRDKjLLj7Lu9Wr6xA==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.2.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.4.0"
 			}
 		},
 		"node_modules/@lmdb/lmdb-darwin-arm64": {

--- a/website/package.json
+++ b/website/package.json
@@ -5,6 +5,7 @@
 	"dependencies": {
 		"@codemirror/commands": "^6.2.2",
 		"@codemirror/lang-php": "^6.0.1",
+		"@codemirror/lang-yaml": "^6.1.2",
 		"@codemirror/language": "^6.6.0",
 		"@codemirror/state": "^6.2.0",
 		"@codemirror/view": "^6.9.2",

--- a/website/src/js/PlaygroundViewModel.ts
+++ b/website/src/js/PlaygroundViewModel.ts
@@ -13,6 +13,8 @@ export class PlaygroundViewModel {
 	mainMenu: MainMenuViewModel;
 	code: ko.Observable<string>;
 	codeDelayed: ko.Computed<string>;
+	userConfig: ko.Observable<string>;
+	userConfigDelayed: ko.Computed<string>;
 	shareText: ko.Observable<string>;
 	legacyResult: ko.Observable<string | null>;
 
@@ -46,6 +48,11 @@ export class PlaygroundViewModel {
 		this.mainMenu = new MainMenuViewModel();
 		this.code = ko.observable('');
 		this.codeDelayed = ko.pureComputed(this.code).extend({
+			notify: 'always',
+			rateLimit: { timeout: 500, method: 'notifyWhenChangesStop' },
+		});
+		this.userConfig = ko.observable('');
+		this.userConfigDelayed = ko.pureComputed(this.userConfig).extend({
 			notify: 'always',
 			rateLimit: { timeout: 500, method: 'notifyWhenChangesStop' },
 		});
@@ -163,6 +170,7 @@ export class PlaygroundViewModel {
 				strictRules: this.strictRules(),
 				bleedingEdge: this.bleedingEdge(),
 				treatPhpDocTypesAsCertain: this.treatPhpDocTypesAsCertain(),
+				userConfig: this.userConfig(),
 				saveResult,
 			}),
 			contentType: 'application/json'
@@ -245,6 +253,7 @@ export class PlaygroundViewModel {
 		this.strictRules.subscribe(instantAnalyse);
 		this.bleedingEdge.subscribe(instantAnalyse);
 		this.treatPhpDocTypesAsCertain.subscribe(instantAnalyse);
+		this.userConfigDelayed.subscribe(instantAnalyse);
 	}
 
 	showUpToDateTabs(): void {
@@ -293,6 +302,7 @@ export class PlaygroundViewModel {
 				this.strictRules(data.config.strictRules);
 				this.bleedingEdge(data.config.bleedingEdge);
 				this.treatPhpDocTypesAsCertain(data.config.treatPhpDocTypesAsCertain);
+				this.userConfig(data.userConfig ?? 'parameters:');
 			}).fail(() => {
 				this.hasServerError(true);
 				const scope = new Sentry.Scope();
@@ -315,6 +325,7 @@ export class PlaygroundViewModel {
 			'\t}\n' +
 			'}'
 		);
+		this.userConfig('parameters:');
 		initCallback();
 		this.tabs([
 			new PlaygroundTabViewModel([

--- a/website/src/js/configMirror.ts
+++ b/website/src/js/configMirror.ts
@@ -1,0 +1,106 @@
+import * as ko from 'knockout';
+import {EditorView} from '@codemirror/view'
+import {keymap, highlightSpecialChars, drawSelection,
+	lineNumbers} from '@codemirror/view'
+import {Compartment, EditorState} from '@codemirror/state'
+import {defaultHighlightStyle, syntaxHighlighting, indentOnInput, indentUnit, bracketMatching} from '@codemirror/language'
+import {defaultKeymap, history, historyKeymap, indentWithTab} from '@codemirror/commands'
+import {closeBrackets, closeBracketsKeymap} from '@codemirror/autocomplete'
+import {yaml} from '@codemirror/lang-yaml'
+import { ttcn } from './ttcn-theme';
+import {errorsCompartment, errorsFacet, lineErrors } from "./editor/errors";
+import {hover} from "./editor/hover";
+import {materialDark} from "./editor/darkTheme";
+
+ko.bindingHandlers.configMirror = {
+	init: (element, valueAccessor, allBindings, viewModel, bindingContext) => {
+		// from https://github.com/codemirror/basic-setup/blob/78d1a916147c8c19678838cbdbf9396a8d1a6460/src/codemirror.ts
+		// options explained here: https://codemirror.net/docs/ref/
+
+		const text: string = ko.unwrap(valueAccessor());
+		const errors: [] = [];
+
+		const themeCompartment = new Compartment();
+
+		const startState = EditorState.create({
+			doc: text,
+			extensions: [
+				lineNumbers(),
+				// highlightActiveLineGutter(),
+				highlightSpecialChars(),
+				history(),
+				// foldGutter(),
+				drawSelection(),
+				// dropCursor(),
+				// EditorState.allowMultipleSelections.of(true),
+				indentOnInput(),
+				syntaxHighlighting(defaultHighlightStyle, {fallback: true}),
+				bracketMatching(),
+				closeBrackets(),
+				// autocompletion(),
+				// rectangularSelection(),
+				// crosshairCursor(),
+				// highlightActiveLine(),
+				// highlightSelectionMatches(),
+				keymap.of([
+					indentWithTab,
+					...closeBracketsKeymap,
+					...defaultKeymap,
+					// ...searchKeymap,
+					...historyKeymap,
+					// ...foldKeymap,
+					// ...completionKeymap,
+					// ...lintKeymap
+				]),
+				yaml(),
+				EditorState.tabSize.of(4),
+				indentUnit.of('\t'),
+				EditorView.lineWrapping,
+				EditorView.updateListener.of((update) => {
+					if (!update.docChanged) {
+						return;
+					}
+
+					const observable = valueAccessor();
+					observable(update.state.doc.toString());
+				}),
+				errorsCompartment.of(errorsFacet.of(errors)),
+				lineErrors,
+				hover,
+				EditorView.baseTheme({
+					'.cm-tooltip.cm-tooltip-hover': {
+						border: 'none',
+						background: 'transparent',
+					},
+				}),
+				themeCompartment.of(
+					document.documentElement.classList.contains('dark')
+						? [materialDark]
+						: [ttcn],
+				),
+			],
+		})
+
+		const editor = new EditorView({
+			state: startState,
+			parent: element,
+		});
+
+		const darkModeObserver = new MutationObserver((mutationsList) => {
+			for (const mutation of mutationsList) {
+				if (mutation.type === 'attributes') {
+					editor.dispatch({
+						effects: themeCompartment.reconfigure(
+							document.documentElement.classList.contains('dark')
+								? [materialDark]
+								: [ttcn],
+						),
+					});
+				}
+			}
+		});
+		darkModeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+		ko.utils.domData.set(element, 'configMirror', editor);
+	},
+};

--- a/website/src/js/playground.ts
+++ b/website/src/js/playground.ts
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import * as ko from 'knockout';
 import {PlaygroundViewModel} from './PlaygroundViewModel';
 import './codeMirror';
+import './configMirror';
 import * as Sentry from '@sentry/browser';
 import fs from 'fs';
 

--- a/website/src/try.njk
+++ b/website/src/try.njk
@@ -20,6 +20,7 @@ permalink: "/try.html"
 	</div>
 	<div style="display: none" data-bind="visible: true">
 		<div data-bind="codeMirror: code, codeMirrorErrors: currentTab() !== null ? currentTab().errors : []"></div>
+		<div data-bind="configMirror: userConfig"></div>
 
 		<div class="flex items-center mt-4 flex-col md:flex-row">
 			<!-- ko if: legacyResult() === null -->


### PR DESCRIPTION
Hello!

Related to: https://github.com/phpstan/phpstan/issues/12956

This adds another editor in the playground for users to customize the config. This user provided configuration is then included in the final configuration.

![image](https://github.com/user-attachments/assets/9937b8f2-e3c0-48a2-937f-d196ed59c62d)

Besides the obvious simple variables that can be set, what I'm really aiming for is to be able to define a custom extension class in the editor and then wire that up in the user provided config.

Thanks!
