### PR TITLE
Playground: ship CodeMirror completion fixes via patch-package

### DIFF
--- a/website/functional-tests/autocomplete.spec.ts
+++ b/website/functional-tests/autocomplete.spec.ts
@@ -90,3 +90,44 @@ test('completes PHPStan stub functions shipped from phpstan-src', async ({page})
 	await expect(popup(page)).toBeVisible({timeout: COMPLETION_TIMEOUT});
 	expect((await labels(page)).some((l) => l.startsWith('assertType'))).toBeTruthy();
 });
+
+// The two tests below depend on the patched @codemirror/autocomplete and
+// @codemirror/lsp-client (see patches/). Without those patches the parameter
+// placeholder isn't selected and the auto-import use statement isn't applied.
+test('selects the parameter placeholder after completing a method with args', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'class Greeter { public function greet(string $name): void {} }',
+		'$g = new Greeter();',
+		'$g->gree',
+	].join('\n'));
+
+	await page.keyboard.press('Control+Space');
+	await expect(popup(page)).toBeVisible({timeout: COMPLETION_TIMEOUT});
+	// Wait until the worker has actually surfaced greet before accepting it.
+	await expect.poll(() => labels(page), {timeout: COMPLETION_TIMEOUT}).toContain('greet($name)');
+	await page.keyboard.press('Enter');
+
+	// The first placeholder ($name) is selected — not the empty $0 — and the
+	// LSP escape is unescaped (no leading backslash).
+	await expect.poll(() => page.evaluate(() => window.getSelection()!.toString())).toBe('$name');
+});
+
+test('adds a use statement when completing a class inside a namespace', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'',
+		'namespace App;',
+		'',
+		'DateTimeImmu',
+	].join('\n'));
+
+	await page.keyboard.press('Control+Space');
+	await expect(popup(page)).toBeVisible({timeout: COMPLETION_TIMEOUT});
+	await expect.poll(() => labels(page), {timeout: COMPLETION_TIMEOUT}).toContain('DateTimeImmutable');
+	await page.keyboard.press('Enter');
+
+	// additionalTextEdits add the import alongside the inserted name.
+	const doc = page.locator('.cm-content').first();
+	await expect(doc).toContainText('use DateTimeImmutable;');
+});

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "phpstan-website",
 			"version": "1.0.0",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bjorn3/browser_wasi_shim": "^0.4.2",
@@ -54,6 +55,7 @@
 				"markdown-it-attrs": "^4.1.3",
 				"markdown-it-footnote": "^3.0.3",
 				"npm-run-all2": "^5.0.0",
+				"patch-package": "^8.0.1",
 				"postcss": "^8.3.9",
 				"postcss-modules": "^6.0.0",
 				"reading-time": "^1.3.0",
@@ -3205,6 +3207,13 @@
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
 			"dev": true
 		},
+		"node_modules/@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/@zeit/schemas": {
 			"version": "2.36.0",
 			"resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
@@ -3686,6 +3695,56 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/call-bind": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3800,6 +3859,22 @@
 			},
 			"peerDependencies": {
 				"devtools-protocol": "*"
+			}
+		},
+		"node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/cli-boxes": {
@@ -4042,6 +4117,24 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/delegated-events": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/delegated-events/-/delegated-events-1.1.2.tgz",
@@ -4184,6 +4277,21 @@
 				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4268,6 +4376,39 @@
 			"dev": true,
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/esbuild": {
@@ -4831,6 +4972,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/find-yarn-workspace-root": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"micromatch": "^4.0.2"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -4879,6 +5030,31 @@
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
 			"dev": true
 		},
+		"node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4925,6 +5101,45 @@
 			"dev": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stream": {
@@ -5046,6 +5261,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5106,11 +5334,38 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/hasown": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -5551,6 +5806,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5619,11 +5881,64 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
+		"node_modules/json-stable-stringify": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+			"integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"isarray": "^2.0.5",
+				"jsonify": "^0.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonfile/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/jsonify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+			"integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+			"dev": true,
+			"license": "Public Domain",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/junk": {
 			"version": "3.1.0",
@@ -5651,6 +5966,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"node_modules/kleur": {
@@ -6159,6 +6484,16 @@
 				"node": ">= 18"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/mdurl": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -6553,6 +6888,16 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -6596,6 +6941,23 @@
 			},
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6715,6 +7077,46 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/patch-package": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+			"integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^3.7.0",
+				"cross-spawn": "^7.0.3",
+				"find-yarn-workspace-root": "^2.0.0",
+				"fs-extra": "^10.0.0",
+				"json-stable-stringify": "^1.0.2",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.6",
+				"open": "^7.4.2",
+				"semver": "^7.5.3",
+				"slash": "^2.0.0",
+				"tmp": "^0.2.4",
+				"yaml": "^2.2.2"
+			},
+			"bin": {
+				"patch-package": "index.js"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">5"
+			}
+		},
+		"node_modules/patch-package/node_modules/slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/path-exists": {
@@ -7930,6 +8332,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -8280,6 +8700,16 @@
 			"dev": true,
 			"dependencies": {
 				"tldts-core": "^6.1.2"
+			}
+		},
+		"node_modules/tmp": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -8813,6 +9243,22 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yargs": {

--- a/website/package.json
+++ b/website/package.json
@@ -48,6 +48,7 @@
 		"markdown-it-attrs": "^4.1.3",
 		"markdown-it-footnote": "^3.0.3",
 		"npm-run-all2": "^5.0.0",
+		"patch-package": "^8.0.1",
 		"postcss": "^8.3.9",
 		"postcss-modules": "^6.0.0",
 		"reading-time": "^1.3.0",
