### PR TITLE
Playground: inline rename session (Enter/Esc, confined caret)

### DIFF
--- a/website/functional-tests/autocomplete.spec.ts
+++ b/website/functional-tests/autocomplete.spec.ts
@@ -198,10 +198,34 @@ test('Ctrl-R inline-renames a variable across its scope, keeping the $', async (
 	// All three occurrences become selections you edit at once.
 	await expect.poll(() => page.locator('.cm-selectionBackground').count(), {timeout: COMPLETION_TIMEOUT}).toBe(3);
 	await page.keyboard.type('amount');
+	await page.keyboard.press('Enter'); // confirm
 
 	const doc = page.locator('.cm-content').first();
 	await expect(doc).toContainText('function sum($amount)');
 	await expect(doc).toContainText('return $amount + $amount;');
+	// Enter confirms and leaves a single cursor — no lingering multi-selection.
+	await expect.poll(() => page.locator('.cm-cursor').count()).toBe(1);
+});
+
+test('Esc reverts an inline rename', async ({page}) => {
+	await setCode(page, [
+		'<?php',
+		'function sum($total) {',
+		'    return $total + $total;',
+		'}',
+	].join('\n'));
+	await page.waitForTimeout(500);
+
+	await page.locator('.cm-content').getByText('$total', {exact: true}).first().click();
+	await page.keyboard.press('Control+r');
+	await expect.poll(() => page.locator('.cm-selectionBackground').count(), {timeout: COMPLETION_TIMEOUT}).toBe(3);
+	await page.keyboard.type('zzz');
+	await page.keyboard.press('Escape'); // cancel
+
+	const doc = page.locator('.cm-content').first();
+	await expect(doc).not.toContainText('zzz');
+	await expect(doc).toContainText('return $total + $total;');
+	await expect.poll(() => page.locator('.cm-cursor').count()).toBe(1);
 });
 
 test('Ctrl-R rename of a method is type-aware (same-named method on another class untouched)', async ({page}) => {
@@ -218,6 +242,7 @@ test('Ctrl-R rename of a method is type-aware (same-named method on another clas
 	await page.keyboard.press('Control+r');
 	await expect.poll(() => page.locator('.cm-selectionBackground').count(), {timeout: COMPLETION_TIMEOUT}).toBe(2);
 	await page.keyboard.type('execute');
+	await page.keyboard.press('Enter');
 
 	const doc = page.locator('.cm-content').first();
 	await expect(doc).toContainText('class A { public function execute()');

--- a/website/src/js/editor/occurrences.ts
+++ b/website/src/js/editor/occurrences.ts
@@ -1,5 +1,5 @@
-import {Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate} from '@codemirror/view';
-import {EditorSelection, EditorState, Extension, StateEffect, StateField} from '@codemirror/state';
+import {Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate, keymap} from '@codemirror/view';
+import {EditorSelection, EditorState, Extension, Prec, StateEffect, StateField, Transaction} from '@codemirror/state';
 import {phpantomLsp, PHP_URI} from '../phpantom/lspClient';
 
 // Two PHPantom-backed editor features over the shared LSP client:
@@ -9,11 +9,13 @@ import {phpantomLsp, PHP_URI} from '../phpantom/lspClient';
 //    is name-based for class members, so a same-named method on a different
 //    type may also light up — acceptable for a read-only highlight.
 //
-//  - Inline rename (Ctrl-R): IntelliJ-style. All occurrences are put under
-//    multiple selections so typing renames them together — no dialog. Only
-//    symbols *declared in this file* can be renamed (PHP builtins/stubs are
-//    skipped), and the ranges come from textDocument/rename, which is
-//    type-aware (renaming A::run never touches B::run).
+//  - Inline rename (Ctrl-R): IntelliJ-style. All occurrences become editable at
+//    once via multiple selections, so typing renames them together — no dialog.
+//    Only symbols *declared in this file* can be renamed (PHP builtins/stubs are
+//    skipped), and the ranges come from textDocument/rename, which is type-aware
+//    (renaming A::run never touches B::run). While renaming, edits and the caret
+//    are confined to the identifier; Enter confirms, Esc reverts, and clicking
+//    away ends the session — so the editor never lingers in multi-cursor mode.
 
 interface LspPosition { line: number; character: number }
 interface LspRange { start: LspPosition; end: LspPosition }
@@ -54,6 +56,8 @@ async function isLocalSymbol(state: EditorState, offset: number): Promise<boolea
 	const location = Array.isArray(result) ? result[0] : result;
 	return !!location && location.uri === PHP_URI;
 }
+
+// ---- Occurrence highlight ---------------------------------------------------
 
 const occurrenceMark = Decoration.mark({class: 'cm-occurrence'});
 
@@ -103,12 +107,16 @@ const occurrencePlugin = ViewPlugin.fromClass(class {
 	}
 
 	private async run(view: EditorView): Promise<void> {
+		// No occurrence highlight while inline-renaming (the selections are there).
+		if (view.state.field(renameField) !== null) {
+			return;
+		}
 		const offset = view.state.selection.main.head;
 		const seq = ++this.seq;
 		const highlights = await request<DocumentHighlight[]>('textDocument/documentHighlight',
 			{textDocument: {uri: PHP_URI}, position: toLspPosition(view.state, offset)});
-		if (seq !== this.seq) {
-			return; // a newer request superseded this one
+		if (seq !== this.seq || view.state.field(renameField) !== null) {
+			return; // superseded, or a rename started meanwhile
 		}
 		const ranges = (highlights ?? [])
 			.map(h => ({from: fromLspPosition(view.state, h.range.start), to: fromLspPosition(view.state, h.range.end)}))
@@ -119,10 +127,132 @@ const occurrencePlugin = ViewPlugin.fromClass(class {
 	}
 });
 
-/// Occurrence highlighting for the symbol under the cursor. Enables multiple
-/// selections too, which inline rename relies on (all occurrences edited at once).
+// ---- Inline rename session --------------------------------------------------
+
+interface RenameSession {
+	// The editable identifier ranges (without the variable's leading `$`), kept
+	// in sync with edits so they grow/shrink as you type.
+	ranges: readonly {from: number; to: number}[];
+	// The original identifier text, used to revert on Esc.
+	original: string;
+}
+
+const startRename = StateEffect.define<RenameSession>();
+const stopRename = StateEffect.define<null>();
+
+const renameField = StateField.define<RenameSession | null>({
+	create: () => null,
+	update(session, tr) {
+		for (const effect of tr.effects) {
+			if (effect.is(startRename)) {
+				return effect.value;
+			}
+			if (effect.is(stopRename)) {
+				return null;
+			}
+		}
+		if (session === null) {
+			return null;
+		}
+		if (tr.docChanged) {
+			return {
+				original: session.original,
+				ranges: session.ranges.map(r => ({
+					from: tr.changes.mapPos(r.from, -1),
+					to: tr.changes.mapPos(r.to, 1),
+				})),
+			};
+		}
+		return session;
+	},
+});
+
+function rangeFor(session: RenameSession, pos: number): {from: number; to: number} {
+	let best = session.ranges[0];
+	let bestDistance = Infinity;
+	for (const range of session.ranges) {
+		if (pos >= range.from && pos <= range.to) {
+			return range;
+		}
+		const distance = pos < range.from ? range.from - pos : pos - range.to;
+		if (distance < bestDistance) {
+			bestDistance = distance;
+			best = range;
+		}
+	}
+	return best;
+}
+
+// Block edits that fall outside the renamed identifiers — e.g. backspacing into
+// the `$` of a variable, or deleting the character after the name.
+const renameChangeGuard = EditorState.changeFilter.of((tr: Transaction) => {
+	const session = tr.startState.field(renameField);
+	if (session === null || !tr.docChanged) {
+		return true;
+	}
+	let allowed = true;
+	tr.changes.iterChangedRanges((fromA, toA) => {
+		if (!session.ranges.some(r => fromA >= r.from && toA <= r.to)) {
+			allowed = false;
+		}
+	});
+	return allowed;
+});
+
+// Keep the caret inside the identifiers (arrow keys can't escape `aaa` in
+// `$aaa`); a pointer click ends the rename instead.
+const renameSelectionGuard = EditorState.transactionFilter.of((tr: Transaction) => {
+	const session = tr.startState.field(renameField);
+	if (session === null || tr.docChanged || tr.selection === undefined) {
+		return tr;
+	}
+	if (tr.isUserEvent('select.pointer')) {
+		return [tr, {effects: stopRename.of(null)}];
+	}
+	const ranges = tr.selection.ranges.map(sel => {
+		const range = rangeFor(session, sel.head);
+		const head = Math.min(Math.max(sel.head, range.from), range.to);
+		const anchor = Math.min(Math.max(sel.anchor, range.from), range.to);
+		return EditorSelection.range(anchor, head);
+	});
+	return [tr, {selection: EditorSelection.create(ranges, tr.selection.mainIndex)}];
+});
+
+function endRename(view: EditorView, revert: boolean): boolean {
+	const session = view.state.field(renameField);
+	if (session === null) {
+		return false; // not renaming — let the key do its normal thing
+	}
+	if (revert) {
+		const changes = session.ranges.map(r => ({from: r.from, to: r.to, insert: session.original}));
+		view.dispatch({
+			changes,
+			selection: EditorSelection.cursor(session.ranges[0].from + session.original.length),
+			effects: stopRename.of(null),
+		});
+	} else {
+		view.dispatch({
+			selection: EditorSelection.cursor(view.state.selection.main.head),
+			effects: stopRename.of(null),
+		});
+	}
+	view.focus();
+	return true;
+}
+
+const renameKeymap = Prec.highest(keymap.of([
+	{key: 'Enter', run: view => endRename(view, false)},
+	{key: 'Escape', run: view => endRename(view, true)},
+]));
+
+/// Occurrence highlighting + the inline-rename machinery. Also enables multiple
+/// selections, which inline rename relies on (all occurrences edited at once).
 export const occurrenceHighlight: Extension = [
 	EditorState.allowMultipleSelections.of(true),
+	renameField,
+	renameChangeGuard,
+	renameSelectionGuard,
+	renameKeymap,
 	occurrenceField,
 	occurrencePlugin,
 ];
@@ -151,13 +281,17 @@ async function startInlineRename(view: EditorView): Promise<void> {
 		if (view.state.doc.sliceString(from, from + 1) === '$') {
 			from += 1;
 		}
-		return EditorSelection.range(from, to);
+		return {from, to};
 	}).sort((a, b) => a.from - b.from);
 
 	let main = ranges.findIndex(r => offset >= r.from && offset <= r.to);
 	if (main < 0) {
 		main = 0;
 	}
-	view.dispatch({selection: EditorSelection.create(ranges, main)});
+	const original = view.state.doc.sliceString(ranges[main].from, ranges[main].to);
+	view.dispatch({
+		selection: EditorSelection.create(ranges.map(r => EditorSelection.range(r.from, r.to)), main),
+		effects: [startRename.of({ranges, original}), setOccurrences.of(Decoration.none)],
+	});
 	view.focus();
 }


### PR DESCRIPTION
Follow-up to the inline-rename PR (#14681) — this polish landed just after it was merged.

Makes Ctrl-R inline rename behave like an IDE rename session:

- **Enter** confirms, **Esc** reverts; both collapse back to a single cursor, so the editor no longer lingers in multi-cursor mode.
- Edits and the caret are **confined to the identifier** — arrow keys can't leave the name, and you can't backspace into a variable's leading `$`.
- **Clicking elsewhere** ends the session.

Implemented with a rename `StateField` (sticky ranges) plus change/selection transaction filters and a high-precedence Enter/Esc keymap; occurrence highlight is suppressed while renaming. All client-side — no wasm/fork change.

Functional tests cover Enter-confirm (asserts a single cursor remains), Esc-revert, and the type-aware method case.
