### PR TITLE
Update shipmonk-rnd/dead-code-detector to fix integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -492,7 +492,7 @@ jobs:
               cp ../../../phpstan vendor/phpstan/phpstan/phpstan
               cp ../../../bootstrap.php vendor/phpstan/phpstan/bootstrap.php
               rm -rf vendor/phpstan/phpstan/turbo-ext && cp -R ../../../turbo-ext vendor/phpstan/phpstan/turbo-ext
-            phpstan-command: vendor/bin/phpstan analyse -c ../shipmonk-dead-code-detector.neon
+            phpstan-command: vendor/bin/phpstan analyse -c ../shipmonk-dead-code-detector.neon --allow-empty-baseline
             baseline-file: shipmonk-dead-code-detector-baseline.neon
           - php-version: 8.4
             repo: drupal/drupal

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -492,8 +492,8 @@ jobs:
               cp ../../../phpstan vendor/phpstan/phpstan/phpstan
               cp ../../../bootstrap.php vendor/phpstan/phpstan/bootstrap.php
               rm -rf vendor/phpstan/phpstan/turbo-ext && cp -R ../../../turbo-ext vendor/phpstan/phpstan/turbo-ext
-            phpstan-command: vendor/bin/phpstan analyse -c ../shipmonk-dead-code-detector.neon --allow-empty-baseline
-            baseline-file: shipmonk-dead-code-detector-baseline.neon
+            phpstan-command: vendor/bin/phpstan analyse -c ../shipmonk-dead-code-detector.neon
+            #baseline-file: shipmonk-dead-code-detector-baseline.neon
           - php-version: 8.4
             repo: drupal/drupal
             ref: 11.2.4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -148,7 +148,7 @@ jobs:
             script: |
               git clone https://github.com/shipmonk-rnd/dead-code-detector.git e2e/integration/repo
               cd e2e/integration/repo
-              git checkout 9dc312dacd817f253a9519703d2c4c3d86579d27
+              git checkout 86da62133f8e2ce1154a80a8bc26ff91243ab8d4
               composer install
               cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar
               cp ../../../phpstan vendor/phpstan/phpstan/phpstan
@@ -485,7 +485,7 @@ jobs:
             baseline-file: shipmonk-rnd-baseline.neon
           - php-version: 8.4
             repo: shipmonk-rnd/dead-code-detector
-            ref: 9dc312dacd817f253a9519703d2c4c3d86579d27
+            ref: 86da62133f8e2ce1154a80a8bc26ff91243ab8d4
             setup: |
               composer install
               cp ../../../phpstan.phar vendor/phpstan/phpstan/phpstan.phar

--- a/e2e/integration/shipmonk-dead-code-detector-baseline.neon
+++ b/e2e/integration/shipmonk-dead-code-detector-baseline.neon
@@ -1,19 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			rawMessage: Cannot use array destructuring on mixed.
-			identifier: offsetAccess.nonArray
-			count: 1
-			path: repo/tests/Rule/DeadCodeRuleTest.php
-
-		-
-			rawMessage: 'Trying to invoke (Closure(): void)|null but it might not be a callable.'
-			identifier: callable.nonCallable
-			count: 1
-			path: repo/tests/Rule/DeadCodeRuleTest.php
-
-		-
-			rawMessage: 'Trying to invoke (Closure(ShipMonk\PHPStan\DeadCode\Error\BlackMember): string)|null but it might not be a callable.'
-			identifier: callable.nonCallable
-			count: 1
-			path: repo/tests/Rule/DeadCodeRuleTest.php


### PR DESCRIPTION
fixes

```
There were 2 failures:

1) ShipMonk\PHPStan\DeadCode\Rule\DeadCodeRuleTest::testDead with data set "provider-vendor" ('/home/runner/work/phpstan-src...or.php')
Errors in file /home/runner/work/phpstan-src/phpstan-src/e2e/integration/repo/tests/Rule/data/providers/vendor.php do not match:

New errors reported:
18: Unused Default\MyPropertiesExtensionProvider::EXTENSION_TAG


Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'34: Unused Default\MyRule::unused
+'18: Unused Default\MyPropertiesExtensionProvider::EXTENSION_TAG
+34: Unused Default\MyRule::unused
 58: Property Default\MyTest::$dead is never read
 58: Property Default\MyTest::$dead is never written
 '

/home/runner/work/phpstan-src/phpstan-src/e2e/integration/repo/vendor/shipmonk/phpstan-dev/src/RuleTestCase.php:73
/home/runner/work/phpstan-src/phpstan-src/e2e/integration/repo/tests/Rule/DeadCodeRuleTest.php:252
/home/runner/work/phpstan-src/phpstan-src/e2e/integration/repo/tests/Rule/DeadCodeRuleTest.php:178

2) ShipMonk\PHPStan\DeadCode\Rule\DeadCodeRuleTest::testDeadWithGroups with data set "provider-vendor" ('/home/runner/work/phpstan-src...or.php')
Errors in file /home/runner/work/phpstan-src/phpstan-src/e2e/integration/repo/tests/Rule/data/providers/vendor.php do not match:

New errors reported:
18: Unused Default\MyPropertiesExtensionProvider::EXTENSION_TAG


Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'34: Unused Default\MyRule::unused
+'18: Unused Default\MyPropertiesExtensionProvider::EXTENSION_TAG
+34: Unused Default\MyRule::unused
 58: Property Default\MyTest::$dead is never read
 58: Property Default\MyTest::$dead is never written
 '

/home/runner/work/phpstan-src/phpstan-src/e2e/integration/repo/vendor/shipmonk/phpstan-dev/src/RuleTestCase.php:73
/home/runner/work/phpstan-src/phpstan-src/e2e/integration/repo/tests/Rule/DeadCodeRuleTest.php:252
/home/runner/work/phpstan-src/phpstan-src/e2e/integration/repo/tests/Rule/DeadCodeRuleTest.php:191

FAILURES!
Tests: 718, Assertions: 3898, Failures: 2, Skipped: 1.
Error: Process completed with exit code 1.

```