### PR TITLE
Playground: occurrence highlight + Ctrl-R inline rename

### DIFF
--- a/website/functional-tests/autocomplete.spec.ts
+++ b/website/functional-tests/autocomplete.spec.ts
@@ -169,3 +169,58 @@ test('Cmd/Ctrl-click jumps to an in-file declaration', async ({page}) => {
 	await expect(page.locator('.cm-goto-def-flash'))
 		.toContainText('function greet', {timeout: COMPLETION_TIMEOUT});
 });
+
+test('highlights every occurrence of the symbol under the cursor', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'function sum($total) {',
+		'    return $total + $total;',
+		'}',
+	].join('\n'));
+	await page.waitForTimeout(500);
+
+	await page.locator('.cm-content').getByText('$total', {exact: true}).first().click();
+	// The param declaration + both uses.
+	await expect.poll(() => page.locator('.cm-occurrence').count(), {timeout: COMPLETION_TIMEOUT}).toBe(3);
+});
+
+test('Ctrl-R inline-renames a variable across its scope, keeping the $', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'function sum($total) {',
+		'    return $total + $total;',
+		'}',
+	].join('\n'));
+	await page.waitForTimeout(500);
+
+	await page.locator('.cm-content').getByText('$total', {exact: true}).first().click();
+	await page.keyboard.press('Control+r');
+	// All three occurrences become selections you edit at once.
+	await expect.poll(() => page.locator('.cm-selectionBackground').count(), {timeout: COMPLETION_TIMEOUT}).toBe(3);
+	await page.keyboard.type('amount');
+
+	const doc = page.locator('.cm-content').first();
+	await expect(doc).toContainText('function sum($amount)');
+	await expect(doc).toContainText('return $amount + $amount;');
+});
+
+test('Ctrl-R rename of a method is type-aware (same-named method on another class untouched)', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'class A { public function run(): int { return 1; } }',
+		'class B { public function run(): int { return 2; } }',
+		'$a = new A(); echo $a->run();',
+	].join('\n'));
+	await page.waitForTimeout(500);
+
+	// Rename from the $a->run() call: only A::run (declaration + this call).
+	await page.locator('.cm-content').getByText('run', {exact: true}).last().click();
+	await page.keyboard.press('Control+r');
+	await expect.poll(() => page.locator('.cm-selectionBackground').count(), {timeout: COMPLETION_TIMEOUT}).toBe(2);
+	await page.keyboard.type('execute');
+
+	const doc = page.locator('.cm-content').first();
+	await expect(doc).toContainText('class A { public function execute()');
+	await expect(doc).toContainText('$a->execute();');
+	await expect(doc).toContainText('class B { public function run()'); // untouched
+});

--- a/website/scripts/build-wasm.sh
+++ b/website/scripts/build-wasm.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 REPO="${PHPANTOM_REPO:-https://github.com/ondrejmirtes/phpantom_lsp.git}"
-REF="${PHPANTOM_REF:-f196a7fb80b01cc7f4a9ad5bf7d75de47f1a4edc}"
+REF="${PHPANTOM_REF:-2667498352ef5af37519d585644c1c1c5cd05100}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WEBSITE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/website/src/app.pcss
+++ b/website/src/app.pcss
@@ -297,3 +297,9 @@ h3.hash-target code {
 		background-color: transparent;
 	}
 }
+
+/* Occurrences of the symbol under the cursor (document highlight). */
+.cm-occurrence {
+	background-color: rgba(128, 128, 128, 0.28);
+	border-radius: 2px;
+}

--- a/website/src/js/codeMirror.ts
+++ b/website/src/js/codeMirror.ts
@@ -17,6 +17,7 @@ import {urlIdField, urlIdExtensions} from "./editor/urlId";
 import {docBlockKeymap} from "./editor/docBlock";
 import {phpantomHover} from "./editor/phpantomHover";
 import {goToDefinition} from "./editor/goToDefinition";
