### PR TITLE
Website: upgrade TypeScript 5 -> 6

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -62,7 +62,7 @@
 				"reading-time": "^1.3.0",
 				"serve": "^14.2.0",
 				"tailwindcss": "^4.1.18",
-				"typescript": "^5.0.2",
+				"typescript": "^6.0.3",
 				"typopo": "^2.5.4",
 				"vite": "^7.3.1",
 				"vite-plugin-static-copy": "^3.2.0"
@@ -9084,9 +9084,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/website/package.json
+++ b/website/package.json
@@ -55,7 +55,7 @@
 		"reading-time": "^1.3.0",
 		"serve": "^14.2.0",
 		"tailwindcss": "^4.1.18",
-		"typescript": "^5.0.2",
+		"typescript": "^6.0.3",
 		"typopo": "^2.5.4",
 		"vite": "^7.3.1",
 		"vite-plugin-static-copy": "^3.2.0"

--- a/website/src/js/untyped.d.ts
+++ b/website/src/js/untyped.d.ts
@@ -1,1 +1,2 @@
 declare module 'docsearch.js/dist/cdn/docsearch.min.js';
+declare module '@docsearch/css';

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
-		"target": "ES6",
+		"target": "ES2020",
 		"module": "esnext",
 		"strict": true,
-		"moduleResolution": "node",
-		"lib": ["dom", "es2015"],
+		"moduleResolution": "bundler",
+		"lib": ["dom", "es2020"],
 		"noImplicitAny": true,
 		"noUnusedLocals": true,
 		"noImplicitThis": true,


### PR DESCRIPTION
Upgrades `typescript` 5.9.3 → 6.0.3.

TypeScript 6 no longer auto-includes every `@types` package and is stricter, which surfaced a few latent issues that 5.x had masked:

- **lib too low**: the code uses es2016–es2019 APIs (`Array.includes`, `Object.entries`/`values`/`fromEntries`) while `lib` was pinned to `es2015`. Bumped `target`/`lib` to `es2020`. This is **type-check only** — Vite transpiles using its own browserslist target, so the shipped JS/CSS bundles are **byte-identical** (verified: asset hashes unchanged).
- **deprecated resolution**: `moduleResolution: "node"` (node10) is deprecated in TS 6 and removed in TS 7. Switched to `"bundler"`, the correct fit for a Vite-bundled project.
- **CSS side-effect import**: added a `declare module '@docsearch/css';` ambient declaration (next to the existing one in `untyped.d.ts`).

### Verification
- `npm run check` passes (tsc 6 + ESLint).
- Build succeeds; JS/CSS asset hashes, HTML, and RSS feed unchanged vs before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)