### PR TITLE
integration-tests: dead-code-detector should pass

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -131,7 +131,7 @@ jobs:
             script: |
               git clone https://github.com/shipmonk-rnd/dead-code-detector.git e2e/integration/repo
               cd e2e/integration/repo
-              git checkout 0.15.1
+              git checkout 9dc312dacd817f253a9519703d2c4c3d86579d27
               composer install
               cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar
               cp ../../../phpstan vendor/phpstan/phpstan/phpstan
@@ -419,7 +419,7 @@ jobs:
             baseline-file: shipmonk-rnd-baseline.neon
           - php-version: 8.3
             repo: shipmonk-rnd/dead-code-detector
-            ref: 0.15.1
+            ref: 9dc312dacd817f253a9519703d2c4c3d86579d27
             setup: |
               composer install
               cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -126,7 +126,7 @@ jobs:
               cp ../../../phpstan vendor/phpstan/phpstan/phpstan
               cp ../../../bootstrap.php vendor/phpstan/phpstan/bootstrap.php
               vendor/bin/phpunit tests
-          - php-version: 8.3
+          - php-version: 8.4
             name: shipmonk/dead-code-detector tests
             script: |
               git clone https://github.com/shipmonk-rnd/dead-code-detector.git e2e/integration/repo
@@ -417,7 +417,7 @@ jobs:
               cp ../../../bootstrap.php vendor/phpstan/phpstan/bootstrap.php
             phpstan-command: vendor/bin/phpstan analyse -c ../shipmonk.neon
             baseline-file: shipmonk-rnd-baseline.neon
-          - php-version: 8.3
+          - php-version: 8.4
             repo: shipmonk-rnd/dead-code-detector
             ref: 9dc312dacd817f253a9519703d2c4c3d86579d27
             setup: |


### PR DESCRIPTION
Previous upgrade was not enough (causing red job) due to old shipmonk/phpstan-rules inside composer.lock of DCD. This should fix it.