+import {occurrenceHighlight, inlineRename} from "./editor/occurrences";
 import {phpantomLsp, PHP_URI} from "./phpantom/lspClient";
 
 ko.bindingHandlers.codeMirror = {
@@ -54,6 +55,10 @@ ko.bindingHandlers.codeMirror = {
 			// highlightActiveLine(),
 			// highlightSelectionMatches(),
 			keymap.of([
+				// Ctrl-R starts inline rename of the symbol under the cursor (all
+				// occurrences become editable at once). preventDefault so it never
+				// falls through to the browser's reload.
+				{key: "Ctrl-r", run: inlineRename, preventDefault: true},
 				...completionKeymap,
 				...docBlockKeymap,
 				indentWithTab,
@@ -89,6 +94,7 @@ ko.bindingHandlers.codeMirror = {
 			hover,
 			phpantomHover,
 			goToDefinition,
+			occurrenceHighlight,
 			phpantomLsp.plugin(PHP_URI, 'php'),
 			EditorView.baseTheme({
 				'.cm-tooltip.cm-tooltip-hover': {

--- a/website/src/js/editor/occurrences.ts
+++ b/website/src/js/editor/occurrences.ts
@@ -1,0 +1,163 @@
+import {Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate} from '@codemirror/view';
+import {EditorSelection, EditorState, Extension, StateEffect, StateField} from '@codemirror/state';
+import {phpantomLsp, PHP_URI} from '../phpantom/lspClient';
+
+// Two PHPantom-backed editor features over the shared LSP client:
+//
+//  - Occurrence highlight: whenever the cursor sits inside a symbol, all of its
+//    occurrences are faintly highlighted (textDocument/documentHighlight). This
+//    is name-based for class members, so a same-named method on a different
+//    type may also light up — acceptable for a read-only highlight.
+//
+//  - Inline rename (Ctrl-R): IntelliJ-style. All occurrences are put under
+//    multiple selections so typing renames them together — no dialog. Only
+//    symbols *declared in this file* can be renamed (PHP builtins/stubs are
+//    skipped), and the ranges come from textDocument/rename, which is
+//    type-aware (renaming A::run never touches B::run).
+
+interface LspPosition { line: number; character: number }
+interface LspRange { start: LspPosition; end: LspPosition }
+interface LspLocation { uri: string; range: LspRange }
+interface DocumentHighlight { range: LspRange }
+interface TextEdit { range: LspRange; newText: string }
+interface WorkspaceEdit { changes?: {[uri: string]: TextEdit[]} }
+interface PositionParams { textDocument: {uri: string}; position: LspPosition }
+
+function toLspPosition(state: EditorState, offset: number): LspPosition {
+	const line = state.doc.lineAt(offset);
+	return {line: line.number - 1, character: offset - line.from};
+}
+
+function fromLspPosition(state: EditorState, pos: LspPosition): number {
+	if (pos.line >= state.doc.lines) {
+		return state.doc.length;
+	}
+	const line = state.doc.line(pos.line + 1);
+	return Math.min(line.from + pos.character, line.to);
+}
+
+async function request<R>(method: string, params: PositionParams | (PositionParams & {newName: string})): Promise<R | null> {
+	// Flush pending edits so the request resolves against the current document.
+	phpantomLsp.sync();
+	try {
+		return await phpantomLsp.request<typeof params, R | null>(method, params);
+	} catch {
+		return null;
+	}
+}
+
+// True only when the symbol's declaration is in the edited document (so we don't
+// offer to rename PHP builtins / stub symbols).
+async function isLocalSymbol(state: EditorState, offset: number): Promise<boolean> {
+	const result = await request<LspLocation[] | LspLocation>('textDocument/definition',
+		{textDocument: {uri: PHP_URI}, position: toLspPosition(state, offset)});
+	const location = Array.isArray(result) ? result[0] : result;
+	return !!location && location.uri === PHP_URI;
+}
+
+const occurrenceMark = Decoration.mark({class: 'cm-occurrence'});
+
+const setOccurrences = StateEffect.define<DecorationSet>();
+const occurrenceField = StateField.define<DecorationSet>({
+	create: () => Decoration.none,
+	update(deco, tr) {
+		deco = deco.map(tr.changes);
+		for (const effect of tr.effects) {
+			if (effect.is(setOccurrences)) {
+				deco = effect.value;
+			}
+		}
+		return deco;
+	},
+	provide: f => EditorView.decorations.from(f),
+});
+
+const occurrencePlugin = ViewPlugin.fromClass(class {
+	private seq = 0;
+	private timer = -1;
+
+	constructor(view: EditorView) {
+		this.schedule(view);
+	}
+
+	update(update: ViewUpdate): void {
+		if (update.selectionSet || update.docChanged) {
+			this.schedule(update.view);
+		}
+	}
+
+	destroy(): void {
+		if (this.timer >= 0) {
+			clearTimeout(this.timer);
+		}
+	}
+
+	private schedule(view: EditorView): void {
+		if (this.timer >= 0) {
+			clearTimeout(this.timer);
+		}
+		this.timer = window.setTimeout(() => {
+			this.timer = -1;
+			void this.run(view);
+		}, 150);
+	}
+
+	private async run(view: EditorView): Promise<void> {
+		const offset = view.state.selection.main.head;
+		const seq = ++this.seq;
+		const highlights = await request<DocumentHighlight[]>('textDocument/documentHighlight',
+			{textDocument: {uri: PHP_URI}, position: toLspPosition(view.state, offset)});
+		if (seq !== this.seq) {
+			return; // a newer request superseded this one
+		}
+		const ranges = (highlights ?? [])
+			.map(h => ({from: fromLspPosition(view.state, h.range.start), to: fromLspPosition(view.state, h.range.end)}))
+			.filter(r => r.to > r.from)
+			.sort((a, b) => a.from - b.from)
+			.map(r => occurrenceMark.range(r.from, r.to));
+		view.dispatch({effects: setOccurrences.of(Decoration.set(ranges))});
+	}
+});
+
+/// Occurrence highlighting for the symbol under the cursor. Enables multiple
+/// selections too, which inline rename relies on (all occurrences edited at once).
+export const occurrenceHighlight: Extension = [
+	EditorState.allowMultipleSelections.of(true),
+	occurrenceField,
+	occurrencePlugin,
+];
+
+/// Ctrl-R: start IntelliJ-style inline rename of the symbol under the cursor.
+export function inlineRename(view: EditorView): boolean {
+	void startInlineRename(view);
+	return true; // always consume the key (never fall through to browser reload)
+}
+
+async function startInlineRename(view: EditorView): Promise<void> {
+	const offset = view.state.selection.main.head;
+	if (!await isLocalSymbol(view.state, offset)) {
+		return; // not declared in this file — nothing to rename
+	}
+	const edit = await request<WorkspaceEdit>('textDocument/rename',
+		{textDocument: {uri: PHP_URI}, position: toLspPosition(view.state, offset), newName: 'PhpantomRenamePlaceholder'});
+	const edits = edit?.changes?.[PHP_URI];
+	if (!edits || edits.length === 0) {
+		return;
+	}
+	const ranges = edits.map(e => {
+		let from = fromLspPosition(view.state, e.range.start);
+		const to = fromLspPosition(view.state, e.range.end);
+		// Keep the leading `$` of a variable; only the name is editable.
+		if (view.state.doc.sliceString(from, from + 1) === '$') {
+			from += 1;
+		}
+		return EditorSelection.range(from, to);
+	}).sort((a, b) => a.from - b.from);
+
+	let main = ranges.findIndex(r => offset >= r.from && offset <= r.to);
+	if (main < 0) {
+		main = 0;
+	}
+	view.dispatch({selection: EditorSelection.create(ranges, main)});
+	view.focus();
+}


### PR DESCRIPTION
Adds two PHPantom-backed editor features to the playground.

**Occurrence highlight** — when the cursor is inside a symbol, all of its occurrences are faintly highlighted (`textDocument/documentHighlight`). Scope-correct for variables, FQN-correct for classes; name-based for class members, so a same-named method on another type may also light up — fine for a read-only highlight.

**Inline rename (Ctrl-R)** — IntelliJ-style: all occurrences become editable at once via multiple selections, no dialog. Only symbols declared in this file are renameable (PHP builtins / stub symbols are skipped via an in-file `definition` check). The ranges come from `textDocument/rename`, which is type-aware — renaming `A::run` never touches `B::run`. The leading `$` of a variable is preserved (you edit just the name).

Implementation:
- Wires `textDocument/documentHighlight` + `textDocument/rename` into the wasm dispatcher; the `build:wasm` pin is bumped to the fork commit that adds them.
- New CodeMirror extension (`src/js/editor/occurrences.ts`) plus `EditorState.allowMultipleSelections` (it was off, so multi-cursor edits collapsed to one).
- Ctrl-R is platform-literal Ctrl and always consumes the key (never falls through to the browser's reload).

Three functional tests added: occurrence highlight, variable rename (keeping `$`), and type-aware method rename.
