### PR TITLE
update zizmor

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -101,7 +101,7 @@ jobs:
           enable-cache: false
 
       - name: Run zizmor
-        run: uvx zizmor@1.20.0 --persona=auditor --format=sarif --strict-collection . > results.sarif
+        run: uvx zizmor@1.25.2 --persona=auditor --format=sarif --strict-collection . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
lets see whether errors introduced in https://github.com/phpstan/phpstan/pull/14760 still happen on the latest zizmor release

<img width="790" height="372" alt="grafik" src="https://github.com/user-attachments/assets/2e429e5f-8786-4a62-91d6-5cd901a9303a" />
