### PR TITLE
Add versioned Algolia Crawler configuration

### DIFF
--- a/.github/workflows/algolia-crawler-config.yml
+++ b/.github/workflows/algolia-crawler-config.yml
@@ -1,0 +1,29 @@
+name: "Algolia Crawler Config Update"
+
+on:
+  push:
+    branches:
+      - "2.2.x"
+    paths:
+      - 'website/algolia-crawler-config.js'
+
+jobs:
+  update-config:
+    name: "Update Algolia Crawler Config"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Update Crawler Config"
+        run: |
+          curl -s -f -X PATCH "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/config" \
+            -H "Content-Type: application/javascript" \
+            -u "${{ secrets.ALGOLIA_CRAWLER_USER_ID }}:${{ secrets.ALGOLIA_CRAWLER_API_KEY }}" \
+            --data-binary @website/algolia-crawler-config.js
+
+      - name: "Trigger Crawler Reindex"
+        run: |
+          curl -s -f -X POST "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/reindex" \
+            -H "Content-Type: application/json" \
+            -u "${{ secrets.ALGOLIA_CRAWLER_USER_ID }}:${{ secrets.ALGOLIA_CRAWLER_API_KEY }}"

--- a/.github/workflows/algolia-crawler-config.yml
+++ b/.github/workflows/algolia-crawler-config.yml
@@ -6,6 +6,7 @@ on:
       - "2.2.x"
     paths:
       - 'website/algolia-crawler-config.js'
+      - '.github/workflows/algolia-crawler-config.yml'
 
 jobs:
   update-config:

--- a/.github/workflows/algolia-crawler-config.yml
+++ b/.github/workflows/algolia-crawler-config.yml
@@ -17,6 +17,7 @@ jobs:
 
       - name: "Update Crawler Config"
         run: |
+          sed -i 's/apiKey: "xxx"/apiKey: "${{ secrets.ALGOLIA_API_KEY }}"/' website/algolia-crawler-config.js
           curl -s -f -X PATCH "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/config" \
             -H "Content-Type: application/javascript" \
             -u "${{ secrets.ALGOLIA_CRAWLER_USER_ID }}:${{ secrets.ALGOLIA_CRAWLER_API_KEY }}" \

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -184,6 +184,12 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.PLAYGROUND_RUNNER_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PLAYGROUND_RUNNER_AWS_SECRET_ACCESS_KEY }}
 
+      - name: "Trigger Algolia Crawler"
+        run: |
+          curl -s -f -X POST "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/reindex" \
+            -H "Content-Type: application/json" \
+            -u "${{ secrets.ALGOLIA_CRAWLER_USER_ID }}:${{ secrets.ALGOLIA_CRAWLER_API_KEY }}"
+
       - uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PHPSTAN_BOT_TOKEN }}

