### PR TITLE
playground-runner: allow-list analysis level

### DIFF
--- a/playground-runner/bref.php
+++ b/playground-runner/bref.php
@@ -35,6 +35,12 @@ return function ($event) use ($phpstanVersion) {
 	clearTemp();
 	$code = $event['code'];
 	$level = $event['level'];
+	if (!in_array((string) $level, ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'max'], true)) {
+		throw new \InvalidArgumentException(sprintf(
+			'Invalid analysis level: %s',
+			var_export($level, true)
+		));
+	}
 	$codePath = '/tmp/tmp.php';
 	file_put_contents($codePath, $code);
 


### PR DESCRIPTION
`bref.php` interpolates `$event['level']` verbatim into the config file path:

```php
sprintf('%s/config.level%s.neon', $containerFactory->getConfigDirectory(), $level)
```

An arbitrary string reaching that sprintf traverses the config directory looking for `config.level<anything>.neon`. Today the trailing `.neon` suffix limits loading to files that already ship in the image, so there is no exploitable primitive -- but nothing guarantees that stays true, and malformed input turns into an opaque 500 from container creation.

This PR accepts exactly the levels PHPStan ships (`0`..`10`, `max`, matching `conf/config.level*.neon` / `config.max.neon` inside the phar) and rejects anything else with a clear error.

Notes:

- The `(string)` cast keeps existing callers working whether the API sends `"7"` or `7`.
- Follow-up option: mirror the same allow-list in `playground-api/handler.ts::analyseResultInternal` so bad requests fail fast with a 400 instead of burning a runner invocation.
