### PR TITLE
Add kayw-geek/phpstan-type-trace to extension library

### DIFF
--- a/website/src/user-guide/extension-library.md
+++ b/website/src/user-guide/extension-library.md
@@ -101,5 +101,6 @@ Unofficial extensions
 * [symplify / phpstan-rules](https://github.com/symplify/phpstan-rules)
 * [roave / no-floaters](https://github.com/Roave/no-floaters)
 * [PHP Language Extensions](https://github.com/DaveLiddament/phpstan-php-language-extensions)
+* [kayw-geek / phpstan-type-trace](https://github.com/kayw-geek/phpstan-type-trace)
 
 [**Find more on Packagist!**](https://packagist.org/?type=phpstan-extension)


### PR DESCRIPTION
Adds kayw-geek/phpstan-type-trace to the extension library.

It traces the chain of params/assignments/narrowings that shaped a
variable's type up to a given line — useful when `dumpType()` shows
an unexpected type and you need to know why.

It's a debugging tool rather than a rule package, so "3rd party
rules" may not be the ideal section. Happy to move it if a
different section.