@@ -59,6 +60,7 @@
 		"vite-plugin-static-copy": "^3.2.0"
 	},
 	"scripts": {
+		"postinstall": "patch-package",
 		"check": "tsc -p tsconfig.json --noEmit && eslint -c .eslintrc.js --ext .ts",
 		"fix": "eslint -c .eslintrc.js --fix --ext .ts",
 		"watch:vite": "vite --config vite.config.js",

--- a/website/patches/@codemirror+autocomplete+6.20.2.patch
+++ b/website/patches/@codemirror+autocomplete+6.20.2.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/@codemirror/autocomplete/dist/index.js b/node_modules/@codemirror/autocomplete/dist/index.js
+index 73183bf..c7f657a 100644
+--- a/node_modules/@codemirror/autocomplete/dist/index.js
++++ b/node_modules/@codemirror/autocomplete/dist/index.js
+@@ -1485,9 +1485,16 @@ class Snippet {
+                         found = i;
+                 }
+                 if (found < 0) {
++                    // ${0} is the final tab stop, so it sorts after every other field.
+                     let i = 0;
+-                    while (i < fields.length && (seq == null || (fields[i].seq != null && fields[i].seq < seq)))
+-                        i++;
++                    if (seq === 0) {
++                        i = fields.length;
++                    }
++                    else {
++                        while (i < fields.length && (seq == null ? fields[i].seq !== 0
++                            : fields[i].seq != null && fields[i].seq !== 0 && fields[i].seq < seq))
++                            i++;
++                    }
+                     fields.splice(i, 0, { seq, name });
+                     found = i;
+                     for (let pos of positions)

--- a/website/patches/@codemirror+lsp-client+6.2.4.patch
+++ b/website/patches/@codemirror+lsp-client+6.2.4.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/@codemirror/lsp-client/dist/index.js b/node_modules/@codemirror/lsp-client/dist/index.js
+index d05b720..fd286e8 100644
+--- a/node_modules/@codemirror/lsp-client/dist/index.js
++++ b/node_modules/@codemirror/lsp-client/dist/index.js
+@@ -3,7 +3,7 @@ import { ChangeSet, MapMode, Facet, EditorState, StateField, StateEffect, Prec }
+ import { language, highlightingFor, getIndentUnit, indentUnit } from '@codemirror/language';
+ import { Marked } from 'marked';
+ import { highlightCode } from '@lezer/highlight';
+-import { autocompletion, snippet } from '@codemirror/autocomplete';
++import { autocompletion, snippet, insertCompletionText } from '@codemirror/autocomplete';
+ import { setDiagnostics } from '@codemirror/lint';
+ 
+ let context = null;
+@@ -918,11 +918,36 @@ const serverCompletionSource = context => {
+                     option.detail = item.detail;
+                 if (item.sortText)
+                     option.sortText = item.sortText;
++                let editApply;
+                 if (insertTextFormat == 2 /* Snippet */) {
+-                    option.apply = (view, c, from, to) => snippet(text.replace(/\$(\d+)/g, "${$1}"))(view, c, from, to);
++                    // Unescape LSP snippet escapes (\$, \}, \\) and brace bare $N tab stops.
++                    editApply = (view, c, from, to) => snippet(text.replace(/\\([$}\\])|\$(\d+)/g, (_m, e, f) => e != null ? e : "${" + f + "}"))(view, c, from, to);
+                 }
+                 else if (option.label != text) {
+-                    option.apply = text;
++                    editApply = text;
++                }
++                let extraEdits = item.additionalTextEdits;
++                if (extraEdits && extraEdits.length) {
++                    // Apply additionalTextEdits (e.g. an auto-import `use` statement) along
++                    // with the completion, remapping the completion range through them.
++                    let edits = extraEdits;
++                    option.apply = (view, c, from, to) => {
++                        let changes = view.state.changes(edits.map(e => ({
++                            from: plugin.fromPosition(e.range.start),
++                            to: plugin.fromPosition(e.range.end),
++                            insert: e.newText,
++                        })));
++                        view.dispatch({ changes });
++                        from = changes.mapPos(from, 1);
++                        to = changes.mapPos(to, 1);
++                        if (typeof editApply == "function")
++                            editApply(view, c, from, to);
++                        else
++                            view.dispatch(insertCompletionText(view.state, editApply ?? text, from, to));
++                    };
++                }
++                else if (editApply != null) {
++                    option.apply = editApply;
+                 }
+                 if (item.documentation)
+                     option.info = () => renderDocInfo(plugin, item.documentation);


### PR DESCRIPTION
The published `@codemirror/autocomplete` and `@codemirror/lsp-client` are missing three completion fixes (all submitted upstream on Marijn's instance):

- **snippet backslash escapes** — `\$` was inserted literally (`foo(\$bar)`)
- **`$0` as the final tab stop** — completing a method now selects the parameter placeholder instead of the empty exit stop
- **`additionalTextEdits`** — completing a class inside a namespace now adds the `use` import

This patches both packages locally with [patch-package](https://www.npmjs.com/package/patch-package) until those releases land, applied automatically on install via a `postinstall` hook. `@codemirror/autocomplete` is deduped to a single copy, so one patch covers every consumer (no `overrides` needed).

Functional tests added for placeholder selection and namespace auto-import.

Drop the patches once the deps are bumped to a release that includes the fixes — they fail loudly on a version change.

Note: touches `package.json`/`package-lock.json` and `functional-tests/autocomplete.spec.ts`, so it'll conflict with the stubs-loader PR; whichever lands first, the other needs a trivial rebase.
