### PR TITLE
Update cache actions docs from v4 to v5

### DIFF
--- a/website/src/user-guide/result-cache.md
+++ b/website/src/user-guide/result-cache.md
@@ -71,7 +71,7 @@ Because GitHub Actions do not overwrite existing cache entries with the same key
   # checkout, setup-php, composer install...
   
   - name: "Restore result cache"
-    uses: actions/cache/restore@v4
+    uses: actions/cache/restore@v5
     with:
       path: tmp # same as in phpstan.neon
       key: "phpstan-result-cache-{% raw %}${{ github.run_id }}"{% endraw %}
@@ -82,7 +82,7 @@ Because GitHub Actions do not overwrite existing cache entries with the same key
     run: "vendor/bin/phpstan"
 
   - name: "Save result cache"
-    uses: actions/cache/save@v4
+    uses: actions/cache/save@v5
     if: {% raw %}${{ !cancelled() }}{% endraw %}
     with:
       path: tmp # same as in phpstan.neon


### PR DESCRIPTION
I noticed the `actions/cache` references was out of date on the docs, v5 was [released](https://github.com/actions/cache/releases/tag/v5.0.0) a couple months ago.