### PR TITLE
Workaround actions/upload-artifact#176

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -544,14 +544,15 @@ jobs:
         run: "${{ matrix.phpstan-command }} -b ../${{ matrix.baseline-file }}"
 
       - name: "Workaround actions/upload-artifact#176"
+        id: baseline
         run: |
-          echo "BASELINE_REALPATH=$(realpath e2e/integration/${{ matrix.baseline-file }})" >> $GITHUB_ENV
+          echo "REALPATH=$(realpath e2e/integration/${{ matrix.baseline-file }})" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ failure() }}
         with:
           name: baselines-${{ matrix.baseline-file }}
-          path: "${{ env.BASELINE_REALPATH }}"
+          path: "${{ steps.baseline.outputs.REALPATH }}"
 
   integration-update-baseline:
     name: "Integration - Update baselines"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -543,7 +543,7 @@ jobs:
         working-directory: ${{ matrix.phpstan-cwd || 'e2e/integration/repo' }}
         run: "${{ matrix.phpstan-command }} -b ../${{ matrix.baseline-file }}"
 
-      - name: Workaround actions/upload-artifact#176
+      - name: "Workaround actions/upload-artifact#176"
         run: |
           echo "BASELINE_REALPATH=$(realpath e2e/integration/${{ matrix.baseline-file }})" >> $GITHUB_ENV
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -543,11 +543,15 @@ jobs:
         working-directory: ${{ matrix.phpstan-cwd || 'e2e/integration/repo' }}
         run: "${{ matrix.phpstan-command }} -b ../${{ matrix.baseline-file }}"
 
+      - name: Workaround actions/upload-artifact#176
+        run: |
+          echo "BASELINE_REALPATH=$(realpath e2e/integration/${{ matrix.baseline-file }})" >> $GITHUB_ENV
+
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ failure() }}
         with:
           name: baselines-${{ matrix.baseline-file }}
-          path: "e2e/integration/${{ matrix.baseline-file }}"
+          path: "${{ env.BASELINE_REALPATH }}"
 
   integration-update-baseline:
     name: "Integration - Update baselines"


### PR DESCRIPTION
should fix

```
Run actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
  with:
    name: baselines-../../shopsys-project-base-baseline.neon
    path: e2e/integration/../../shopsys-project-base-baseline.neon
    if-no-files-found: warn
    compression-level: 6
    overwrite: false
    include-hidden-files: false
  env:
    COMPOSER_PROCESS_TIMEOUT: 0
    COMPOSER_NO_INTERACTION: 1
    COMPOSER_NO_AUDIT: 1
    CACHE_RESTORE_KEY: Linux-php-8.4.20-composer-locked-
    INPUT_NAME: phar-file
    INPUT_ARTIFACT-IDS: 
    INPUT_PATH: 
    INPUT_PATTERN: 
    INPUT_MERGE-MULTIPLE: false
    INPUT_GITHUB-TOKEN: 
    INPUT_REPOSITORY: phpstan/phpstan-src
    INPUT_RUN-ID: 24623649353
Error: Invalid pattern 'e2e/integration/../../shopsys-project-base-baseline.neon'. Relative pathing '.' and '..' is not allowed.
```