### PR TITLE
Playground: Cmd/Ctrl-click go-to-definition

### DIFF
--- a/website/functional-tests/autocomplete.spec.ts
+++ b/website/functional-tests/autocomplete.spec.ts
@@ -124,7 +124,7 @@ test('selects the parameter placeholder after completing a method with args', as
 
 	// The first placeholder ($name) is selected — not the empty $0 — and the
 	// LSP escape is unescaped (no leading backslash).
-	await expect.poll(() => page.evaluate(() => window.getSelection()!.toString())).toBe('$name');
+	await expect.poll(() => page.evaluate(() => window.getSelection()!.toString()), {timeout: COMPLETION_TIMEOUT}).toBe('$name');
 });
 
 test('adds a use statement when completing a class inside a namespace', async ({page}) => {
@@ -144,4 +144,27 @@ test('adds a use statement when completing a class inside a namespace', async ({
 	// additionalTextEdits add the import alongside the inserted name.
 	const doc = page.locator('.cm-content').first();
 	await expect(doc).toContainText('use DateTimeImmutable;');
+});
+
+test('Cmd/Ctrl-click jumps to an in-file declaration', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'class Greeter {',
+		'    public function greet(): string { return "hi"; }',
+		'}',
+		'$g = new Greeter();',
+		'$g->greet();',
+	].join('\n'));
+	// Let the worker index the document before resolving the definition.
+	await page.waitForTimeout(500);
+
+	// Modifier-click the greet() call (second 'greet' token; the first is the
+	// declaration). ControlOrMeta maps to Cmd on macOS, Ctrl elsewhere — the
+	// same split the extension uses.
+	await page.locator('.cm-content').getByText('greet', {exact: true}).nth(1)
+		.click({modifiers: ['ControlOrMeta']});
+
+	// The declaration line flashes (and the cursor jumps there).
+	await expect(page.locator('.cm-goto-def-flash'))
+		.toContainText('function greet', {timeout: COMPLETION_TIMEOUT});
 });

--- a/website/functional-tests/playwright.config.ts
+++ b/website/functional-tests/playwright.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
 	testDir: '.',
 	outputDir: './test-results',
 	fullyParallel: true,
+	// Each page downloads + compiles the ~11 MB PHPantom wasm; running them in
+	// parallel contends for CPU/memory and makes completion/jump requests flaky.
+	// Serialise the suite to keep it stable (it's only a handful of tests).
+	workers: 1,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
 	reporter: process.env.CI ? 'github' : 'list',