--- a/website/algolia-crawler-config.js
+++ b/website/algolia-crawler-config.js
@@ -1,49 +1,21 @@
-// Algolia DocSearch Crawler Configuration
-// https://crawler.algolia.com/admin/crawlers
-//
-// This file is the source of truth for the Algolia Crawler configuration.
-// After modifying this file, update the crawler config via the API:
-//
-//   curl -X PATCH "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/config" \
-//     -H "Content-Type: application/javascript" \
-//     -u "${CRAWLER_USER_ID}:${CRAWLER_API_KEY}" \
-//     --data-binary @website/algolia-crawler-config.js
-//
-// To trigger a reindex:
-//
-//   curl -X POST "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/reindex" \
-//     -H "Content-Type: application/json" \
-//     -u "${CRAWLER_USER_ID}:${CRAWLER_API_KEY}"
-//
 new Crawler({
   rateLimit: 8,
-  startUrls: ["https://phpstan.org/", "https://apiref.phpstan.org/2.1.x/"],
-  renderJavaScript: false,
-  sitemaps: ["https://phpstan.org/sitemap.xml"],
+  startUrls: ["https://phpstan.org/", "https://apiref.phpstan.org/"],
+  sitemaps: [],
   ignoreCanonicalTo: false,
   discoveryPatterns: [
     "https://phpstan.org/**",
-    "https://apiref.phpstan.org/2.1.x/**",
+    "https://apiref.phpstan.org/2.2.x/**",
   ],
   exclusionPatterns: [
     "https://phpstan.org/merch*",
-    "https://phpstan.org/try*",
-    "https://phpstan.org/sponsor*",
-    "https://phpstan.org/rss*",
-    "https://phpstan.org/sitemap*",
-    "https://phpstan.org/llms*",
     "https://apiref.phpstan.org/*/source-*",
   ],
   schedule: "at 12:05 PM on Monday",
   actions: [
     {
       indexName: "phpstan",
-      pathsToMatch: [
-        "https://phpstan.org/**",
-        "!https://phpstan.org/blog/**",
-        "!https://phpstan.org/error-identifiers",
-        "!https://phpstan.org/error-identifiers/**",
-      ],
+      pathsToMatch: ["https://phpstan.org/**", "!https://phpstan.org/blog/**"],
       recordExtractor: ({ helpers }) => {
         return helpers.docsearch({
           recordProps: {
@@ -59,31 +31,6 @@ new Crawler({
             lvl5: ["article h5", "main h5", "h5"],
             lvl6: ["article h6", "main h6", "h6"],
             pageRank: "90",
-          },
-          aggregateContent: true,
-        });
-      },
-    },
-    {
-      indexName: "phpstan",
-      pathsToMatch: [
-        "https://phpstan.org/error-identifiers/**",
-      ],
-      recordExtractor: ({ helpers }) => {
-        return helpers.docsearch({
-          recordProps: {
-            lvl1: ["header h1", "article h1", "main h1", "h1", "head > title"],
-            content: ["article p, article li", "main p, main li", "p, li"],
-            lvl0: {
-              selectors: "#algoliaSectionTitle",
-              defaultValue: "Error Identifiers",
-            },
-            lvl2: ["article h2", "main h2", "h2"],
-            lvl3: ["article h3", "main h3", "h3"],
-            lvl4: ["article h4", "main h4", "h4"],
-            lvl5: ["article h5", "main h5", "h5"],
-            lvl6: ["article h6", "main h6", "h6"],
-            pageRank: "70",
           },
           aggregateContent: true,
         });
@@ -114,7 +61,7 @@ new Crawler({
     },
     {
       indexName: "phpstan",
-      pathsToMatch: ["https://apiref.phpstan.org/2.1.x/**"],
+      pathsToMatch: ["https://apiref.phpstan.org/2.2.x/**"],
       recordExtractor: ({ helpers }) => {
         return helpers.docsearch({
           recordProps: {
@@ -197,8 +144,7 @@ new Crawler({
         "exact",
         "custom",
       ],
-      highlightPreTag:
-        '<span class="algolia-docsearch-suggestion--highlight">',
+      highlightPreTag: '<span class="algolia-docsearch-suggestion--highlight">',
       highlightPostTag: "</span>",
       minWordSizefor1Typo: 3,
       minWordSizefor2Typos: 7,
@@ -212,4 +158,5 @@ new Crawler({
   },
   appId: "563YUB35R3",
   apiKey: "xxx",
+  safetyChecks: { beforeIndexPublishing: { maxLostRecordsPercentage: 100 } },
 });

--- a/website/algolia-crawler-config.js
+++ b/website/algolia-crawler-config.js
@@ -1,0 +1,215 @@
+// Algolia DocSearch Crawler Configuration
+// https://crawler.algolia.com/admin/crawlers
+//
+// This file is the source of truth for the Algolia Crawler configuration.
+// After modifying this file, update the crawler config via the API:
+//
+//   curl -X PATCH "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/config" \
+//     -H "Content-Type: application/javascript" \
+//     -u "${CRAWLER_USER_ID}:${CRAWLER_API_KEY}" \
+//     --data-binary @website/algolia-crawler-config.js
+//
+// To trigger a reindex:
+//
+//   curl -X POST "https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/reindex" \
+//     -H "Content-Type: application/json" \
+//     -u "${CRAWLER_USER_ID}:${CRAWLER_API_KEY}"
+//
+new Crawler({
+  rateLimit: 8,
+  startUrls: ["https://phpstan.org/", "https://apiref.phpstan.org/2.1.x/"],
+  renderJavaScript: false,
+  sitemaps: ["https://phpstan.org/sitemap.xml"],
+  ignoreCanonicalTo: false,
+  discoveryPatterns: [
+    "https://phpstan.org/**",
+    "https://apiref.phpstan.org/2.1.x/**",
+  ],
+  exclusionPatterns: [
+    "https://phpstan.org/merch*",
+    "https://phpstan.org/try*",
+    "https://phpstan.org/sponsor*",
+    "https://phpstan.org/rss*",
+    "https://phpstan.org/sitemap*",
+    "https://phpstan.org/llms*",
+    "https://apiref.phpstan.org/*/source-*",
+  ],
+  schedule: "at 12:05 PM on Monday",
+  actions: [
+    {
+      indexName: "phpstan",
+      pathsToMatch: [
+        "https://phpstan.org/**",
+        "!https://phpstan.org/blog/**",
+        "!https://phpstan.org/error-identifiers",
+        "!https://phpstan.org/error-identifiers/**",
+      ],
+      recordExtractor: ({ helpers }) => {
+        return helpers.docsearch({
+          recordProps: {
+            lvl1: ["header h1", "article h1", "main h1", "h1", "head > title"],
+            content: ["article p, article li", "main p, main li", "p, li"],
+            lvl0: {
+              selectors: "#algoliaSectionTitle",
+              defaultValue: "Documentation",
+            },
+            lvl2: ["article h2", "main h2", "h2"],
+            lvl3: ["article h3", "main h3", "h3"],
+            lvl4: ["article h4", "main h4", "h4"],
+            lvl5: ["article h5", "main h5", "h5"],
+            lvl6: ["article h6", "main h6", "h6"],
+            pageRank: "90",
+          },
+          aggregateContent: true,
+        });
+      },
+    },
+    {
+      indexName: "phpstan",
+      pathsToMatch: [
+        "https://phpstan.org/error-identifiers/**",
+      ],
+      recordExtractor: ({ helpers }) => {
+        return helpers.docsearch({
+          recordProps: {
+            lvl1: ["header h1", "article h1", "main h1", "h1", "head > title"],
+            content: ["article p, article li", "main p, main li", "p, li"],
+            lvl0: {
+              selectors: "#algoliaSectionTitle",
+              defaultValue: "Error Identifiers",
+            },
+            lvl2: ["article h2", "main h2", "h2"],
+            lvl3: ["article h3", "main h3", "h3"],
+            lvl4: ["article h4", "main h4", "h4"],
+            lvl5: ["article h5", "main h5", "h5"],
+            lvl6: ["article h6", "main h6", "h6"],
+            pageRank: "70",
+          },
+          aggregateContent: true,
+        });
+      },
+    },
+    {
+      indexName: "phpstan",
+      pathsToMatch: ["https://phpstan.org/blog/**"],
+      recordExtractor: ({ helpers }) => {
+        return helpers.docsearch({
+          recordProps: {
+            lvl1: ["header h1", "article h1", "main h1", "h1", "head > title"],
+            content: ["article p, article li", "main p, main li", "p, li"],
+            lvl0: {
+              selectors: "#algoliaSectionTitle",
+              defaultValue: "Blog",
+            },
+            lvl2: ["article h2", "main h2", "h2"],
+            lvl3: ["article h3", "main h3", "h3"],
+            lvl4: ["article h4", "main h4", "h4"],
+            lvl5: ["article h5", "main h5", "h5"],
+            lvl6: ["article h6", "main h6", "h6"],
+            pageRank: "50",
+          },
+          aggregateContent: true,
+        });
+      },
+    },
+    {
+      indexName: "phpstan",
+      pathsToMatch: ["https://apiref.phpstan.org/2.1.x/**"],
+      recordExtractor: ({ helpers }) => {
+        return helpers.docsearch({
+          recordProps: {
+            lvl1: ["header h1", "article h1", "main h1", "h1", "head > title"],
+            content: ["article p, article li", "main p, main li", "p, li"],
+            lvl0: {
+              selectors: "#sectionTitle",
+              defaultValue: "API Reference",
+            },
+            lvl2: ["article h2", "main h2", "h2"],
+            lvl3: ["article h3", "main h3", "h3"],
+            lvl4: ["article h4", "main h4", "h4"],
+            lvl5: ["article h5", "main h5", "h5"],
+            lvl6: ["article h6", "main h6", "h6"],
+            pageRank: "10",
+          },
+          aggregateContent: true,
+        });
+      },
+    },
+  ],
+  initialIndexSettings: {
+    phpstan: {
+      attributesForFaceting: ["type", "lang"],
+      attributesToRetrieve: [
+        "hierarchy",
+        "content",
+        "anchor",
+        "url",
+        "url_without_anchor",
+        "type",
+      ],
+      attributesToHighlight: ["hierarchy", "hierarchy_camel", "content"],
+      attributesToSnippet: ["content:10"],
+      camelCaseAttributes: ["hierarchy", "hierarchy_radio", "content"],
+      searchableAttributes: [
+        "unordered(hierarchy_radio_camel.lvl0)",
+        "unordered(hierarchy_radio.lvl0)",
+        "unordered(hierarchy_radio_camel.lvl1)",
+        "unordered(hierarchy_radio.lvl1)",
+        "unordered(hierarchy_radio_camel.lvl2)",
+        "unordered(hierarchy_radio.lvl2)",
+        "unordered(hierarchy_radio_camel.lvl3)",
+        "unordered(hierarchy_radio.lvl3)",
+        "unordered(hierarchy_radio_camel.lvl4)",
+        "unordered(hierarchy_radio.lvl4)",
+        "unordered(hierarchy_radio_camel.lvl5)",
+        "unordered(hierarchy_radio.lvl5)",
+        "unordered(hierarchy_radio_camel.lvl6)",
+        "unordered(hierarchy_radio.lvl6)",
+        "unordered(hierarchy_camel.lvl0)",
+        "unordered(hierarchy.lvl0)",
+        "unordered(hierarchy_camel.lvl1)",
+        "unordered(hierarchy.lvl1)",
+        "unordered(hierarchy_camel.lvl2)",
+        "unordered(hierarchy.lvl2)",
+        "unordered(hierarchy_camel.lvl3)",
+        "unordered(hierarchy.lvl3)",
+        "unordered(hierarchy_camel.lvl4)",
+        "unordered(hierarchy.lvl4)",
+        "unordered(hierarchy_camel.lvl5)",
+        "unordered(hierarchy.lvl5)",
+        "unordered(hierarchy_camel.lvl6)",
+        "unordered(hierarchy.lvl6)",
+        "content",
+      ],
+      distinct: true,
+      attributeForDistinct: "url",
+      customRanking: [
+        "desc(weight.pageRank)",
+        "desc(weight.level)",
+        "asc(weight.position)",
+      ],
+      ranking: [
+        "words",
+        "filters",
+        "typo",
+        "attribute",
+        "proximity",
+        "exact",
+        "custom",
+      ],
+      highlightPreTag:
+        '<span class="algolia-docsearch-suggestion--highlight">',
+      highlightPostTag: "</span>",
+      minWordSizefor1Typo: 3,
+      minWordSizefor2Typos: 7,
+      allowTyposOnNumericTokens: false,
+      minProximity: 1,
+      ignorePlurals: true,
+      advancedSyntax: true,
+      attributeCriteriaComputedByMinProximity: true,
+      removeWordsIfNoResults: "allOptional",
+    },
+  },
+  appId: "563YUB35R3",
+  apiKey: "xxx",
+});


### PR DESCRIPTION
Add `website/algolia-crawler-config.js` with the optimized crawler configuration for version control and CI/CD integration.

Key optimizations:
- Restrict API reference discovery to 2.1.x only
- Add sitemap for faster page discovery
- Remove JavaScript rendering (noscript fallback suffices)
- Add exclusion patterns for non-content pages
- Remove empty /error-identifiers action
- Update API reference version from 2.0.x to 2.1.x

Closes #14163

Generated with [Claude Code](https://claude.ai/code)