### PR TITLE
Playground: PHPantom autocomplete, hover & signature help via WebAssembly

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -46,9 +46,45 @@ jobs:
         working-directory: ./website
         run: "npm run check"
 
+  build-wasm:
+    name: "Build PHPantom wasm"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: "Checkout"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: "Install Node"
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "24"
+
+      - name: "Install Rust"
+        run: |
+          rustup update stable
+          rustup default stable
+          rustc --version
+
+      - name: "Build wasm (cargo -> wasm32-wasip1)"
+        working-directory: ./website
+        run: "npm run build:wasm"
+
+      - name: "Upload PHPantom wasm"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: phpantom-wasm
+          path: website/src/js/phpantom/pkg-wasi/phpantom_lsp.wasm
+          if-no-files-found: error
+
   build:
     name: "Build"
     runs-on: "ubuntu-latest"
+    needs: build-wasm
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -65,6 +101,12 @@ jobs:
           node-version: "24"
           cache: "npm"
           cache-dependency-path: website/package-lock.json
+
+      - name: "Download PHPantom wasm"
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: phpantom-wasm
+          path: website/src/js/phpantom/pkg-wasi
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # v2
@@ -163,12 +205,60 @@ jobs:
           commit-message: "Update visual tests screenshots"
           committer: "phpstan-bot <ondrej+phpstanbot@mirtes.cz>"
 
+  functional-tests:
+    name: "Functional Tests"
+    runs-on: "ubuntu-latest"
+    needs: build
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: "Checkout"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: "Install Node"
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: website/package-lock.json
+
+      - name: "Download website dist"
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: website-dist
+          path: website/dist
+
+      - name: "Install dependencies"
+        working-directory: ./website
+        run: "npm ci"
+
+      - name: "Install Playwright browsers"
+        working-directory: ./website
+        run: "npx playwright install --with-deps chromium"
+
+      - name: "Run functional tests"
+        working-directory: ./website
+        run: "npm run test:functional"
+
+      - name: "Upload test results"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: failure()
+        with:
+          name: functional-test-results
+          path: website/functional-tests/test-results/
+          retention-days: 30
+
   deploy:
     name: "Deploy"
     needs:
       - typescript-check
       - build
       - visual-regression
+      - functional-tests
     if: "github.ref == 'refs/heads/2.2.x'"
     runs-on: "ubuntu-latest"
     concurrency: website

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -4,3 +4,8 @@
 /visual-tests/test-results/
 /visual-tests/playwright-report/
 /playwright-report/
