### PR TITLE
Fix sealed shape error

### DIFF
--- a/e2e/undiscoverable-symbols-2/src/Validator/Enum.php
+++ b/e2e/undiscoverable-symbols-2/src/Validator/Enum.php
@@ -31,7 +31,7 @@ class Enum extends Constraint
     /**
      * {@inheritdoc}
      *
-     * @param class-string<ClabsEnum<int>>|class-string<ClabsEnum<string>>|class-string<\BackedEnum>|array{class:class-string<ClabsEnum<string>>|class-string<\BackedEnum>} $class
+     * @param class-string<ClabsEnum<int>>|class-string<ClabsEnum<string>>|class-string<\BackedEnum>|array{class:class-string<ClabsEnum<string>>|class-string<\BackedEnum>, message:string} $class
      * @param array<string,mixed>                                                                                                                                           $options
      */
     public function __construct(


### PR DESCRIPTION
should fix

```
------ ----------------------------------------------------------------------- 
  Line   tests/EnumValidatorTest.php                                            
 ------ ----------------------------------------------------------------------- 
  22     Parameter #1 $class of class App\Validator\Enum constructor expects    
         array{class: class-string<BackedEnum>|class-string<MyCLabs\Enum\Enum<  
         string>>}|class-string<BackedEnum>|class-string<MyCLabs\Enum\Enum<int  
         >>|class-string<MyCLabs\Enum\Enum<string>>, array{class: 'App\\Securi  
         ty\\Authorization\\Role', message: 'myMessage'} given.                 
         🪪  argument.type                                                      
         💡  Type #1 from the union: Sealed array shape does not accept array   
         with extra key 'message'.                                              
  35     Parameter #1 $class of class App\Validator\Enum constructor expects    
         array{class: class-string<BackedEnum>|class-string<MyCLabs\Enum\Enum<  
         string>>}|class-string<BackedEnum>|class-string<MyCLabs\Enum\Enum<int  
         >>|class-string<MyCLabs\Enum\Enum<string>>, array{class: 'App\\Securi  
         ty\\Authorization\\Role', message: 'myMessage'} given.                 
         🪪  argument.type                                                      
         💡  Type #1 from the union: Sealed array shape does not accept array   
         with extra key 'message'.                                              
 ------ ----------------------------------------------------------------------- 

```

see https://github.com/phpstan/phpstan/actions/runs/26709894475/job/78718064876?pr=14733