### PR TITLE
Fix link for Bladestan in extension library

### DIFF
--- a/website/src/user-guide/extension-library.md
+++ b/website/src/user-guide/extension-library.md
@@ -63,7 +63,7 @@ Check out as well [phpstan-deprecation-rules](https://github.com/phpstan/phpstan
 Unofficial extensions
 -----------------
 
-* Laravel ([Larastan](https://github.com/larastan/larastan) and [Bladestan](https://github.com/TomasVotruba/bladestan))
+* Laravel ([Larastan](https://github.com/larastan/larastan) and [Bladestan](https://github.com/bladestan/bladestan))
 * [Drupal](https://github.com/mglaman/phpstan-drupal)
 * [WordPress](https://github.com/szepeviktor/phpstan-wordpress)
 * [Laminas](https://github.com/Slamdunk/phpstan-laminas-framework)


### PR DESCRIPTION
It has moved under https://github.com/bladestan org.