### PR TITLE
automatically link source-code in laravel-types integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -253,7 +253,7 @@ jobs:
             ref: 00f0216e493867f399401397cc40347f869a7e1e
             setup: |
               composer install
-            phpstan-command: ../../../phpstan.phar analyse -c phpstan.types.neon.dist
+            phpstan-command: ../../../phpstan.phar analyse -c ../laravel-types.neon
             baseline-file: laravel-types-baseline.neon
           - php-version: 8.4
             repo: Roave/BetterReflection

--- a/e2e/integration/laravel-types-baseline.neon
+++ b/e2e/integration/laravel-types-baseline.neon
@@ -1,7 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 2
-			path: repo/types/Support/Helpers.php

--- a/e2e/integration/laravel-types.neon
+++ b/e2e/integration/laravel-types.neon
@@ -1,0 +1,4 @@
+includes:
+	- repo/phpstan.types.neon.dist
+	- laravel-types-baseline.neon
+	- editor-link-repo.php


### PR DESCRIPTION
analog https://github.com/phpstan/phpstan/pull/14287

---

editor-link generation for this project is missing atm, see github action logs in phpstan-src:

<img width="695" height="510" alt="grafik" src="https://github.com/user-attachments/assets/5102d93e-ebf3-4963-b8b5-5a81de7971b5" />
