### PR TITLE
Clarify `class-string` meaning

### DIFF
--- a/website/src/writing-php-code/phpdoc-types.md
+++ b/website/src/writing-php-code/phpdoc-types.md
@@ -219,6 +219,8 @@ function foo(string $className): void { ... }
 
 Both literal strings with valid class names (`'stdClass'`) and `class` constants (`\stdClass::class`) are accepted as `class-string` arguments.
 
+The string has to be a fully qualified name of an existing class, interface or enum.
+
 If you have a general `string` and want to pass it as a `class-string` argument, you need to make sure the string contains a valid class name:
 
 ```php


### PR DESCRIPTION
The docs say:

> `class-string` type can be used wherever a valid class name string is expected.

But "valid class name string" is ambiguous. It could mean:

1. a valid string that could be used as a class name in PHP
2. a name of a valid (existing) class

I suggest to make it more clear in docs which of them is correct.

From my understanding the second one is correct, right?

I also suggest to make it more clear that it has to be the fully qualified name, not the short name or a qualified name or something else.