### PR TITLE
Preserve PHPStan result cache between playground-runner invocations

### DIFF
--- a/playground-runner/bref.php
+++ b/playground-runner/bref.php
@@ -20,14 +20,14 @@ $phpstanVersion = \Jean85\PrettyVersions::getVersion('phpstan/phpstan')->getPret
 
 function clearTemp(): void
 {
-	$files = new RecursiveIteratorIterator(
-		new RecursiveDirectoryIterator('/tmp', RecursiveDirectoryIterator::SKIP_DOTS),
-		RecursiveIteratorIterator::CHILD_FIRST
-	);
-
-	foreach ($files as $fileinfo) {
-		$todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
-		$todo($fileinfo->getRealPath());
+	// Remove only this request's input artifacts. PHPStan's result cache also
+	// lives under /tmp; on a warm Lambda we want to keep it so repeated analyses
+	// reuse it. The cache is keyed on file content and config, so each distinct
+	// submission still gets a correct result even though the path is reused.
+	foreach (['/tmp/tmp.php', '/tmp/run-phpstan-tmp.neon'] as $file) {
+		if (is_file($file)) {
+			unlink($file);
+		}
 	}
 }
 


### PR DESCRIPTION
**Before:** `clearTemp()` recursively deletes everything under `/tmp` on every Lambda invocation, including PHPStan's result cache.
**After:** it removes only this request's input files (`/tmp/tmp.php`, `/tmp/run-phpstan-tmp.neon`); the cache survives.
**Why:** on a warm Lambda the full wipe forces PHPStan to rebuild its cache on every analysis. The cache is keyed on file content and config, so reusing the `/tmp/tmp.php` path across requests still yields correct results, and isolation holds because both user-content files are overwritten each request.

I couldn't exercise the deployed Lambda from the repo; verified by reading and `php -l`. Worth a sanity check on staging that the cache dir under `/tmp` is the one the container factory reuses.
