### PR TITLE
Autocomplete PHPStan's own symbols in the playground

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -122,6 +122,10 @@ jobs:
         working-directory: ./website
         run: echo -n "$(git rev-parse --short HEAD)" > src/release.txt
 
+      - name: "Fetch PHPStan stub shells"
+        working-directory: ./website
+        run: "npm run build:stubs"
+
       - name: "Build"
         working-directory: ./website
         run: "npm run build"

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -9,3 +9,6 @@
 src/js/phpantom/pkg-wasi/*.wasm
 .phpantom-build/
 functional-tests/test-results/
+
+# PHPStan stub shells (fetched via npm run build:stubs)
+src/js/phpantom/stubs/*.php

--- a/website/functional-tests/autocomplete.spec.ts
+++ b/website/functional-tests/autocomplete.spec.ts
@@ -83,3 +83,10 @@ test('completes global functions by prefix', async ({page}) => {
 	await expect(popup(page)).toBeVisible({timeout: COMPLETION_TIMEOUT});
 	expect((await labels(page)).some((l) => l.startsWith('str_re'))).toBeTruthy();
 });
+
+test('completes PHPStan stub functions shipped from phpstan-src', async ({page}) => {
+	await setCode(page, '<?php\n\\PHPStan\\Testing\\assertT');
+	await page.keyboard.press('Control+Space');
+	await expect(popup(page)).toBeVisible({timeout: COMPLETION_TIMEOUT});
+	expect((await labels(page)).some((l) => l.startsWith('assertType'))).toBeTruthy();
+});

--- a/website/package.json
+++ b/website/package.json
@@ -68,6 +68,7 @@
 		"watch": "run-p watch:*",
 		"build": "npm run build:11ty && npm run build:vite",
 		"build:wasm": "bash scripts/build-wasm.sh",
+		"build:stubs": "bash scripts/fetch-stubs.sh",
 		"test:visual": "playwright test --config=visual-tests/playwright.config.ts",
 		"test:visual:update": "playwright test --config=visual-tests/playwright.config.ts --update-snapshots",
 		"test:functional": "playwright test --config=functional-tests/playwright.config.ts"

--- a/website/scripts/fetch-stubs.sh
+++ b/website/scripts/fetch-stubs.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Fetches PHPStan's stub shells (declaration-only PHP) from phpstan-src into
+# src/js/phpantom/stubs/. The playground worker opens these as hidden documents
+# on startup, so the editor autocompletes PHPStan's own symbols alongside
+# phpstorm-stubs and the symbols from the file being edited.
+#
+# These ship from phpstan-src so they stay in sync with the real definitions.
+# Run as `npm run build:stubs` (and in CI before the website build).
+set -euo pipefail
+
+REF="${PHPSTAN_SRC_REF:-2.2.x}"
+BASE="https://raw.githubusercontent.com/phpstan/phpstan-src/${REF}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/src/js/phpantom/stubs"
+mkdir -p "$OUT_DIR"
+
+# <source path in phpstan-src> <local filename>
+fetch() {
+	curl -fsSL "$BASE/$1" -o "$OUT_DIR/$2"
+	echo "==> $2 ($(wc -c <"$OUT_DIR/$2") bytes) from $1@${REF}"
+}
+
+echo "==> fetching PHPStan stub shells (ref: ${REF})"
+fetch "src/Testing/functions.php" "Testing.php"

--- a/website/src/js/phpantom/worker.ts
+++ b/website/src/js/phpantom/worker.ts
@@ -7,6 +7,14 @@
 // hits a memory-corruption bug on wasm32-unknown-unknown but is correct on
 // wasm32-wasip1.
 import {WASI, OpenFile, File as WasiFile, ConsoleStdout} from '@bjorn3/browser_wasi_shim';
+// PHPStan stub shells fetched from phpstan-src by `npm run build:stubs`. Opened
+// as hidden documents (below) so the editor autocompletes PHPStan's own symbols
+// alongside phpstorm-stubs and the file being edited.
+import testingStub from './stubs/Testing.php?raw';
+
+const STUBS: ReadonlyArray<{uri: string; text: string}> = [
+	{uri: 'file:///stubs/phpstan/Testing.php', text: testingStub},
+];
 
 // `self` is a DedicatedWorkerGlobalScope here; typed loosely to avoid pulling
 // the webworker lib into the project's DOM-typed build.
@@ -66,10 +74,29 @@ function callHandle(message: string): string | undefined {
 	return response;
 }
 
+let stubsLoaded = false;
+
+// Open the PHPStan stub shells once, right after the client's `initialize`, so
+// their symbols are indexed before any completion request. They use hidden
+// `file:///stubs/...` URIs the editor never references.
+function loadStubs(): void {
+	for (const stub of STUBS) {
+		callHandle(JSON.stringify({
+			jsonrpc: '2.0',
+			method: 'textDocument/didOpen',
+			params: {textDocument: {uri: stub.uri, languageId: 'php', version: 1, text: stub.text}},
+		}));
+	}
+}
+
 ctx.onmessage = async (e: MessageEvent) => {
 	const message = e.data as string;
 	await ensureReady();
 	const response = callHandle(message);
+	if (!stubsLoaded) {
+		stubsLoaded = true;
+		loadStubs();
+	}
 	if (response !== undefined) {
 		ctx.postMessage(response);
 	}


### PR DESCRIPTION
The `/try` editor completes phpstorm-stubs and symbols from the file being
edited, but not PHPStan's own functions. This adds PHPStan's stub shells so
e.g. `\PHPStan\Testing\assertType()` autocompletes.

- `build:stubs` (`scripts/fetch-stubs.sh`) fetches declaration-only PHP from
  `phpstan-src@2.2.x` into `src/js/phpantom/stubs/` (gitignored; run in CI
  before the build), so the stubs ship from and stay in sync with PHPStan
  sources.
- The worker opens them as hidden `file:///stubs/...` documents on startup.
  mago indexes every open file into one symbol table, so they complete
  alongside phpstorm-stubs and the edited file (confirmed with the WASI build).
- Starts with `src/Testing/functions.php` (`assertType`, `assertNativeType`,
  `assertSuperType`, ...). More shells can be added to the fetch list — e.g. a
  `TrinaryLogic` shell if we want that parameter type to resolve.

Functional test added; full suite (5) green.