### PR TITLE
apply table borders everywhere

### DIFF
--- a/website/src/app.pcss
+++ b/website/src/app.pcss
@@ -174,11 +174,11 @@ html.dark {
     margin-top: 4em;
 }
 
-.typesystem-types table {
+.content table {
 	@apply table-fixed mb-8;
 }
 
-.typesystem-types table th, .typesystem-types table td {
+.content table th, .content table td {
 	@apply border-2 p-2;
 }
 


### PR DESCRIPTION
Fixes borders for table added by https://github.com/phpstan/phpstan/pull/13594
<img width="910" height="256" alt="Screenshot 2025-09-28 at 10-11-56 Config Reference PHPStan" src="https://github.com/user-attachments/assets/be444a6c-ca73-45ba-b83f-6fbaf75a5de4" />

The only other page that I found to have tables is the type system page and it still looks the same with the change.