### PR TITLE
Add 3rd party extension

### DIFF
--- a/website/src/user-guide/extension-library.md
+++ b/website/src/user-guide/extension-library.md
@@ -101,5 +101,6 @@ Unofficial extensions
 * [symplify / phpstan-rules](https://github.com/symplify/phpstan-rules)
 * [roave / no-floaters](https://github.com/Roave/no-floaters)
 * [PHP Language Extensions](https://github.com/DaveLiddament/phpstan-php-language-extensions)
+* [mspirkov/yii2-phpstan-rules](https://github.com/mspirkov/yii2-phpstan-rules)
 
 [**Find more on Packagist!**](https://packagist.org/?type=phpstan-extension)


### PR DESCRIPTION
Add [mspirkov/yii2-phpstan-rules](https://github.com/mspirkov/yii2-phpstan-rules) library to list of 3rd party extensions.
This is an extension with rules specific to the Yii2 framework.