### PR TITLE
Update pocketmine-ng-baseline.neon

### DIFF
--- a/e2e/integration/pocketmine-ng-baseline.neon
+++ b/e2e/integration/pocketmine-ng-baseline.neon
@@ -173,3 +173,21 @@ parameters:
 			identifier: offsetAccess.invalidOffset
 			count: 10
 			path: repo/tools/generate-item-upgrade-schema.php
+
+		-
+			message: '#^Casting to list\<string\> something that''s already list\<string\>\.$#'
+			identifier: cast.useless
+			count: 1
+			path: repo/src/crash/CrashDump.php
+
+		-
+			message: '#^Offset 0\|1 might not exist on non\-empty\-array\{1\?\: \*NEVER\*, 0\?\: \*NEVER\*\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: repo/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
+
+		-
+			message: '#^Offset 0\|1\|2\|3 might not exist on non\-empty\-array\{0\?\: non\-empty\-array\{1\?\: \*NEVER\*, 0\?\: \*NEVER\*\}, 1\?\: non\-empty\-array\{1\?\: \*NEVER\*, 0\?\: \*NEVER\*\}, 2\?\: non\-empty\-array\{1\?\: \*NEVER\*, 0\?\: \*NEVER\*\}, 3\?\: non\-empty\-array\{1\?\: \*NEVER\*, 0\?\: \*NEVER\*\}\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: repo/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php


### PR DESCRIPTION
the [PMMP build needs to be green](https://github.com/phpstan/phpstan/blob/891b9d085c2e6c9c5ec017e50209453abf7d614f/.github/workflows/integration-tests.yml#L583) so the "regenerate baseline" job is working again