### PR TITLE
Build the Docker images' PHP with profile-guided optimization

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -1,6 +1,11 @@
 # From:
   # https://www.docker.com/blog/docker-github-actions/
   # https://github.com/metcalfc/docker-action-examples
+  # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+#
+# Each platform builds on a native runner (the PGO training run inside the
+# Dockerfiles would be prohibitively slow under QEMU emulation) and pushes
+# by digest; a merge job then assembles the multi-platform manifests.
 
 name: Docker image nightly
 
@@ -24,27 +29,23 @@ permissions:
   packages: write
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    concurrency: docker-nightly-${{ github.ref }}-${{ matrix.docker-file }}
+  build:
+    runs-on: ${{ matrix.runner }}
+    concurrency: docker-nightly-${{ github.ref }}-${{ matrix.key }}-${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
+        key: [ "php8.0", "php8.1", "php8.2", "php8.3", "php8.4", "php8.5" ]
+        platform: [ "linux/amd64", "linux/arm64" ]
         include:
-          - docker-file: "./docker/Dockerfile.php.8.5"
-            image-tag-suffix: ""
-          - docker-file: "./docker/Dockerfile.php.8.0"
-            image-tag-suffix: "-php8.0"
-          - docker-file: "./docker/Dockerfile.php.8.1"
-            image-tag-suffix: "-php8.1"
-          - docker-file: "./docker/Dockerfile.php.8.2"
-            image-tag-suffix: "-php8.2"
-          - docker-file: "./docker/Dockerfile.php.8.3"
-            image-tag-suffix: "-php8.3"
-          - docker-file: "./docker/Dockerfile.php.8.4"
-            image-tag-suffix: "-php8.4"
-          - docker-file: "./docker/Dockerfile.php.8.5"
-            image-tag-suffix: "-php8.5"
+          - { key: "php8.0", docker-file: "./docker/Dockerfile.php.8.0", image-tag-suffix: "-php8.0" }
+          - { key: "php8.1", docker-file: "./docker/Dockerfile.php.8.1", image-tag-suffix: "-php8.1" }
+          - { key: "php8.2", docker-file: "./docker/Dockerfile.php.8.2", image-tag-suffix: "-php8.2" }
+          - { key: "php8.3", docker-file: "./docker/Dockerfile.php.8.3", image-tag-suffix: "-php8.3" }
+          - { key: "php8.4", docker-file: "./docker/Dockerfile.php.8.4", image-tag-suffix: "-php8.4" }
+          - { key: "php8.5", docker-file: "./docker/Dockerfile.php.8.5", image-tag-suffix: "-php8.5" }
+          - { platform: "linux/amd64", runner: "ubuntu-latest" }
+          - { platform: "linux/arm64", runner: "ubuntu-24.04-arm" }
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -53,9 +54,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         id: buildx
@@ -68,7 +66,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
@@ -76,8 +75,70 @@ jobs:
           file: "${{ matrix.docker-file }}"
           build-args: |
             PHPSTAN_VERSION=2.2.x-dev#${{ github.sha }}
-          push: true
-          tags: "ghcr.io/phpstan/phpstan:nightly${{ matrix.image-tag-suffix }}"
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/phpstan/phpstan,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
+          cache-to: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.key }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    concurrency: docker-nightly-merge-${{ github.ref }}-${{ matrix.key }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # "default" (no suffix) tags reuse the php8.5 digests - same image
+          - { key: "default", digest-key: "php8.5", image-tag-suffix: "" }
+          - { key: "php8.0", digest-key: "php8.0", image-tag-suffix: "-php8.0" }
+          - { key: "php8.1", digest-key: "php8.1", image-tag-suffix: "-php8.1" }
+          - { key: "php8.2", digest-key: "php8.2", image-tag-suffix: "-php8.2" }
+          - { key: "php8.3", digest-key: "php8.3", image-tag-suffix: "-php8.3" }
+          - { key: "php8.4", digest-key: "php8.4", image-tag-suffix: "-php8.4" }
+          - { key: "php8.5", digest-key: "php8.5", image-tag-suffix: "-php8.5" }
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digests-${{ matrix.digest-key }}-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to ghcr
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-platform manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t "ghcr.io/phpstan/phpstan:nightly${{ matrix.image-tag-suffix }}" \
+            $(printf 'ghcr.io/phpstan/phpstan@sha256:%s ' *)
+
+      - name: Inspect
+        run: docker buildx imagetools inspect "ghcr.io/phpstan/phpstan:nightly${{ matrix.image-tag-suffix }}"

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -96,8 +96,11 @@ jobs:
           # Pull requests build without any cache: they must not evict the
           # nightly/stable scopes from the repository cache quota, and an
           # uncached build validates the whole build path.
-          cache-from: ${{ github.event_name != 'pull_request' && format('type=gha, scope={0}-{1}-{2}', github.workflow, matrix.key, matrix.platform) || '' }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=gha, scope={0}-{1}-{2}', github.workflow, matrix.key, matrix.platform) || '' }}
+          # The scope is shared with the stable workflow: both build identical
+          # instrument layers from the same Dockerfiles, so a release reuses
+          # what a recent nightly already compiled.
+          cache-from: ${{ github.event_name != 'pull_request' && format('type=gha, scope=docker-{0}-{1}', matrix.key, matrix.platform) || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=gha, scope=docker-{0}-{1}', matrix.key, matrix.platform) || '' }}
 
       - name: Verify the built image
         if: github.event_name == 'pull_request'

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -93,8 +93,11 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: ${{ github.event_name == 'pull_request' && 'phpstan-pr-test' || '' }}
           outputs: ${{ github.event_name == 'pull_request' && 'type=docker' || 'type=image,name=ghcr.io/phpstan/phpstan,push-by-digest=true,name-canonical=true,push=true' }}
-          cache-from: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
-          cache-to: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
+          # Pull requests build without any cache: they must not evict the
+          # nightly/stable scopes from the repository cache quota, and an
+          # uncached build validates the whole build path.
+          cache-from: ${{ github.event_name != 'pull_request' && format('type=gha, scope={0}-{1}-{2}', github.workflow, matrix.key, matrix.platform) || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=gha, scope={0}-{1}-{2}', github.workflow, matrix.key, matrix.platform) || '' }}
 
       - name: Verify the built image
         if: github.event_name == 'pull_request'

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -104,10 +104,11 @@ jobs:
 
       - name: Export digest
         if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p "${RUNNER_TEMP}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -96,9 +96,6 @@ jobs:
           # Pull requests build without any cache: they must not evict the
           # nightly/stable scopes from the repository cache quota, and an
           # uncached build validates the whole build path.
-          # The scope is shared with the stable workflow: both build identical
-          # instrument layers from the same Dockerfiles, so a release reuses
-          # what a recent nightly already compiled.
           cache-from: ${{ github.event_name != 'pull_request' && format('type=gha, scope=docker-{0}-{1}', matrix.key, matrix.platform) || '' }}
           cache-to: ${{ github.event_name != 'pull_request' && format('type=gha, scope=docker-{0}-{1}', matrix.key, matrix.platform) || '' }}
 

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -9,6 +9,10 @@
 
 name: Docker image nightly
 
+# On pull requests the images are built and smoke-tested but nothing is
+# pushed: the build loads the image into the runner's Docker instead of
+# pushing by digest, and the merge job does not run.
+
 on:
   push:
     branches:
@@ -23,14 +27,24 @@ on:
       # binaries can land without a phar change (a new platform or PHP minor
       # at an unchanged extension version).
       - 'turbo-ext/**'
+  pull_request:
+    paths:
+      - '.github/workflows/docker-nightly.yml'
+      - 'docker/**'
+      - 'phpstan'
+      - '.phar-checksum'
+      - 'bootstrap.php'
+      - 'turbo-ext/**'
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     concurrency: docker-nightly-${{ github.ref }}-${{ matrix.key }}-${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -60,6 +74,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to ghcr
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -74,19 +89,28 @@ jobs:
           context: ./docker
           file: "${{ matrix.docker-file }}"
           build-args: |
-            PHPSTAN_VERSION=2.2.x-dev#${{ github.sha }}
+            PHPSTAN_VERSION=${{ github.event_name == 'pull_request' && '2.2.x-dev' || format('2.2.x-dev#{0}', github.sha) }}
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=ghcr.io/phpstan/phpstan,push-by-digest=true,name-canonical=true,push=true
+          tags: ${{ github.event_name == 'pull_request' && 'phpstan-pr-test' || '' }}
+          outputs: ${{ github.event_name == 'pull_request' && 'type=docker' || 'type=image,name=ghcr.io/phpstan/phpstan,push-by-digest=true,name-canonical=true,push=true' }}
           cache-from: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
           cache-to: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
 
+      - name: Verify the built image
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm --entrypoint php phpstan-pr-test -v
+          docker run --rm phpstan-pr-test --version
+
       - name: Export digest
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p "${RUNNER_TEMP}/digests"
           digest="${{ steps.build.outputs.digest }}"
           touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
 
       - name: Upload digest
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ matrix.key }}-${{ strategy.job-index }}
@@ -95,7 +119,11 @@ jobs:
           retention-days: 1
 
   merge:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs: build
     concurrency: docker-nightly-merge-${{ github.ref }}-${{ matrix.key }}
     strategy:

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -164,9 +164,11 @@ jobs:
       - name: Create multi-platform manifest
         working-directory: ${{ runner.temp }}/digests
         run: |
+          digests=()
+          for digest in *; do digests+=("ghcr.io/phpstan/phpstan@sha256:${digest}"); done
           docker buildx imagetools create \
             -t "ghcr.io/phpstan/phpstan:nightly${{ matrix.image-tag-suffix }}" \
-            $(printf 'ghcr.io/phpstan/phpstan@sha256:%s ' *)
+            "${digests[@]}"
 
       - name: Inspect
         run: docker buildx imagetools inspect "ghcr.io/phpstan/phpstan:nightly${{ matrix.image-tag-suffix }}"

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -58,10 +58,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get the version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -70,17 +66,18 @@ jobs:
           context: ./docker
           file: "${{ matrix.docker-file }}"
           build-args: |
-            PHPSTAN_VERSION=${{ steps.get_version.outputs.VERSION }}
+            PHPSTAN_VERSION=${{ github.ref_name }}
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/phpstan/phpstan,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
           cache-to: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
 
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p "${RUNNER_TEMP}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -132,20 +129,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get the version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-
       - name: Create multi-platform manifests
         working-directory: ${{ runner.temp }}/digests
+        env:
+          VERSION: ${{ github.ref_name }}
         run: |
           digests=()
           for digest in *; do digests+=("ghcr.io/phpstan/phpstan@sha256:${digest}"); done
           docker buildx imagetools create \
             -t "ghcr.io/phpstan/phpstan:latest${{ matrix.image-tag-suffix }}" \
             -t "ghcr.io/phpstan/phpstan:2${{ matrix.image-tag-suffix }}" \
-            -t "ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}${{ matrix.image-tag-suffix }}" \
+            -t "ghcr.io/phpstan/phpstan:${VERSION}${{ matrix.image-tag-suffix }}" \
             "${digests[@]}"
 
       - name: Inspect
-        run: docker buildx imagetools inspect "ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}${{ matrix.image-tag-suffix }}"
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: docker buildx imagetools inspect "ghcr.io/phpstan/phpstan:${VERSION}${{ matrix.image-tag-suffix }}"

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -68,12 +68,10 @@ jobs:
           build-args: |
             PHPSTAN_VERSION=${{ github.ref_name }}
           platforms: ${{ matrix.platform }}
+          # Release builds deliberately use no layer cache: every release
+          # binary is compiled fresh in this run from the upstream sources,
+          # the same posture phar.yml takes.
           outputs: type=image,name=ghcr.io/phpstan/phpstan,push-by-digest=true,name-canonical=true,push=true
-          # The scope is shared with the nightly workflow: both build identical
-          # instrument layers from the same Dockerfiles, so a release reuses
-          # what a recent nightly already compiled.
-          cache-from: type=gha, scope=docker-${{ matrix.key }}-${{ matrix.platform }}
-          cache-to: type=gha, scope=docker-${{ matrix.key }}-${{ matrix.platform }}
 
       - name: Export digest
         env:

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -1,6 +1,11 @@
 # From:
   # https://www.docker.com/blog/docker-github-actions/
   # https://github.com/metcalfc/docker-action-examples
+  # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+#
+# Each platform builds on a native runner (the PGO training run inside the
+# Dockerfiles would be prohibitively slow under QEMU emulation) and pushes
+# by digest; a merge job then assembles the multi-platform manifests.
 
 name: Docker image stable
 
@@ -14,27 +19,23 @@ permissions:
   packages: write
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    concurrency: docker-stable-${{ github.ref }}-${{ matrix.docker-file }}
+  build:
+    runs-on: ${{ matrix.runner }}
+    concurrency: docker-stable-${{ github.ref }}-${{ matrix.key }}-${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
+        key: [ "php8.0", "php8.1", "php8.2", "php8.3", "php8.4", "php8.5" ]
+        platform: [ "linux/amd64", "linux/arm64" ]
         include:
-          - docker-file: "./docker/Dockerfile.php.8.5"
-            image-tag-suffix: ""
-          - docker-file: "./docker/Dockerfile.php.8.0"
-            image-tag-suffix: "-php8.0"
-          - docker-file: "./docker/Dockerfile.php.8.1"
-            image-tag-suffix: "-php8.1"
-          - docker-file: "./docker/Dockerfile.php.8.2"
-            image-tag-suffix: "-php8.2"
-          - docker-file: "./docker/Dockerfile.php.8.3"
-            image-tag-suffix: "-php8.3"
-          - docker-file: "./docker/Dockerfile.php.8.4"
-            image-tag-suffix: "-php8.4"
-          - docker-file: "./docker/Dockerfile.php.8.5"
-            image-tag-suffix: "-php8.5"
+          - { key: "php8.0", docker-file: "./docker/Dockerfile.php.8.0", image-tag-suffix: "-php8.0" }
+          - { key: "php8.1", docker-file: "./docker/Dockerfile.php.8.1", image-tag-suffix: "-php8.1" }
+          - { key: "php8.2", docker-file: "./docker/Dockerfile.php.8.2", image-tag-suffix: "-php8.2" }
+          - { key: "php8.3", docker-file: "./docker/Dockerfile.php.8.3", image-tag-suffix: "-php8.3" }
+          - { key: "php8.4", docker-file: "./docker/Dockerfile.php.8.4", image-tag-suffix: "-php8.4" }
+          - { key: "php8.5", docker-file: "./docker/Dockerfile.php.8.5", image-tag-suffix: "-php8.5" }
+          - { platform: "linux/amd64", runner: "ubuntu-latest" }
+          - { platform: "linux/arm64", runner: "ubuntu-24.04-arm" }
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -43,9 +44,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         id: buildx
@@ -62,7 +60,8 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
@@ -70,8 +69,76 @@ jobs:
           file: "${{ matrix.docker-file }}"
           build-args: |
             PHPSTAN_VERSION=${{ steps.get_version.outputs.VERSION }}
-          push: true
-          tags: "ghcr.io/phpstan/phpstan:latest${{ matrix.image-tag-suffix }},ghcr.io/phpstan/phpstan:2${{ matrix.image-tag-suffix }},ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}${{ matrix.image-tag-suffix }}"
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/phpstan/phpstan,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
+          cache-to: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.key }}-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    concurrency: docker-stable-merge-${{ github.ref }}-${{ matrix.key }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # "default" (no suffix) tags reuse the php8.5 digests - same image
+          - { key: "default", digest-key: "php8.5", image-tag-suffix: "" }
+          - { key: "php8.0", digest-key: "php8.0", image-tag-suffix: "-php8.0" }
+          - { key: "php8.1", digest-key: "php8.1", image-tag-suffix: "-php8.1" }
+          - { key: "php8.2", digest-key: "php8.2", image-tag-suffix: "-php8.2" }
+          - { key: "php8.3", digest-key: "php8.3", image-tag-suffix: "-php8.3" }
+          - { key: "php8.4", digest-key: "php8.4", image-tag-suffix: "-php8.4" }
+          - { key: "php8.5", digest-key: "php8.5", image-tag-suffix: "-php8.5" }
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digests-${{ matrix.digest-key }}-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to ghcr
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Create multi-platform manifests
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t "ghcr.io/phpstan/phpstan:latest${{ matrix.image-tag-suffix }}" \
+            -t "ghcr.io/phpstan/phpstan:2${{ matrix.image-tag-suffix }}" \
+            -t "ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}${{ matrix.image-tag-suffix }}" \
+            $(printf 'ghcr.io/phpstan/phpstan@sha256:%s ' *)
+
+      - name: Inspect
+        run: docker buildx imagetools inspect "ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}${{ matrix.image-tag-suffix }}"

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -139,11 +139,13 @@ jobs:
       - name: Create multi-platform manifests
         working-directory: ${{ runner.temp }}/digests
         run: |
+          digests=()
+          for digest in *; do digests+=("ghcr.io/phpstan/phpstan@sha256:${digest}"); done
           docker buildx imagetools create \
             -t "ghcr.io/phpstan/phpstan:latest${{ matrix.image-tag-suffix }}" \
             -t "ghcr.io/phpstan/phpstan:2${{ matrix.image-tag-suffix }}" \
             -t "ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}${{ matrix.image-tag-suffix }}" \
-            $(printf 'ghcr.io/phpstan/phpstan@sha256:%s ' *)
+            "${digests[@]}"
 
       - name: Inspect
         run: docker buildx imagetools inspect "ghcr.io/phpstan/phpstan:${{ steps.get_version.outputs.VERSION }}${{ matrix.image-tag-suffix }}"

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -69,8 +69,11 @@ jobs:
             PHPSTAN_VERSION=${{ github.ref_name }}
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/phpstan/phpstan,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
-          cache-to: type=gha, scope=${{ github.workflow }}-${{ matrix.key }}-${{ matrix.platform }}
+          # The scope is shared with the nightly workflow: both build identical
+          # instrument layers from the same Dockerfiles, so a release reuses
+          # what a recent nightly already compiled.
+          cache-from: type=gha, scope=docker-${{ matrix.key }}-${{ matrix.platform }}
+          cache-to: type=gha, scope=docker-${{ matrix.key }}-${{ matrix.platform }}
 
       - name: Export digest
         env:

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -16,11 +16,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     concurrency: docker-stable-${{ github.ref }}-${{ matrix.key }}-${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -90,6 +92,9 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs: build
     concurrency: docker-stable-merge-${{ github.ref }}-${{ matrix.key }}
     strategy:

--- a/docker/Dockerfile.php.8.0
+++ b/docker/Dockerfile.php.8.0
@@ -1,3 +1,22 @@
+# Stage 1: rebuild the php binary with profile-guided optimization, trained
+# by running this very PHPStan release on the phpstan-src codebase. All the
+# logic lives in pgo-build.sh.
+FROM php:8.0-cli-alpine AS pgo-builder
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY pgo-build.sh /usr/local/bin/pgo-build
+
+RUN pgo-build instrument
+
+ARG PHPSTAN_VERSION
+ARG PHPSTAN_SRC_REF=2.2.x
+
+RUN pgo-build train
+
+RUN pgo-build rebuild
+
+# Stage 2: the shipped image - identical to the stock one except for the
+# profile-guided php binary dropped in over the original.
 FROM php:8.0-cli-alpine
 
 ENV COMPOSER_HOME="/composer" \
@@ -5,6 +24,8 @@ ENV COMPOSER_HOME="/composer" \
     PATH="/composer/vendor/bin:$PATH" \
     PHP_CONF_DIR="/usr/local/etc/php/conf.d" \
     PHPSTAN_PRO_WEB_PORT="11111"
+
+COPY --from=pgo-builder /pgo-install/usr/local/bin/php /usr/local/bin/php
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
     && apk add --no-cache git

--- a/docker/Dockerfile.php.8.1
+++ b/docker/Dockerfile.php.8.1
@@ -1,3 +1,22 @@
+# Stage 1: rebuild the php binary with profile-guided optimization, trained
+# by running this very PHPStan release on the phpstan-src codebase. All the
+# logic lives in pgo-build.sh.
+FROM php:8.1-cli-alpine AS pgo-builder
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY pgo-build.sh /usr/local/bin/pgo-build
+
+RUN pgo-build instrument
+
+ARG PHPSTAN_VERSION
+ARG PHPSTAN_SRC_REF=2.2.x
+
+RUN pgo-build train
+
+RUN pgo-build rebuild
+
+# Stage 2: the shipped image - identical to the stock one except for the
+# profile-guided php binary dropped in over the original.
 FROM php:8.1-cli-alpine
 
 ENV COMPOSER_HOME="/composer" \
@@ -5,6 +24,8 @@ ENV COMPOSER_HOME="/composer" \
     PATH="/composer/vendor/bin:$PATH" \
     PHP_CONF_DIR="/usr/local/etc/php/conf.d" \
     PHPSTAN_PRO_WEB_PORT="11111"
+
+COPY --from=pgo-builder /pgo-install/usr/local/bin/php /usr/local/bin/php
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
     && apk add --no-cache git

--- a/docker/Dockerfile.php.8.2
+++ b/docker/Dockerfile.php.8.2
@@ -1,3 +1,22 @@
+# Stage 1: rebuild the php binary with profile-guided optimization, trained
+# by running this very PHPStan release on the phpstan-src codebase. All the
+# logic lives in pgo-build.sh.
+FROM php:8.2-cli-alpine AS pgo-builder
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY pgo-build.sh /usr/local/bin/pgo-build
+
+RUN pgo-build instrument
+
+ARG PHPSTAN_VERSION
+ARG PHPSTAN_SRC_REF=2.2.x
+
+RUN pgo-build train
+
+RUN pgo-build rebuild
+
+# Stage 2: the shipped image - identical to the stock one except for the
+# profile-guided php binary dropped in over the original.
 FROM php:8.2-cli-alpine
 
 ENV COMPOSER_HOME="/composer" \
@@ -5,6 +24,8 @@ ENV COMPOSER_HOME="/composer" \
     PATH="/composer/vendor/bin:$PATH" \
     PHP_CONF_DIR="/usr/local/etc/php/conf.d" \
     PHPSTAN_PRO_WEB_PORT="11111"
+
+COPY --from=pgo-builder /pgo-install/usr/local/bin/php /usr/local/bin/php
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
     && apk add --no-cache git

--- a/docker/Dockerfile.php.8.3
+++ b/docker/Dockerfile.php.8.3
@@ -1,3 +1,22 @@
+# Stage 1: rebuild the php binary with profile-guided optimization, trained
+# by running this very PHPStan release on the phpstan-src codebase. All the
+# logic lives in pgo-build.sh.
+FROM php:8.3-cli-alpine AS pgo-builder
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY pgo-build.sh /usr/local/bin/pgo-build
+
+RUN pgo-build instrument
+
+ARG PHPSTAN_VERSION
+ARG PHPSTAN_SRC_REF=2.2.x
+
+RUN pgo-build train
+
+RUN pgo-build rebuild
+
+# Stage 2: the shipped image - identical to the stock one except for the
+# profile-guided php binary dropped in over the original.
 FROM php:8.3-cli-alpine
 
 ENV COMPOSER_HOME="/composer" \
@@ -5,6 +24,8 @@ ENV COMPOSER_HOME="/composer" \
     PATH="/composer/vendor/bin:$PATH" \
     PHP_CONF_DIR="/usr/local/etc/php/conf.d" \
     PHPSTAN_PRO_WEB_PORT="11111"
+
+COPY --from=pgo-builder /pgo-install/usr/local/bin/php /usr/local/bin/php
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
     && apk add --no-cache git

--- a/docker/Dockerfile.php.8.4
+++ b/docker/Dockerfile.php.8.4
@@ -1,3 +1,22 @@
+# Stage 1: rebuild the php binary with profile-guided optimization, trained
+# by running this very PHPStan release on the phpstan-src codebase. All the
+# logic lives in pgo-build.sh.
+FROM php:8.4-cli-alpine AS pgo-builder
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY pgo-build.sh /usr/local/bin/pgo-build
+
+RUN pgo-build instrument
+
+ARG PHPSTAN_VERSION
+ARG PHPSTAN_SRC_REF=2.2.x
+
+RUN pgo-build train
+
+RUN pgo-build rebuild
+
+# Stage 2: the shipped image - identical to the stock one except for the
+# profile-guided php binary dropped in over the original.
 FROM php:8.4-cli-alpine
 
 ENV COMPOSER_HOME="/composer" \
@@ -5,6 +24,8 @@ ENV COMPOSER_HOME="/composer" \
     PATH="/composer/vendor/bin:$PATH" \
     PHP_CONF_DIR="/usr/local/etc/php/conf.d" \
     PHPSTAN_PRO_WEB_PORT="11111"
+
+COPY --from=pgo-builder /pgo-install/usr/local/bin/php /usr/local/bin/php
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
     && apk add --no-cache git

--- a/docker/Dockerfile.php.8.5
+++ b/docker/Dockerfile.php.8.5
@@ -1,3 +1,22 @@
+# Stage 1: rebuild the php binary with profile-guided optimization, trained
+# by running this very PHPStan release on the phpstan-src codebase. All the
+# logic lives in pgo-build.sh.
+FROM php:8.5-cli-alpine AS pgo-builder
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY pgo-build.sh /usr/local/bin/pgo-build
+
+RUN pgo-build instrument
+
+ARG PHPSTAN_VERSION
+ARG PHPSTAN_SRC_REF=2.2.x
+
+RUN pgo-build train
+
+RUN pgo-build rebuild
+
+# Stage 2: the shipped image - identical to the stock one except for the
+# profile-guided php binary dropped in over the original.
 FROM php:8.5-cli-alpine
 
 ENV COMPOSER_HOME="/composer" \
@@ -5,6 +24,8 @@ ENV COMPOSER_HOME="/composer" \
     PATH="/composer/vendor/bin:$PATH" \
     PHP_CONF_DIR="/usr/local/etc/php/conf.d" \
     PHPSTAN_PRO_WEB_PORT="11111"
+
+COPY --from=pgo-builder /pgo-install/usr/local/bin/php /usr/local/bin/php
 
 RUN echo "memory_limit=-1" > $PHP_CONF_DIR/99_memory-limit.ini \
     && apk add --no-cache git

--- a/docker/pgo-build.sh
+++ b/docker/pgo-build.sh
@@ -16,7 +16,10 @@ set -eux
 export COMPOSER_HOME=/composer COMPOSER_ALLOW_SUPERUSER=1
 
 php_build_flags() {
-	export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS"
+	# -Wno-error=incompatible-pointer-types: PHP <= 8.1 sources predate GCC 14
+	# turning this warning into an error (musl fopencookie seeker signature);
+	# the stock images were built back when it was a warning.
+	export CFLAGS="$PHP_CFLAGS -Wno-error=incompatible-pointer-types" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS"
 }
 
 case "$1" in

--- a/docker/pgo-build.sh
+++ b/docker/pgo-build.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# Rebuilds the official php:*-cli-alpine binary with profile-guided
+# optimization, trained by running the shipped PHPStan release on the
+# phpstan-src codebase (measured: ~5-10% faster analysis). The sources,
+# configure options and compiler flags all come from the image itself, so
+# the result differs from the stock binary only in the profile-guided code
+# layout.
+#
+# Meant to run inside a pgo-builder stage (see the Dockerfiles):
+#   pgo-build instrument   compile the bundled PHP sources with profiling
+#   pgo-build train        run PHPStan on phpstan-src, gathering the profile
+#                          (needs PHPSTAN_VERSION and PHPSTAN_SRC_REF)
+#   pgo-build rebuild      recompile with the profile, install to /pgo-install
+set -eux
+
+export COMPOSER_HOME=/composer COMPOSER_ALLOW_SUPERUSER=1
+
+php_build_flags() {
+	export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS"
+}
+
+case "$1" in
+
+instrument)
+	# This stage is discarded, no need to keep the apk cache clean - and the
+	# index must be around for the --simulate availability probes below.
+	apk update
+	apk add git
+	# Union of docker-library/php's own build dependency lists across the
+	# supported PHP/Alpine versions; packages a given Alpine does not have
+	# are filtered out.
+	candidates="$PHPIZE_DEPS argon2-dev coreutils curl-dev gnu-libiconv-dev \
+		libedit-dev libsodium-dev libxml2-dev linux-headers oniguruma-dev \
+		openssl-dev readline-dev sqlite-dev"
+	deps=""
+	for p in $candidates; do
+		if apk add --simulate "$p" > /dev/null 2>&1; then deps="$deps $p"; fi
+	done
+	echo "build deps: $deps"
+	test -n "$deps"
+	# shellcheck disable=SC2086
+	apk add --virtual .build-deps $deps
+	command -v gcc
+	# make sure musl's iconv doesn't get used, same as the official build
+	rm -vf /usr/include/iconv.h
+	docker-php-source extract
+	cd /usr/src/php
+	php_build_flags
+	# php-config drops the quoting around PHP_UNAME='Linux - Docker'; restore it
+	configureOptions="$(php-config --configure-options | sed "s/PHP_UNAME=Linux - Docker/PHP_UNAME='Linux - Docker'/")"
+	eval ./configure "$configureOptions"
+	make -j"$(nproc)" PROF_FLAGS="-fprofile-generate -fprofile-update=atomic" all
+	;;
+
+train)
+	: "${PHPSTAN_VERSION:?}" "${PHPSTAN_SRC_REF:?}"
+	composer global require phpstan/phpstan:"$PHPSTAN_VERSION" --prefer-dist
+	composer clear-cache
+	git clone --depth 1 --branch "$PHPSTAN_SRC_REF" https://github.com/phpstan/phpstan-src.git /pgo-corpus
+	cd /pgo-corpus
+	# phpstan-src's autoload.files (debugScope.php etc.) collide with the
+	# phar's own copies when the phar loads the corpus autoloader - the
+	# function files stay in src/ for analysis, they just must not be loaded
+	php -r '$j = json_decode(file_get_contents("composer.json"), true); unset($j["autoload"]["files"]); file_put_contents("composer.json", json_encode($j));'
+	composer install --no-dev --no-scripts --no-plugins --ignore-platform-reqs --no-interaction
+	printf 'parameters:\n    level: 8\n    paths:\n        - src\n' > pgo-training.neon
+	# Found errors are expected (exit code 1) - the run exercising the
+	# engine is the point. Anything else is a broken training run and must
+	# fail the build, as must an empty profile. Parallel worker processes
+	# merge their profiles safely thanks to -fprofile-update=atomic.
+	/usr/src/php/sapi/cli/php -d memory_limit=-1 /composer/vendor/bin/phpstan analyse \
+		-c pgo-training.neon --no-progress -q || test "$?" -eq 1
+	gcdaCount="$(find /usr/src/php -name '*.gcda' | wc -l)"
+	echo "PGO training produced $gcdaCount profile data files"
+	test "$gcdaCount" -gt 100
+	;;
+
+rebuild)
+	cd /usr/src/php
+	make prof-clean
+	php_build_flags
+	# -fprofile-partial-training keeps GCC from pessimizing code the
+	# training did not reach (untrained != cold)
+	make -j"$(nproc)" PROF_FLAGS="-fprofile-use -fprofile-correction -fprofile-partial-training -Wno-missing-profile -Wno-coverage-mismatch" all
+	make INSTALL_ROOT=/pgo-install install-cli
+	/pgo-install/usr/local/bin/php -v
+	;;
+
+*)
+	echo "usage: pgo-build instrument|train|rebuild" >&2
+	exit 1
+	;;
+
+esac

--- a/docker/pgo-build.sh
+++ b/docker/pgo-build.sh
@@ -83,8 +83,10 @@ rebuild)
 	make prof-clean
 	php_build_flags
 	# -fprofile-partial-training keeps GCC from pessimizing code the
-	# training did not reach (untrained != cold)
-	make -j"$(nproc)" PROF_FLAGS="-fprofile-use -fprofile-correction -fprofile-partial-training -Wno-missing-profile -Wno-coverage-mismatch" all
+	# training did not reach (untrained != cold); -fno-tracer works around
+	# GCC's tracer pass crashing on ext/session under -fprofile-use
+	# (https://github.com/php/php-src/issues/18807)
+	make -j"$(nproc)" PROF_FLAGS="-fprofile-use -fprofile-correction -fprofile-partial-training -fno-tracer -Wno-missing-profile -Wno-coverage-mismatch" all
 	make INSTALL_ROOT=/pgo-install install-cli
 	/pgo-install/usr/local/bin/php -v
 	;;


### PR DESCRIPTION
The php binary in the Docker images is rebuilt with profile-guided optimization, trained by running the shipped PHPStan release on the phpstan-src codebase. Measured on analysing phpstan-src: **~5% less user CPU** vs. the stock image (local Docker, arm64; bare-metal reference measurements of the same technique: −4.6% with generic training, −8.8% with PHPStan-trained profiles).

## How it works

- All logic lives in `docker/pgo-build.sh` with three subcommands: `instrument` (rebuilds the official image's own bundled PHP sources with `-fprofile-generate`, using the image's recorded configure options and compiler flags), `train` (runs the shipped PHPStan on a fresh phpstan-src clone at level 8), and `rebuild` (`-fprofile-use -fprofile-partial-training`, installing just the binary to `/pgo-install`).
- The six Dockerfiles are logic-less and identical modulo the base tag: the builder stage is `FROM` + two `COPY`s + three `RUN pgo-build …` lines, and the shipped stage adds a single `COPY --from=pgo-builder` line over the original content. The `ARG`s sit after `RUN pgo-build instrument`, so version bumps rerun only training + rebuild, not the instrumented compile.
- Guards: the training run must exit 0/1 (a fatal fails the build) and must produce ≥100 `.gcda` profile files — this caught a real silent failure during development (phpstan-src's `autoload.files` collide with the phar's own `debugScope()`/`dumpType()`; the training clone strips them from `composer.json` before `composer install`).
- The docker workflows build each platform on a native runner (`ubuntu-latest` / `ubuntu-24.04-arm`) and assemble multi-platform manifests from digests — the training run would be prohibitively slow under QEMU. The unsuffixed tags reuse the `php8.5` digests instead of building the same image twice.
- On `pull_request` the nightly workflow builds every image without pushing (no registry login, image loaded into the runner's Docker, no merge job) and smoke-tests it with `php -v` + `phpstan --version`. `packages: write` moved from workflow level to the jobs that push.

## Notes

- PR builds install the `2.2.x-dev` branch-head phar from Packagist (a PR's merge sha isn't fetchable by composer) — PR CI validates the Dockerfile/PGO logic, the sha-pinned phar is covered by the nightly push run.
- Validated locally end to end on `Dockerfile.php.8.5` (667 profile files) and `Dockerfile.php.8.0` (408 profile files — the oldest Alpine, exercising the availability-filtered build-dep list).
- Image grows by ~28 MB: ~24 MB is the stock binary shadowed in a lower layer by the overlay copy, ~3.4 MB is actual PGO binary growth.

## Cross-project benchmark

Does a profile trained on phpstan-src transfer to analysing other codebases? Measured locally (user CPU inside the container, interleaved runs, corpora and pinned refs from the integration tests):

| corpus | stock 2.2.8 image | PGO image | Δ |
|---|---|---|---|
| phpstan-src (the training corpus) | 105–110 s | 97–108 s | ≈ −5% |
| WordPress (`wordpress-develop`) | 140.0 s | 134.0 s | **−4.3%** (consistent across all runs) |
| Prado | 42.5 s | 41.5 s | −2.4% (within rounding) |
| PHP_CodeSniffer | 27.5 s | 26.5 s | −3.6% (within rounding) |

The win carries over: the hot code under any analysis is the engine itself, not the analysed project. No corpus regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8ddgihE2ApSZcJEiA26Z4

