### PR TITLE
playground: backup changes in localStorage to prevent data loss

### DIFF
--- a/website/src/js/PlaygroundViewModel.ts
+++ b/website/src/js/PlaygroundViewModel.ts
@@ -10,6 +10,9 @@ import {slugify} from './ErrorIdentifiersViewModel';
 
 export class PlaygroundViewModel {
 
+	localStorageKey: string = 'playground';
+	hasUnsavedChanges: ko.Observable<boolean> = ko.observable(false);
+
 	mainMenu: MainMenuViewModel;
 	code: ko.Observable<string>;
 	codeDelayed: ko.Computed<string>;
@@ -197,6 +200,7 @@ export class PlaygroundViewModel {
 		this.analyse(true).done((data) => {
 			this.id(data.id);
 			this.copyId();
+			this.clearBackup();
 
 			const anyWindow = (window as any);
 			if (typeof anyWindow.fathom !== 'undefined') {
@@ -224,8 +228,14 @@ export class PlaygroundViewModel {
 		}
 	}
 
+	reset(): void {
+		this.clearBackup();
+		location.reload();
+	}
+
 	startAcceptingChanges(): void {
 		this.code.subscribe(() => {
+			this.backup();
 			this.preanalyse();
 		});
 		this.codeDelayed.subscribe(() => {
@@ -238,6 +248,7 @@ export class PlaygroundViewModel {
 		});
 
 		const instantAnalyse = () => {
+			this.backup();
 			this.preanalyse();
 			this.analyse(false);
 		};
@@ -302,6 +313,15 @@ export class PlaygroundViewModel {
 				initCallback();
 				this.startAcceptingChanges();
 			});
+			return;
+		}
+
+		this.hasUnsavedChanges(this.restoreBackup());
+		if (this.hasUnsavedChanges()) {
+			initCallback();
+			this.startAcceptingChanges();
+			this.preanalyse();
+			this.analyse(false);
 			return;
 		}
 
@@ -398,6 +418,37 @@ export class PlaygroundViewModel {
 		}
 
 		return viewModelTabs;
+	}
+
+	backup(): void {
+		this.hasUnsavedChanges(true);
+		localStorage.setItem(this.localStorageKey, JSON.stringify({
+			code: this.code(),
+			level: this.level(),
+			strictRules: this.strictRules(),
+			bleedingEdge: this.bleedingEdge(),
+			treatPhpDocTypesAsCertain: this.treatPhpDocTypesAsCertain(),
+		}));
+	}
+
+	restoreBackup(): boolean {
+		const backup = localStorage.getItem(this.localStorageKey);
+		if (backup === null) {
+			return false;
+		}
+
+		const data = JSON.parse(backup);
+		this.code(data.code);
+		this.level(data.level);
+		this.strictRules(data.strictRules);
+		this.bleedingEdge(data.bleedingEdge);
+		this.treatPhpDocTypesAsCertain(data.treatPhpDocTypesAsCertain);
+		return true;
+	}
+
+	clearBackup(): void {
+		localStorage.removeItem(this.localStorageKey);
+		this.hasUnsavedChanges(false);
 	}
 
 }

--- a/website/src/try.njk
+++ b/website/src/try.njk
@@ -19,6 +19,13 @@ permalink: "/try.html"
 		<div class="spinner"></div>
 	</div>
 	<div style="display: none" data-bind="visible: true">
+		<!-- ko if: hasUnsavedChanges -->
+			<div class="text-right">
+				<a href="#" data-bind="click: reset" class="inline-flex flex-grow md:flex-grow-0 mx-4 md:mx-0 items-center px-2.5 py-3 rounded-lg text-md font-medium leading-4 bg-gray-100 hover:bg-gray-200 w-auto md:w-32 h-10 justify-center border-gray-300 border dark:border-black">
+					<span>Reset</span>
+				</a>
+			</div>
+		<!-- /ko -->
 		<div data-bind="codeMirror: code, codeMirrorErrors: currentTab() !== null ? currentTab().errors : []"></div>
 
 		<div class="flex items-center mt-4 flex-col md:flex-row">


### PR DESCRIPTION
Hello!

Related to #12956 
Supercedes: #12961 

This backups changes to localStorage so that if the user accidentally refreshes the page or navigates away then they don't lose their work. Upon loading the page, if there is a backup in localStorage then the data will be restored and analysed.

If unsaved changes are detected, then a `Reset` button appears in the upper right corner. Clicking this button will clear the local storage and return the editor to the default state:

![image](https://github.com/user-attachments/assets/06695ca3-2826-447c-93e0-9b1cf05eb452)


Thanks!