### PR TITLE
Fix build

### DIFF
--- a/e2e/rector-autoload/src/ImportPhpUnitFunctionsRector.php
+++ b/e2e/rector-autoload/src/ImportPhpUnitFunctionsRector.php
@@ -19,6 +19,7 @@ final class ImportPhpUnitFunctionsRector extends AbstractRector
 			return null;
 		}
 
+        /** @phpstan-ignore classConstant.internal */
 		$parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
 		if (!$parentNode instanceof Node\Expr\FuncCall) {

--- a/e2e/rector-autoload/src/ImportPhpUnitFunctionsRector.php
+++ b/e2e/rector-autoload/src/ImportPhpUnitFunctionsRector.php
@@ -19,7 +19,7 @@ final class ImportPhpUnitFunctionsRector extends AbstractRector
 			return null;
 		}
 
-        /** @phpstan-ignore classConstant.internal */
+		/** @phpstan-ignore classConstant.internal */
 		$parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
 		if (!$parentNode instanceof Node\Expr\FuncCall) {


### PR DESCRIPTION
fixes

```
 ------ --------------------------------------------------------------------- 
  Line   ImportPhpUnitFunctionsRector.php                                     
 ------ --------------------------------------------------------------------- 
  22     Access to internal constant                                          
         Rector\NodeTypeResolver\Node\AttributeKey::PARENT_NODE from outside  
         its root namespace Rector.                                           
         🪪 classConstant.internal                                             
 ------ --------------------------------------------------------------------- 
 ```