### PR TITLE
Docs: mention MegaLinter on the Docker page

### DIFF
--- a/website/src/user-guide/docker.md
+++ b/website/src/user-guide/docker.md
@@ -148,3 +148,7 @@ zlib
 
 [Zend Modules]
 ```
+
+## Running PHPStan via MegaLinter
+
+If you're setting up multiple linters in CI at once, [MegaLinter](https://megalinter.io/) is an open-source linters aggregator whose Docker images run PHPStan out of the box, alongside analyzers for other languages. See its [PHPStan page](https://megalinter.io/latest/descriptors/php_phpstan/) for configuration details.


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI that has been shipping PHPStan out of the box for years. I added a short note at the bottom of the Docker user-guide page so people wiring up several linters at once can find it — feel free to reword or move it if there's a better spot. Thanks for PHPStan!