--- a/website/scripts/build-wasm.sh
+++ b/website/scripts/build-wasm.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 REPO="${PHPANTOM_REPO:-https://github.com/ondrejmirtes/phpantom_lsp.git}"
-REF="${PHPANTOM_REF:-39cd19623546c06e48fb553b237024183b48835c}"
+REF="${PHPANTOM_REF:-f196a7fb80b01cc7f4a9ad5bf7d75de47f1a4edc}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WEBSITE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/website/src/app.pcss
+++ b/website/src/app.pcss
@@ -280,3 +280,20 @@ h3.hash-target code {
 .cm-phpantom-hover hr {
 	@apply my-2 border-gray-200 dark:border-gray-600;
 }
+
+/* Cmd/Ctrl-hover affordance + jump-target flash for go-to-definition. */
+.cm-goto-def-link {
+	cursor: pointer;
+	text-decoration: underline;
+}
+.cm-goto-def-flash {
+	animation: cm-goto-def-flash 1.2s ease-out;
+}
+@keyframes cm-goto-def-flash {
+	from {
+		background-color: rgba(250, 204, 21, 0.45);
+	}
+	to {
+		background-color: transparent;
+	}
+}

--- a/website/src/js/codeMirror.ts
+++ b/website/src/js/codeMirror.ts
@@ -16,6 +16,7 @@ import {materialDark} from "./editor/darkTheme";
 import {urlIdField, urlIdExtensions} from "./editor/urlId";
 import {docBlockKeymap} from "./editor/docBlock";
 import {phpantomHover} from "./editor/phpantomHover";
+import {goToDefinition} from "./editor/goToDefinition";
 import {phpantomLsp, PHP_URI} from "./phpantom/lspClient";
 
 ko.bindingHandlers.codeMirror = {
@@ -87,6 +88,7 @@ ko.bindingHandlers.codeMirror = {
 			lineErrors,
 			hover,
 			phpantomHover,
+			goToDefinition,
 			phpantomLsp.plugin(PHP_URI, 'php'),
 			EditorView.baseTheme({
 				'.cm-tooltip.cm-tooltip-hover': {

--- a/website/src/js/editor/goToDefinition.ts
+++ b/website/src/js/editor/goToDefinition.ts
@@ -1,0 +1,194 @@
+import {Decoration, DecorationSet, EditorView, ViewPlugin} from '@codemirror/view';
+import {EditorState, Extension, StateEffect, StateField} from '@codemirror/state';
+import {phpantomLsp, PHP_URI} from '../phpantom/lspClient';
+
+// Cmd/Ctrl-click go-to-definition for symbols declared in the playground file
+// itself (classes, methods, properties, functions). Holding the modifier and
+// hovering shows an underline + pointer over navigable symbols; clicking jumps
+// to the declaration and briefly flashes its line. Symbols from phpstorm-stubs,
+// PHP builtins or the shipped PHPStan stubs are deliberately not navigable —
+// PHPantom resolves their definition to a different (or no) URI, and we only
+// act when it points back into the edited document.
+
+interface LspPosition { line: number; character: number }
+interface LspLocation { uri: string; range: {start: LspPosition; end: LspPosition} }
+interface DefinitionParams { textDocument: {uri: string}; position: LspPosition }
+
+// CodeMirror abstracts the platform modifier for *keymaps* (`Mod-` = Cmd on
+// macOS, Ctrl elsewhere) but not for mouse events, so we mirror its own check.
+const isMac = typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/.test(navigator.platform);
+function modHeld(event: MouseEvent): boolean {
+	return isMac ? event.metaKey : event.ctrlKey;
+}
+
+function toLspPosition(state: EditorState, offset: number): LspPosition {
+	const line = state.doc.lineAt(offset);
+	return {line: line.number - 1, character: offset - line.from};
+}
+
+function fromLspPosition(state: EditorState, pos: LspPosition): number {
+	if (pos.line >= state.doc.lines) {
+		return state.doc.length;
+	}
+	const line = state.doc.line(pos.line + 1);
+	return Math.min(line.from + pos.character, line.to);
+}
+
+// Ask PHPantom for the definition at `offset`; return the in-document target
+// offset, or null if there's none or it lives outside the edited file.
+async function resolveInFileDefinition(state: EditorState, offset: number): Promise<number | null> {
+	// Flush pending edits to the worker so the definition is resolved against
+	// the current document (mirrors what serverCompletion does).
+	phpantomLsp.sync();
+	let result: LspLocation[] | LspLocation | null;
+	try {
+		result = await phpantomLsp.request<DefinitionParams, LspLocation[] | LspLocation | null>(
+			'textDocument/definition',
+			{textDocument: {uri: PHP_URI}, position: toLspPosition(state, offset)},
+		);
+	} catch {
+		return null;
+	}
+	const location = Array.isArray(result) ? result[0] : result;
+	if (!location || location.uri !== PHP_URI) {
+		return null;
+	}
+	return fromLspPosition(state, location.range.start);
+}
+
+const linkMark = Decoration.mark({class: 'cm-goto-def-link'});
+const flashLine = Decoration.line({class: 'cm-goto-def-flash'});
+
+const setLink = StateEffect.define<{from: number; to: number} | null>();
+const setFlash = StateEffect.define<number | null>();
+
+const linkField = StateField.define<DecorationSet>({
+	create: () => Decoration.none,
+	update(deco, tr) {
+		deco = deco.map(tr.changes);
+		for (const effect of tr.effects) {
+			if (effect.is(setLink)) {
+				deco = effect.value
+					? Decoration.set([linkMark.range(effect.value.from, effect.value.to)])
+					: Decoration.none;
+			}
+		}
+		return deco;
+	},
+	provide: f => EditorView.decorations.from(f),
+});
+
+const flashField = StateField.define<DecorationSet>({
+	create: () => Decoration.none,
+	update(deco, tr) {
+		deco = deco.map(tr.changes);
+		for (const effect of tr.effects) {
+			if (effect.is(setFlash)) {
+				deco = effect.value == null
+					? Decoration.none
+					: Decoration.set([flashLine.range(tr.state.doc.lineAt(effect.value).from)]);
+			}
+		}
+		return deco;
+	},
+	provide: f => EditorView.decorations.from(f),
+});
+
+const goToDefinitionPlugin = ViewPlugin.fromClass(class {
+	private link: {from: number; to: number} | null = null;
+	private requestSeq = 0;
+	private flashTimer = -1;
+
+	constructor(private readonly view: EditorView) {
+		this.onKeyUp = this.onKeyUp.bind(this);
+		window.addEventListener('keyup', this.onKeyUp);
+	}
+
+	destroy(): void {
+		window.removeEventListener('keyup', this.onKeyUp);
+		if (this.flashTimer >= 0) {
+			clearTimeout(this.flashTimer);
+		}
+	}
+
+	private onKeyUp(): void {
+		this.clearLink();
+	}
+
+	clearLink(): void {
+		if (this.link !== null) {
+			this.link = null;
+			this.view.dispatch({effects: setLink.of(null)});
+		}
+	}
+
+	onMouseMove(event: MouseEvent): void {
+		if (!modHeld(event)) {
+			this.clearLink();
+			return;
+		}
+		const offset = this.view.posAtCoords({x: event.clientX, y: event.clientY});
+		const word = offset == null ? null : this.view.state.wordAt(offset);
+		if (offset == null || word == null) {
+			this.clearLink();
+			return;
+		}
+		if (this.link !== null && this.link.from === word.from && this.link.to === word.to) {
+			return; // already showing this token
+		}
+		const seq = ++this.requestSeq;
+		void resolveInFileDefinition(this.view.state, offset).then(target => {
+			if (seq !== this.requestSeq) {
+				return; // a newer hover superseded this request
+			}
+			if (target == null) {
+				this.clearLink();
+				return;
+			}
+			this.link = {from: word.from, to: word.to};
+			this.view.dispatch({effects: setLink.of(this.link)});
+		});
+	}
+
+	onMouseDown(event: MouseEvent): boolean {
+		if (!modHeld(event)) {
+			return false;
+		}
+		const offset = this.view.posAtCoords({x: event.clientX, y: event.clientY});
+		if (offset == null || this.view.state.wordAt(offset) == null) {
+			return false;
+		}
+		// Take over the modifier-click (CodeMirror would otherwise add a cursor).
+		event.preventDefault();
+		void resolveInFileDefinition(this.view.state, offset).then(target => {
+			if (target != null) {
+				this.jumpTo(target);
+			}
+		});
+		return true;
+	}
+
+	private jumpTo(offset: number): void {
+		this.clearLink();
+		this.view.dispatch({
+			selection: {anchor: offset},
+			effects: [EditorView.scrollIntoView(offset, {y: 'center'}), setFlash.of(offset)],
+		});
+		this.view.focus();
+		if (this.flashTimer >= 0) {
+			clearTimeout(this.flashTimer);
+		}
+		this.flashTimer = window.setTimeout(() => {
+			this.view.dispatch({effects: setFlash.of(null)});
+			this.flashTimer = -1;
+		}, 1200);
+	}
+}, {
+	eventHandlers: {
+		mousemove(event) { this.onMouseMove(event); },
+		mousedown(event) { return this.onMouseDown(event); },
+		mouseleave() { this.clearLink(); },
+	},
+});
+
+export const goToDefinition: Extension = [linkField, flashField, goToDefinitionPlugin];


### PR DESCRIPTION
Adds Cmd/Ctrl-click go-to-definition in the playground editor, for symbols declared in the file itself.

- Hold Cmd (macOS) / Ctrl (elsewhere) and hover: navigable symbols get an underline + pointer cursor.
- Click: jump to the declaration and briefly flash its line.

Only symbols declared in the edited document are navigable — PHPantom resolves builtins and the shipped stub symbols to other URIs, and the extension acts only when the definition points back into the open file.

Implementation:
- PHPantom's wasm dispatcher gains a `textDocument/definition` arm (`Backend::resolve_definition`) and advertises `definitionProvider`; the `build:wasm` pin is bumped to the fork commit that adds it.
- A CodeMirror extension (`src/js/editor/goToDefinition.ts`) handles the modifier hover/click, requests the definition over the existing LSP client, and does the jump + line flash. The modifier is platform-detected — CodeMirror only abstracts `Mod` for keymaps, not mouse events.

Functional test added (uses Playwright's `ControlOrMeta`, matching the platform split). The functional suite now runs serially (`workers: 1`) — the parallel 11 MB wasm loads had become flaky.
