### PR TITLE
Playground: strip leading backslash from exception class names

### DIFF
--- a/website/src/js/PlaygroundViewModel.ts
+++ b/website/src/js/PlaygroundViewModel.ts
@@ -267,7 +267,7 @@ export class PlaygroundViewModel {
 
 	private getApiOptions(): Record<string, any> {
 		const parseClasses = (s: string): string[] =>
-			s.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+			s.split('\n').map(l => l.trim().replace(/^\\+/, '')).filter(l => l.length > 0);
 		const opts: Record<string, any> = {};
 		for (const [key, obs] of this.newOptionEntries) {
 			opts[key] = obs();


### PR DESCRIPTION
## Summary

In the playground Options dialog, the *Unchecked/Checked exception classes* textareas show placeholders `\LogicException` / `\RuntimeException`. Users who follow that hint end up passing `\RuntimeException` to PHPStan's `exceptions.checkedExceptionClasses`, which compares class names by plain string match and silently ignores entries with a leading backslash — so the "Missing checked exception in @throws" check has no effect.

Trim any leading backslashes in `parseClasses()` so the input is tolerant to both forms (`RuntimeException` and `\RuntimeException`, including FQNs pasted from code like `\Foo\Bar\MyException`).

## Reproduction

Playground link that returns zero errors despite expecting `missingType.checkedException` on line 5:
https://phpstan.org/r/4360f0d3-1c86-49de-bde4-89db5044313d

Local PHPStan with the exact NEON the playground generates confirms the silent drop:

```neon
parameters:
    exceptions:
        checkedExceptionClasses:
            - \RuntimeException     # ignored -> "No errors"
        check:
            missingCheckedExceptionInThrows: true
```

vs.

```neon
        checkedExceptionClasses:
            - RuntimeException       # reports the missing @throws
```

## Test plan

- [ ] Open the playground Options dialog, enable *Missing checked exception in @throws*, paste `\RuntimeException` into *Checked exception classes*
- [ ] Verify the error now fires on a method that throws `\RuntimeException` without a matching `@throws`
- [ ] Verify typing `RuntimeException` (no backslash) still works

Co-Authored-By: Claude Code