+
+# PHPantom wasm (built via npm run build:wasm)
+src/js/phpantom/pkg-wasi/*.wasm
+.phpantom-build/
+functional-tests/test-results/

--- a/website/functional-tests/autocomplete.spec.ts
+++ b/website/functional-tests/autocomplete.spec.ts
@@ -1,0 +1,85 @@
+import {test, expect, Page} from '@playwright/test';
+
+// PHPantom runs as wasm in a Web Worker, loaded eagerly when /try opens. The
+// first completion has to wait for that ~11 MB module to download + initialise.
+const COMPLETION_TIMEOUT = 30_000;
+
+// Replace the playground editor's contents with the given PHP.
+async function setCode(page: Page, code: string): Promise<void> {
+	const editor = page.locator('.cm-content').first();
+	await editor.click();
+	await page.keyboard.press('ControlOrMeta+A');
+	await page.keyboard.press('Backspace');
+	await page.keyboard.insertText(code);
+}
+
+function popup(page: Page) {
+	return page.locator('.cm-tooltip-autocomplete');
+}
+
+async function labels(page: Page): Promise<string[]> {
+	return page.locator('.cm-tooltip-autocomplete .cm-completionLabel').allInnerTexts();
+}
+
+test.beforeEach(async ({page}) => {
+	await page.goto('/try');
+	await expect(page.locator('.cm-content').first()).toBeVisible();
+});
+
+test('completes instance methods and properties after ->', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'class Greeter {',
+		'    public function hello(string $name): string { return $name; }',
+		'    public string $title = "";',
+		'}',
+		'$g = new Greeter();',
+		'$g->',
+	].join('\n'));
+
+	await page.keyboard.press('Control+Space');
+	await expect(popup(page)).toBeVisible({timeout: COMPLETION_TIMEOUT});
+
+	const items = await labels(page);
+	expect(items.some((l) => l.startsWith('hello'))).toBeTruthy();
+	expect(items).toContain('title');
+});
+
+test('auto-triggers completion while typing a member name', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'class Greeter { public function greet(): void {} }',
+		'$g = new Greeter();',
+		'$g->gr',
+	].join('\n'));
+
+	// One more typed character (a real keystroke) triggers completion.
+	await page.keyboard.type('e');
+	await expect(popup(page)).toBeVisible({timeout: COMPLETION_TIMEOUT});
+	expect((await labels(page)).some((l) => l.startsWith('greet'))).toBeTruthy();
+});
+
+test('completes static members after ::', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'class Box {',
+		'    public static function make(): self { return new self(); }',
+		'    const VERSION = 1;',
+		'}',
+		'Box::',
+	].join('\n'));
+
+	await page.keyboard.press('Control+Space');
+	await expect(popup(page)).toBeVisible({timeout: COMPLETION_TIMEOUT});
+
+	const items = await labels(page);
+	expect(items.some((l) => l.startsWith('make'))).toBeTruthy();
+	expect(items).toContain('VERSION');
+});
+
+test('completes global functions by prefix', async ({page}) => {
+	await setCode(page, '<?php\n');
+	await page.keyboard.type('str_re');
+	await expect(popup(page)).toBeVisible({timeout: COMPLETION_TIMEOUT});
+	expect((await labels(page)).some((l) => l.startsWith('str_re'))).toBeTruthy();
+});

--- a/website/functional-tests/playwright.config.ts
+++ b/website/functional-tests/playwright.config.ts
@@ -1,0 +1,39 @@
+import {defineConfig, devices} from '@playwright/test';
+
+// Functional (non-screenshot) tests for the playground editor — currently the
+// PHPantom-in-wasm autocomplete. Runs against the built site served from
+// ../dist (so the wasm worker is exercised exactly as shipped).
+//
+// For a quick local run against the dev server instead, set
+// PW_BASE_URL=http://localhost:5173 (this skips the built-site web server).
+const baseURL = process.env.PW_BASE_URL || 'http://localhost:3001';
+
+export default defineConfig({
+	testDir: '.',
+	outputDir: './test-results',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	reporter: process.env.CI ? 'github' : 'list',
+
+	use: {
+		baseURL,
+		trace: 'on-first-retry',
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			use: {...devices['Desktop Chrome'], viewport: {width: 1280, height: 900}},
+		},
+	],
+
+	webServer: process.env.PW_BASE_URL
+		? undefined
+		: {
+				command: 'npx serve ../dist -l 3001',
+				url: baseURL,
+				reuseExistingServer: !process.env.CI,
+				timeout: 120 * 1000,
+		  },
+});

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,9 +9,11 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"@bjorn3/browser_wasi_shim": "^0.4.2",
 				"@codemirror/commands": "^6.2.2",
 				"@codemirror/lang-php": "^6.0.1",
 				"@codemirror/language": "^6.6.0",
+				"@codemirror/lsp-client": "^6.2.4",
 				"@codemirror/search": "^6.7.0",
 				"@codemirror/state": "^6.2.0",
 				"@codemirror/view": "^6.9.2",
@@ -46,6 +48,7 @@
 				"glob": "^13.0.0",
 				"headless-mermaid": "^1.3.0",
 				"luxon": "^3.0.0",
+				"markdown-it": "^14.1.1",
 				"markdown-it-abbr": "^1.0.4",
 				"markdown-it-anchor": "^9.2.0",
 				"markdown-it-attrs": "^4.1.3",
@@ -852,6 +855,12 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/@bjorn3/browser_wasi_shim": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.4.2.tgz",
+			"integrity": "sha512-/iHkCVUG3VbcbmEHn5iIUpIrh7a7WPiwZ3sHy4HZKZzBdSadwdddYDZAII2zBvQYV0Lfi8naZngPCN7WPHI/hA==",
+			"license": "MIT OR Apache-2.0"
+		},
 		"node_modules/@cliqz/adblocker": {
 			"version": "1.26.12",
 			"resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.26.12.tgz",
@@ -898,19 +907,14 @@
 			}
 		},
 		"node_modules/@codemirror/autocomplete": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.11.1.tgz",
-			"integrity": "sha512-L5UInv8Ffd6BPw0P3EF7JLYAMeEbclY7+6Q11REt8vhih8RuLreKtPy/xk8wPxs4EQgYqzI7cdgpiYwWlbS/ow==",
+			"version": "6.20.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
+			"integrity": "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.17.0",
-				"@lezer/common": "^1.0.0"
-			},
-			"peerDependencies": {
-				"@codemirror/language": "^6.0.0",
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0",
 				"@lezer/common": "^1.0.0"
 			}
 		},
@@ -996,13 +1000,30 @@
 			}
 		},
 		"node_modules/@codemirror/lint": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.2.tgz",
-			"integrity": "sha512-wzRkluWb1ptPKdzlsrbwwjYCPLgzU6N88YBAmlZi8WFyuiEduSd05MnJYNogzyc8rPK7pj6m95ptUApc8sHKVA==",
+			"version": "6.9.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
+			"integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0",
+				"@codemirror/view": "^6.42.0",
 				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/lsp-client": {
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lsp-client/-/lsp-client-6.2.4.tgz",
+			"integrity": "sha512-unH8VuWlgbJJxulh0uCrXE0L2xZXpeItIngyKUlpqe5ir/LAMtouf7rnKrVR2ZzGU5FhmMz9PkZ/WFa2WzNSww==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.20.0",
+				"@codemirror/language": "^6.11.0",
+				"@codemirror/lint": "^6.8.5",
+				"@codemirror/state": "^6.5.2",
+				"@codemirror/view": "^6.37.0",
+				"@lezer/highlight": "^1.2.1",
+				"marked": "^15.0.12",
+				"vscode-languageserver-protocol": "^3.17.5"
 			}
 		},
 		"node_modules/@codemirror/search": {
@@ -1732,11 +1753,12 @@
 			}
 		},
 		"node_modules/@lezer/highlight": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
-			"integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+			"license": "MIT",
 			"dependencies": {
-				"@lezer/common": "^1.0.0"
+				"@lezer/common": "^1.3.0"
 			}
 		},
 		"node_modules/@lezer/html": {
@@ -6125,6 +6147,18 @@
 			"integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w==",
 			"dev": true
 		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/mdurl": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -8586,6 +8620,31 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"license": "MIT"
 		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",

--- a/website/package.json
+++ b/website/package.json
@@ -3,9 +3,11 @@
 	"version": "1.0.0",
 	"license": "MIT",
 	"dependencies": {
+		"@bjorn3/browser_wasi_shim": "^0.4.2",
 		"@codemirror/commands": "^6.2.2",
 		"@codemirror/lang-php": "^6.0.1",
 		"@codemirror/language": "^6.6.0",
+		"@codemirror/lsp-client": "^6.2.4",
 		"@codemirror/search": "^6.7.0",
 		"@codemirror/state": "^6.2.0",
 		"@codemirror/view": "^6.9.2",
@@ -40,6 +42,7 @@
 		"glob": "^13.0.0",
 		"headless-mermaid": "^1.3.0",
 		"luxon": "^3.0.0",
+		"markdown-it": "^14.1.1",
 		"markdown-it-abbr": "^1.0.4",
 		"markdown-it-anchor": "^9.2.0",
 		"markdown-it-attrs": "^4.1.3",
@@ -64,8 +67,10 @@
 		"build:11ty": "eleventy",
 		"watch": "run-p watch:*",
 		"build": "npm run build:11ty && npm run build:vite",
+		"build:wasm": "bash scripts/build-wasm.sh",
 		"test:visual": "playwright test --config=visual-tests/playwright.config.ts",
-		"test:visual:update": "playwright test --config=visual-tests/playwright.config.ts --update-snapshots"
+		"test:visual:update": "playwright test --config=visual-tests/playwright.config.ts --update-snapshots",
+		"test:functional": "playwright test --config=functional-tests/playwright.config.ts"
 	},
 	"browserslist": [
 		"defaults",

--- a/website/scripts/build-wasm.sh
+++ b/website/scripts/build-wasm.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Builds the PHPantom language server to WebAssembly (wasm32-wasip1) and writes
+# it to src/js/phpantom/pkg-wasi/phpantom_lsp.wasm, where the playground editor
+# loads it (via @bjorn3/browser_wasi_shim in a Web Worker).
+#
+# We target WASI rather than wasm-bindgen: PHPantom's completion path returns
+# empty results on wasm32-unknown-unknown (a target-specific memory bug) but is
+# correct on wasm32-wasip1.
+#
+# Source lives on the `wasm` branch of the fork. The ref is pinned for
+# reproducible builds — bump PHPANTOM_REF to pull a newer PHPantom.
+#
+# Requirements: git, rustup, and a Rust toolchain >= 1.95 (the mago crates
+# require it). Run as `npm run build:wasm`.
+set -euo pipefail
+
+REPO="${PHPANTOM_REPO:-https://github.com/ondrejmirtes/phpantom_lsp.git}"
+REF="${PHPANTOM_REF:-39cd19623546c06e48fb553b237024183b48835c}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WEBSITE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="${PHPANTOM_BUILD_DIR:-$WEBSITE_DIR/.phpantom-build}"
+OUT="$WEBSITE_DIR/src/js/phpantom/pkg-wasi/phpantom_lsp.wasm"
+
+echo "==> PHPantom wasm build (ref: ${REF:0:12})"
+
+# Fetch the pinned source.
+if [ ! -d "$BUILD_DIR/.git" ]; then
+	echo "==> cloning $REPO"
+	git clone --no-checkout "$REPO" "$BUILD_DIR"
+fi
+git -C "$BUILD_DIR" fetch --depth 1 origin "$REF"
+git -C "$BUILD_DIR" checkout --quiet --detach "$REF"
+
+# Toolchain (the rust-std for the target; rustc itself must already be >= 1.95).
+echo "==> ensuring wasm32-wasip1 target"
+rustup target add wasm32-wasip1
+
+echo "==> cargo build --release --target wasm32-wasip1"
+( cd "$BUILD_DIR" && cargo build --lib --release --target wasm32-wasip1 )
+
+mkdir -p "$(dirname "$OUT")"
+cp "$BUILD_DIR/target/wasm32-wasip1/release/phpantom_lsp.wasm" "$OUT"
+echo "==> wrote $OUT ($(du -h "$OUT" | cut -f1))"

--- a/website/src/app.pcss
+++ b/website/src/app.pcss
@@ -252,3 +252,31 @@ h3.hash-target code {
 .options-dialog::backdrop {
 	@apply bg-black/50;
 }
+
+/* PHPantom (wasm) hover tooltip — rendered Markdown with Prism-highlighted PHP. */
+.cm-phpantom-hover {
+	@apply max-w-lg rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs leading-relaxed text-gray-900 shadow-lg dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100;
+	max-height: 320px;
+	overflow: auto;
+}
+.cm-phpantom-hover > :first-child {
+	@apply mt-0;
+}
+.cm-phpantom-hover > :last-child {
+	@apply mb-0;
+}
+.cm-phpantom-hover p {
+	@apply my-1;
+}
+.cm-phpantom-hover pre {
+	@apply my-1 overflow-auto rounded-md bg-gray-50 p-2;
+}
+.cm-phpantom-hover pre code {
+	@apply text-xs font-normal;
+}
+.cm-phpantom-hover :not(pre) > code {
+	@apply rounded bg-gray-100 px-1 dark:bg-gray-700;
+}
+.cm-phpantom-hover hr {
+	@apply my-2 border-gray-200 dark:border-gray-600;
+}

