### PR TITLE
add docs for checkStrictPrintfPlaceholderTypes

### DIFF
--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -592,7 +592,7 @@ Please note that aside from setting this config parameter to `true`, you also ne
 
 **default**: `false` ([strict-rules](https://github.com/phpstan/phpstan-strict-rules) sets it to `true`)
 
-**example**: [with `false`](https://phpstan.org/r/b42e2b39-bd07-4420-906f-82252fd2eb9c), [with `true`](https://phpstan.org/r/4e1144b1-38bc-4f04-86c0-cf009414ce72)
+**example**: [with `false`](https://phpstan.org/r/2abca81b-ebb4-4443-ab88-d59cf1405355), [with `true`](https://phpstan.org/r/37874f07-e0f8-4768-853a-82771e090998)
 
 Requires Bleeding Edge until PHPStan 3.0. It determines which value types are allowed to be passed to various placeholders in printf-like functions:
 

--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -592,6 +592,8 @@ Please note that aside from setting this config parameter to `true`, you also ne
 
 **default**: `false` ([strict-rules](https://github.com/phpstan/phpstan-strict-rules) sets it to `true`)
 
+**example**: [with `false`](https://phpstan.org/r/b42e2b39-bd07-4420-906f-82252fd2eb9c), [with `true`](https://phpstan.org/r/4e1144b1-38bc-4f04-86c0-cf009414ce72)
+
 Requires Bleeding Edge until PHPStan 3.0. It determines which value types are allowed to be passed to various placeholders in printf-like functions:
 
 |       | `false`                     | `true`                                          |

--- a/website/src/config-reference.md
+++ b/website/src/config-reference.md
@@ -586,6 +586,23 @@ class Bar extends Foo
 
 Please note that aside from setting this config parameter to `true`, you also need to set [`phpVersion`](#phpversion) to `80300` or higher. If you're not changing `phpVersion` in your config, make sure you're running PHPStan with PHP 8.3 or newer.
 
+### `checkStrictPrintfPlaceholderTypes`
+
+<div class="text-xs inline-block border border-green-600 text-green-600 bg-green-100 rounded px-1 mb-4">Available in PHPStan 2.1.29</div>
+
+**default**: `false` ([strict-rules](https://github.com/phpstan/phpstan-strict-rules) sets it to `true`)
+
+Requires Bleeding Edge until PHPStan 3.0. It determines which value types are allowed to be passed to various placeholders in printf-like functions:
+
+|       | `false`                     | `true`                                          |
+|-------|-----------------------------|-------------------------------------------------|
+| `%d`  | anything castable to int    | int                                             |
+| `%f`  | anything castable to float  | float, int                                      |
+| `%s`  | anything castable to string | string, int, float, objects with `__toString()` |
+| `*`   | int                         | int                                             |
+
+This affects for example booleans which are castable to int/float/string, but it may not be what you intended.
+
 Exceptions
 ------------
 


### PR DESCRIPTION
Follow up to https://github.com/phpstan/phpstan-src/pull/4349

I'd wait with merging until we settle the debate about `null` in `%s`.