### PR TITLE
Precise version for rawMessage and rawMessages

### DIFF
--- a/website/src/user-guide/ignoring-errors.md
+++ b/website/src/user-guide/ignoring-errors.md
@@ -129,9 +129,7 @@ parameters:
 		- '#Other error to ignore everywhere#'
 ```
 
-Instead of writing a regular expression, you can use the `rawMessage` key to match the exact error message as a plain string. This avoids the need for regex escaping. The `rawMessages` key accepts a list of plain strings.
-
-<div class="text-xs inline-block border border-green-600 text-green-600 bg-green-100 rounded px-1 mb-4">Available in PHPStan 2.1.24</div>
+In PHPStan 2.1.24 and later, instead of writing a regular expression, you can use the `rawMessage` key to match the exact error message as a plain string. This avoids the need for regex escaping. The `rawMessages` key (available since PHPStan 2.1.40) accepts a list of plain strings.
 
 ```yaml
 parameters:


### PR DESCRIPTION
I don't have better solution in mind so far.

Also I feel like 
```
<div class="text-xs inline-block border border-green-600 text-green-600 bg-green-100 rounded px-1 mb-4">Available in PHPStan 2.1.24</div>
```
is reserved for some other documentation pages, since the only version I found on `ignoreError` page is
https://phpstan.org/user-guide/ignoring-errors#excluding-whole-files

> If the excludePaths entry is a file path or a directory path, but it does not always exist, you can append the path with (?) to make it optional. Available since PHPStan 1.11.10.