### PR TITLE
playground-api: upgrade Node.js runtime from 18 to 24

### DIFF
--- a/playground-api/package-lock.json
+++ b/playground-api/package-lock.json
@@ -17,9 +17,9 @@
 				"zod": "^4.3.6"
 			},
 			"devDependencies": {
-				"@tsconfig/node20": "^20.1.0",
+				"@tsconfig/node24": "^24.0.0",
 				"@types/aws-lambda": "^8.10.112",
-				"@types/node": "^20.0.0",
+				"@types/node": "^24.0.0",
 				"@types/uuid": "^9.0.1",
 				"@typescript-eslint/eslint-plugin": "^6.7.5",
 				"@typescript-eslint/parser": "^6.7.5",
@@ -6010,10 +6010,10 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/@tsconfig/node20": {
-			"version": "20.1.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-			"integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+		"node_modules/@tsconfig/node24": {
+			"version": "24.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
+			"integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -6088,13 +6088,13 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.41",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-			"integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+			"version": "24.12.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.21.0"
+				"undici-types": "~7.16.0"
 			}
 		},
 		"node_modules/@types/responselike": {
@@ -13060,9 +13060,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/playground-api/package.json
+++ b/playground-api/package.json
@@ -20,9 +20,9 @@
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@tsconfig/node20": "^20.1.0",
+		"@tsconfig/node24": "^24.0.0",
 		"@types/aws-lambda": "^8.10.112",
-		"@types/node": "^20.0.0",
+		"@types/node": "^24.0.0",
 		"@types/uuid": "^9.0.1",
 		"@typescript-eslint/eslint-plugin": "^6.7.5",
 		"@typescript-eslint/parser": "^6.7.5",

--- a/playground-api/serverless.yml
+++ b/playground-api/serverless.yml
@@ -2,7 +2,7 @@ service: phpstan-playground-api
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs24.x
   architecture: arm64
   stage: prod
   region: eu-west-1

--- a/playground-api/tsconfig.json
+++ b/playground-api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@tsconfig/node20/tsconfig.json",
+	"extends": "@tsconfig/node24/tsconfig.json",
 	"compilerOptions": {
 		"moduleResolution": "node16",
 		"rootDir": "./",


### PR DESCRIPTION
## Summary
- Bump Lambda runtime from `nodejs18.x` to `nodejs24.x` in `playground-api/serverless.yml`
- Update `@tsconfig/node20` → `@tsconfig/node24` and `@types/node` `^20.0.0` → `^24.0.0`
- Regenerate `package-lock.json`

AWS is ending support for Node.js 20.x on April 30, 2026, and Node.js 18.x is already past EOL. The CI workflow (`update-playground-api.yml`) was already installing Node 24, so this brings the runtime and types in line with what tests run against.

## Test plan
- [x] `npm run check` passes (tsc + eslint, no errors)
- [ ] CI green
- [ ] Deploy succeeds and Lambda functions report `nodejs24.x`