### PR TITLE
website/infra: bump aws-cdk-lib to clear nodejs20.x runtime on OIDC custom resource

### DIFF
--- a/website/infra/package-lock.json
+++ b/website/infra/package-lock.json
@@ -13,8 +13,8 @@
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.0",
-				"aws-cdk": "^2.1010.0",
-				"aws-cdk-lib": "2.189.1",
+				"aws-cdk": "^2.1122.0",
+				"aws-cdk-lib": "2.253.1",
 				"constructs": "^10.4.2",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.7.2",
@@ -22,9 +22,9 @@
 			}
 		},
 		"node_modules/@aws-cdk/asset-awscli-v1": {
-			"version": "2.2.280",
-			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.280.tgz",
-			"integrity": "sha512-O876vn0wQwsWd2D367pPW58bjvg909B8OS6wgwVg5sZUmN53mCCmnxe4bVyon88ZphvSkWgp9mmnfg5IzNAhyw==",
+			"version": "2.2.273",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+			"integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -36,9 +36,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema": {
-			"version": "41.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
-			"integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
+			"version": "53.24.0",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.24.0.tgz",
+			"integrity": "sha512-rCwsd0Y9z4CUmV5FhzjbO2MprXjKG0rxCACuLEY40lD+wInvgcHer0lSDo7Xq9Sxe/IoNe/Wxb2YP3GgxvT3GA==",
 			"bundleDependencies": [
 				"jsonschema",
 				"semver"
@@ -47,10 +47,10 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonschema": "~1.4.1",
-				"semver": "^7.7.1"
+				"semver": "^7.8.0"
 			},
 			"engines": {
-				"node": ">= 14.15.0"
+				"node": ">= 18.0.0"
 			}
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -63,7 +63,7 @@
 			}
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-			"version": "7.7.1",
+			"version": "7.8.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -1142,11 +1142,12 @@
 			}
 		},
 		"node_modules/aws-cdk-lib": {
-			"version": "2.189.1",
-			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.189.1.tgz",
-			"integrity": "sha512-9JU0yUr2iRTJ1oCPrHyx7hOtBDWyUfyOcdb6arlumJnMcQr2cyAMASY8HuAXHc8Y10ipVp8dRTW+J4/132IIYA==",
+			"version": "2.253.1",
+			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.1.tgz",
+			"integrity": "sha512-vy+hA15/ZfSQpivkNdlIn2ZDA2hesp3WJgmtIZJDFwu6xzwv7wH7glbAdu5xCHGcOjepOaTKZSvCPC6sN+0/Vw==",
 			"bundleDependencies": [
 				"@balena/dockerignore",
+				"@aws-cdk/cloud-assembly-api",
 				"case",
 				"fs-extra",
 				"ignore",
@@ -1161,26 +1162,47 @@
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-cdk/asset-awscli-v1": "^2.2.229",
-				"@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-				"@aws-cdk/cloud-assembly-schema": "^41.0.0",
+				"@aws-cdk/asset-awscli-v1": "2.2.273",
+				"@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+				"@aws-cdk/cloud-assembly-api": "^2.2.2",
+				"@aws-cdk/cloud-assembly-schema": "^53.18.0",
 				"@balena/dockerignore": "^1.0.2",
 				"case": "1.6.3",
-				"fs-extra": "^11.3.0",
+				"fs-extra": "^11.3.3",
 				"ignore": "^5.3.2",
 				"jsonschema": "^1.5.0",
 				"mime-types": "^2.1.35",
-				"minimatch": "^3.1.2",
+				"minimatch": "^10.2.3",
 				"punycode": "^2.3.1",
-				"semver": "^7.7.1",
+				"semver": "^7.7.4",
 				"table": "^6.9.0",
-				"yaml": "1.10.2"
+				"yaml": "1.10.3"
 			},
 			"engines": {
-				"node": ">= 14.15.0"
+				"node": ">= 20.0.0"
 			},
 			"peerDependencies": {
-				"constructs": "^10.0.0"
+				"constructs": "^10.5.0"
+			}
+		},
+		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+			"version": "2.2.2",
+			"bundleDependencies": [
+				"jsonschema",
+				"semver"
+			],
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"jsonschema": "~1.4.1",
+				"semver": "^7.7.4"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"peerDependencies": {
+				"@aws-cdk/cloud-assembly-schema": ">=53.15.0"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -1190,7 +1212,7 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/aws-cdk-lib/node_modules/ajv": {
-			"version": "8.17.1",
+			"version": "8.18.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -1239,19 +1261,24 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/balanced-match": {
-			"version": "1.0.2",
+			"version": "4.0.4",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-			"version": "1.1.11",
+			"version": "5.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/case": {
@@ -1281,12 +1308,6 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
-		"node_modules/aws-cdk-lib/node_modules/concat-map": {
-			"version": "0.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
 		"node_modules/aws-cdk-lib/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"dev": true,
@@ -1300,7 +1321,7 @@
 			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fast-uri": {
-			"version": "3.0.6",
+			"version": "3.1.0",
 			"dev": true,
 			"funding": [
 				{
@@ -1316,7 +1337,7 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fs-extra": {
-			"version": "11.3.0",
+			"version": "11.3.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -1360,7 +1381,7 @@
 			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/jsonfile": {
-			"version": "6.1.0",
+			"version": "6.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -1408,15 +1429,18 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/minimatch": {
-			"version": "3.1.2",
+			"version": "10.2.5",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": "*"
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/punycode": {
@@ -1438,7 +1462,7 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/semver": {
-			"version": "7.7.1",
+			"version": "7.7.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -1518,7 +1542,7 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/yaml": {
-			"version": "1.10.2",
+			"version": "1.10.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -1812,9 +1836,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -1832,7 +1856,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/website/infra/package.json
+++ b/website/infra/package.json
@@ -19,8 +19,8 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.0",
-		"aws-cdk": "^2.1010.0",
-		"aws-cdk-lib": "2.189.1",
+		"aws-cdk": "^2.1122.0",
+		"aws-cdk-lib": "2.253.1",
 		"constructs": "^10.4.2",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.7.2",


### PR DESCRIPTION
## Summary

The `PhpstanOrgGithubOidc-CustomAWSCDKOpenIdConnectProv-vQRz2u6mFOi8` Lambda — the custom resource CDK auto-generates for `iam.OpenIdConnectProvider` — is still on `nodejs20.x`, which AWS deprecates for security patching on April 30, 2026 (per the AWS Health email). The runtime isn't a knob in our CDK code; it's baked into `aws-cdk-lib` and updates when we bump the library.

- `aws-cdk-lib` 2.189.1 → **2.253.1**
- `aws-cdk` ^2.1010.0 → ^2.1122.0

`cdk synth` of `PhpstanOrgGithubOidc` now emits `nodejs22.x` for the custom resource handler. CDK's `NODEJS_LATEST` currently caps at 22 across the runtime targets it supports — clearing the deprecation deadline, which is what we need.

### Why 2.253.1 and not 2.255.0 (latest)

`aws-cdk-lib` 2.254.0 and 2.255.0 ship with a bundling regression that makes `npm ci` reject the lockfile — the bundled `@aws-cdk/cloud-assembly-api@2.2.3` declares `jsonschema: ~1.4.1` but the parent bundle ships `jsonschema@1.5.0`, and npm 11's stricter validation flags the conflict. Tracked upstream:

- aws/aws-cdk#37870 — "npm ci fails with Missing: jsonschema@1.4.1 from lock file in aws-cdk-lib@2.254.0"
- aws/aws-cdk#37756 — root-cause discussion

2.253.1 is the highest release before that regression and is unaffected. We can bump again once AWS ships a fix.

No application or stack code changes — purely a dep bump.

## Test plan
- [x] `npm install` produces a lockfile that `npm ci` then accepts (the actual CI failure mode)
- [x] `npm run check` passes
- [x] `npm test` passes (27/27)
- [x] `cdk synth --all` succeeds; OIDC stack's custom resource Runtime is now `nodejs22.x` (was `nodejs20.x`)
- [ ] CI `test` + `diff` jobs green
- [ ] After merge & deploy, the live Lambda function reports `nodejs22.x`