### PR TITLE
add vscode+wsl link example

### DIFF
--- a/website/src/user-guide/output-format.md
+++ b/website/src/user-guide/output-format.md
@@ -52,6 +52,7 @@ Examples of URLs for the most common editors are:
 
 * PhpStorm: `'phpstorm://open?file=%%file%%&line=%%line%%'`
 * Visual Studio Code: `'vscode://file/%%file%%:%%line%%'`
+* Visual Studio Code (WSL): `'vscode://vscode-remote/wsl+${DISTRO}/%%file%%:%%line%%'` (replace `${DISTRO}` with your current distro, e.g. `Ubuntu-24.04`)
 * Atom: `'atom://core/open/file?filename=%%file%%&line=%%line%%'`
 
 Setting this parameter should most likely be done in [your local configuration file](/config-reference#multiple-files) that isn't committed to version control. The common pattern is to have `phpstan.neon.dist` with project-specific settings shared by everyone on the team, and *.gitignored* `phpstan.neon` that includes `phpstan.neon.dist` and overrides values specific to a single developer:


### PR DESCRIPTION
Update output-format.md with a further example for creating clickable links that work in VSCode when running in a WSL "remote" environment.