### PR TITLE
Add file and line context to "Unknown identifier" exceptions

### DIFF
--- a/identifier-extractor/src/ErrorWithIdentifierCollector.php
+++ b/identifier-extractor/src/ErrorWithIdentifierCollector.php
@@ -41,7 +41,7 @@ class ErrorWithIdentifierCollector implements Collector
 
 		$identifier = $scope->getType($args[0]->value);
 		if (count($identifier->getConstantStrings()) === 0) {
-			throw new ShouldNotHappenException(sprintf('Unknown identifier'));
+			throw new ShouldNotHappenException(sprintf('Unknown identifier in %s on line %d', $scope->getFile(), $args[0]->getStartLine()));
 		}
 
 		$calledOnType = $scope->getType($node->var);

--- a/identifier-extractor/src/RestrictedUsageCollector.php
+++ b/identifier-extractor/src/RestrictedUsageCollector.php
@@ -47,7 +47,7 @@ class RestrictedUsageCollector implements Collector
 
         $identifier = $scope->getType($args[1]->value);
         if (count($identifier->getConstantStrings()) === 0) {
-            throw new ShouldNotHappenException(sprintf('Unknown identifier'));
+            throw new ShouldNotHappenException(sprintf('Unknown identifier in %s on line %d', $scope->getFile(), $args[1]->getStartLine()));
         }
 
         if (!$scope->isInClass()) {

--- a/identifier-extractor/src/RuleErrorBuilderCollector.php
+++ b/identifier-extractor/src/RuleErrorBuilderCollector.php
@@ -53,7 +53,7 @@ class RuleErrorBuilderCollector implements Collector
                     return null;
                 }
             }
-			throw new ShouldNotHappenException(sprintf('Unknown identifier'));
+			throw new ShouldNotHappenException(sprintf('Unknown identifier in %s on line %d', $scope->getFile(), $args[0]->getStartLine()));
 		}
 
 		$calledOnType = $scope->getType($node->var);


### PR DESCRIPTION
`ErrorWithIdentifierCollector`, `RuleErrorBuilderCollector` and `RestrictedUsageCollector` threw `ShouldNotHappenException` with a static `"Unknown identifier"` message built by a placeholder-less `sprintf`. When a rule passes a non-constant-string identifier the whole extraction aborts with no indication of which file or call caused it. Each message now includes the analysed file and line. `php -l` clean.