--- a/website/src/js/codeMirror.ts
+++ b/website/src/js/codeMirror.ts
@@ -5,7 +5,7 @@ import {keymap, highlightSpecialChars, drawSelection,
 import {Compartment, EditorState} from '@codemirror/state'
 import {defaultHighlightStyle, syntaxHighlighting, indentOnInput, indentUnit, bracketMatching} from '@codemirror/language'
 import {defaultKeymap, history, historyField, historyKeymap, indentWithTab} from '@codemirror/commands'
-import {closeBrackets, closeBracketsKeymap} from '@codemirror/autocomplete'
+import {closeBrackets, closeBracketsKeymap, completionKeymap} from '@codemirror/autocomplete'
 import {highlightSelectionMatches} from '@codemirror/search'
 import {php} from '@codemirror/lang-php'
 import { PHPStanError } from './PHPStanError';
@@ -15,6 +15,8 @@ import {hover} from "./editor/hover";
 import {materialDark} from "./editor/darkTheme";
 import {urlIdField, urlIdExtensions} from "./editor/urlId";
 import {docBlockKeymap} from "./editor/docBlock";
+import {phpantomHover} from "./editor/phpantomHover";
+import {phpantomLsp, PHP_URI} from "./phpantom/lspClient";
 
 ko.bindingHandlers.codeMirror = {
 	init: (element, valueAccessor, allBindings, viewModel, bindingContext) => {
@@ -51,6 +53,7 @@ ko.bindingHandlers.codeMirror = {
 			// highlightActiveLine(),
 			// highlightSelectionMatches(),
 			keymap.of([
+				...completionKeymap,
 				...docBlockKeymap,
 				indentWithTab,
 				...closeBracketsKeymap,
@@ -58,7 +61,6 @@ ko.bindingHandlers.codeMirror = {
 				// ...searchKeymap,
 				...historyKeymap,
 				// ...foldKeymap,
-				// ...completionKeymap,
 				// ...lintKeymap
 			]),
 			php(),
@@ -84,6 +86,8 @@ ko.bindingHandlers.codeMirror = {
 			errorsCompartment.of(errorsFacet.of(errors)),
 			lineErrors,
 			hover,
+			phpantomHover,
+			phpantomLsp.plugin(PHP_URI, 'php'),
 			EditorView.baseTheme({
 				'.cm-tooltip.cm-tooltip-hover': {
 					border: 'none',

--- a/website/src/js/editor/phpantomHover.ts
+++ b/website/src/js/editor/phpantomHover.ts
@@ -1,0 +1,82 @@
+import {hoverTooltip} from '@codemirror/view';
+import MarkdownIt from 'markdown-it';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-markup-templating';
+import 'prismjs/components/prism-php';
+import {phpantomLsp, PHP_URI} from '../phpantom/lspClient';
+
+// PHPantom returns LSP hover as Markdown (fenced ```php blocks for signatures,
+// prose for docblock descriptions). Render it properly, with Prism syntax
+// highlighting for the PHP code blocks (the prism-ghcolors theme is already
+// imported globally in app.pcss, so tokens get coloured for free).
+let md: MarkdownIt | null = null;
+function markdown(): MarkdownIt {
+	if (md === null) {
+		md = new MarkdownIt({
+			html: false,
+			linkify: true,
+			highlight: (str, lang) => {
+				if (lang === 'php' && Prism.languages.php) {
+					// Drop the redundant leading `<?php` PHPantom prepends to signatures.
+					const code = str.replace(/^<\?php\n/, '');
+					try {
+						return Prism.highlight(code, Prism.languages.php, 'php');
+					} catch {
+						// fall through to default escaping
+					}
+				}
+				return '';
+			},
+		});
+	}
+	return md;
+}
+
+interface LspHover {
+	contents?: {value?: string} | string;
+}
+
+interface HoverParams {
+	textDocument: {uri: string};
+	position: {line: number; character: number};
+}
+
+// Live hover backed by PHPantom-in-wasm, over the shared LSP client. Separate
+// from the PHPStan error hover (editor/hover.ts) — both tooltip sources coexist.
+// We render hover ourselves (rather than lsp-client's hoverTooltips) to get
+// Prism-highlighted code blocks.
+export const phpantomHover = hoverTooltip(async (view, pos) => {
+	const doc = view.state.doc;
+	const line = doc.lineAt(pos);
+
+	let hover: LspHover | null;
+	try {
+		hover = await phpantomLsp.request<HoverParams, LspHover | null>('textDocument/hover', {
+			textDocument: {uri: PHP_URI},
+			position: {line: line.number - 1, character: pos - line.from},
+		});
+	} catch {
+		return null;
+	}
+	if (!hover) {
+		return null;
+	}
+
+	const value = typeof hover.contents === 'string' ? hover.contents : hover.contents?.value;
+	if (!value) {
+		return null;
+	}
+
+	const html = markdown().render(value);
+
+	return {
+		pos,
+		above: true,
+		create() {
+			const dom = document.createElement('div');
+			dom.className = 'cm-phpantom-hover';
+			dom.innerHTML = html;
+			return {dom};
+		},
+	};
+});

--- a/website/src/js/phpantom/lspClient.ts
+++ b/website/src/js/phpantom/lspClient.ts
@@ -1,0 +1,14 @@
+import {LSPClient, serverCompletion, signatureHelp} from '@codemirror/lsp-client';
+import {createPhpantomTransport} from './transport';
+
+// Stable virtual URI for the single playground document.
+export const PHP_URI = 'file:///try/main.php';
+
+// One PHPantom LSP client per page, talking to the wasm worker. We include
+// only completion + signature help here: hover is rendered by our own
+// Prism-highlighted source (editor/phpantomHover.ts) via phpantomLsp.request(),
+// and diagnostics stay with PHPStan on the server (its result panel is
+// authoritative — we don't want PHPantom squiggles disagreeing with it).
+export const phpantomLsp = new LSPClient({
+	extensions: [serverCompletion(), signatureHelp()],
+}).connect(createPhpantomTransport());

--- a/website/src/js/phpantom/transport.ts
+++ b/website/src/js/phpantom/transport.ts
@@ -1,0 +1,27 @@
+import {Transport} from '@codemirror/lsp-client';
+
+// A @codemirror/lsp-client Transport that runs the PHPantom language server
+// (compiled to wasm) inside a Web Worker, exchanging LSP JSON-RPC messages.
+export function createPhpantomTransport(): Transport {
+	const worker = new Worker(new URL('./worker.ts', import.meta.url), {type: 'module'});
+	const handlers = new Set<(value: string) => void>();
+
+	worker.onmessage = (e: MessageEvent) => {
+		const message = e.data as string;
+		for (const handler of handlers) {
+			handler(message);
+		}
+	};
+
+	return {
+		send(message: string) {
+			worker.postMessage(message);
+		},
+		subscribe(handler: (value: string) => void) {
+			handlers.add(handler);
+		},
+		unsubscribe(handler: (value: string) => void) {
+			handlers.delete(handler);
+		},
+	};
+}

--- a/website/src/js/phpantom/worker.ts
+++ b/website/src/js/phpantom/worker.ts
@@ -1,0 +1,76 @@
+// Web Worker hosting the PHPantom language server (compiled to wasm32-wasip1)
+// under a browser WASI runtime. It speaks LSP JSON-RPC: each posted message is
+// marshalled into wasm memory, handed to `lsp_handle`, and the response posted
+// back. Notifications produce no response.
+//
+// We target WASI rather than wasm-bindgen because PHPantom's completion path
+// hits a memory-corruption bug on wasm32-unknown-unknown but is correct on
+// wasm32-wasip1.
+import {WASI, OpenFile, File as WasiFile, ConsoleStdout} from '@bjorn3/browser_wasi_shim';
+
+// `self` is a DedicatedWorkerGlobalScope here; typed loosely to avoid pulling
+// the webworker lib into the project's DOM-typed build.
+const ctx = self as unknown as {
+	onmessage: ((e: MessageEvent) => void) | null;
+	postMessage: (message: unknown) => void;
+};
+
+interface LspExports {
+	memory: WebAssembly.Memory;
+	lsp_alloc: (len: number) => number;
+	lsp_dealloc: (ptr: number, len: number) => void;
+	// Returns a pointer to the response (length via lsp_response_len), or 0.
+	lsp_handle: (ptr: number, len: number) => number;
+	lsp_response_len: () => number;
+}
+
+let lsp: LspExports | null = null;
+let initPromise: Promise<void> | null = null;
+
+function ensureReady(): Promise<void> {
+	if (initPromise === null) {
+		initPromise = (async () => {
+			const url = new URL('./pkg-wasi/phpantom_lsp.wasm', import.meta.url);
+			const wasi = new WASI([], [], [
+				new OpenFile(new WasiFile([])), // fd 0: stdin (unused)
+				ConsoleStdout.lineBuffered((m: string) => console.log('[phpantom]', m)), // fd 1
+				ConsoleStdout.lineBuffered((m: string) => console.warn('[phpantom]', m)), // fd 2
+			]);
+			const bytes = await (await fetch(url)).arrayBuffer();
+			const module = await WebAssembly.compile(bytes);
+			const instance = await WebAssembly.instantiate(module, {
+				wasi_snapshot_preview1: wasi.wasiImport,
+			});
+			wasi.initialize(instance as unknown as Parameters<WASI['initialize']>[0]); // reactor
+			lsp = instance.exports as unknown as LspExports;
+		})();
+	}
+	return initPromise;
+}
+
+function callHandle(message: string): string | undefined {
+	const ex = lsp!;
+	const bytes = new TextEncoder().encode(message);
+	const inPtr = ex.lsp_alloc(bytes.length);
+	new Uint8Array(ex.memory.buffer, inPtr, bytes.length).set(bytes);
+	const outPtr = ex.lsp_handle(inPtr, bytes.length);
+	ex.lsp_dealloc(inPtr, bytes.length);
+	if (outPtr === 0) {
+		return undefined;
+	}
+	const outLen = ex.lsp_response_len();
+	// .slice() copies out of wasm memory before we free it (and before any
+	// later call grows/detaches the buffer).
+	const response = new TextDecoder().decode(new Uint8Array(ex.memory.buffer, outPtr, outLen).slice());
+	ex.lsp_dealloc(outPtr, outLen);
+	return response;
+}
+
+ctx.onmessage = async (e: MessageEvent) => {
+	const message = e.data as string;
+	await ensureReady();
+	const response = callHandle(message);
+	if (response !== undefined) {
+		ctx.postMessage(response);
+	}
+};

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "ES6",
-		"module": "commonjs",
+		"module": "esnext",
 		"strict": true,
 		"moduleResolution": "node",
 		"lib": ["dom", "es2015"],


### PR DESCRIPTION
## What

Brings IDE-style editor intelligence to the `/try` playground — **autocomplete**, **hover**, and **signature help** — powered by the [PHPantom](https://github.com/PHPantom-dev/phpantom_lsp) language server compiled to WebAssembly and run **entirely in the browser**.

PHPStan (on Lambda) stays the authoritative source for the error panel. PHPantom only provides editor assistance, so its own diagnostics are deliberately **not** surfaced — no conflicting squiggles.

## How it works

- **`@codemirror/lsp-client`** drives `serverCompletion` (members after `->`, statics after `::`, and bare function/class/constant prefixes — e.g. typing `str_re` offers `str_replace`) plus `signatureHelp`. Hover is rendered by us with `markdown-it` + Prism-highlighted PHP.
- A **Web Worker** (`src/js/phpantom/`) hosts the wasm and speaks **LSP JSON-RPC** over a small `Transport`. The worker runs the wasm under [`@bjorn3/browser_wasi_shim`](https://github.com/bjorn3/browser_wasi_shim).
- The wasm is built from the PHPantom fork to **`wasm32-wasip1`**. We target WASI rather than wasm-bindgen because completion hits a target-specific memory-corruption bug on `wasm32-unknown-unknown` but is correct on WASI.

## Build & CI — no manual steps

- **`npm run build:wasm`** (`scripts/build-wasm.sh`) clones the fork at a pinned commit, builds the `wasm32-wasip1` reactor, and drops it in `src/js/phpantom/pkg-wasi/`. The 11 MB wasm is **gitignored** and produced by CI.
- **`website.yml`**: a new `build-wasm` job compiles the wasm; the `build` job downloads and bundles it; a new `functional-tests` job runs the autocomplete tests; `deploy` gates on build + visual regression + functional tests.

## Tests

`functional-tests/` — Playwright autocomplete tests over small PHP snippets (`->` members, `::` statics, global prefixes, auto-trigger while typing). Run with **`npm run test:functional`**. Verified locally against the production-built `dist`.

## Notes

- The ~11 MB wasm is **eager-loaded** on `/try` (intentional) in a background worker; the editor is usable immediately and completion lights up once it's ready.
- `tsconfig` `module` bumped `commonjs → esnext` (the worker uses `import.meta.url`).
- The `wasm32-unknown-unknown` bug is avoided, not fixed upstream — worth a heads-up to the mago/PHPantom maintainers if we want it cured there too.
- Heads-up: the existing visual-regression job screenshots `/try`; the editor's static appearance shouldn't change (completion/hover are interaction-only), but if a baseline shifts, run `npm run test:visual:update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
