### PR TITLE
playground-api: validate result id format

### DIFF
--- a/playground-api/handler.ts
+++ b/playground-api/handler.ts
@@ -44,6 +44,12 @@ interface HttpResponse {
 	body?: string;
 }
 
+const RESULT_ID_PATTERN = /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
+function isValidResultId(id: unknown): boolean {
+	return typeof id === 'string' && RESULT_ID_PATTERN.test(id);
+}
+
 interface PHPStanError {
 	message: string,
 	line: number,
@@ -328,6 +334,9 @@ async function analyseResult(request: HttpRequest): Promise<HttpResponse> {
 async function retrieveResult(request: HttpRequest): Promise<HttpResponse> {
 	try {
 		const id = request.queryStringParameters.id;
+		if (!isValidResultId(id)) {
+			return Promise.resolve({statusCode: 400, body: JSON.stringify({error: 'Invalid id'})});
+		}
 		const object = await s3.getObject({
 			Bucket: 'phpstan-playground',
 			Key: 'api/results/' + id + '.json',
@@ -457,6 +466,9 @@ async function retrieveResult(request: HttpRequest): Promise<HttpResponse> {
 async function retrieveSample(request: HttpRequest): Promise<HttpResponse> {
 	try {
 		const id = request.queryStringParameters.id;
+		if (!isValidResultId(id)) {
+			return Promise.resolve({statusCode: 400, body: JSON.stringify({error: 'Invalid id'})});
+		}
 		const object = await s3.getObject({
 			Bucket: 'phpstan-playground',
 			Key: 'api/results/' + id + '.json',
@@ -499,6 +511,9 @@ async function retrieveSample(request: HttpRequest): Promise<HttpResponse> {
 async function retrieveLegacyResult(request: HttpRequest): Promise<HttpResponse> {
 	try {
 		const id = request.queryStringParameters.id;
+		if (!isValidResultId(id)) {
+			return Promise.resolve({statusCode: 400, body: JSON.stringify({error: 'Invalid id'})});
+		}
 		const firstTwoChars = id.substr(0, 2);
 		const path = 'data/results/' + firstTwoChars + '/' + id;
 		const inputObject = await s3.getObject({


### PR DESCRIPTION
Three handlers build S3 object keys by concatenating a client-supplied query parameter:

```ts
// retrieveResult / retrieveSample
Key: 'api/results/' + id + '.json'
// retrieveLegacyResult
const path = 'data/results/' + firstTwoChars + '/' + id;
```

S3 keys are matched literally (no path normalization), so `../` cannot traverse prefixes -- the practical issue today is only that arbitrary garbage reaches the S3 API and surfaces as raw 500s. But the id is also the only thing separating "read my shared snippet" from "read any result object", so pinning the format is cheap defense in depth.

Legitimate ids are legacy 32-char hex (shared via `/r/<id>`) and current UUID v4 produced by `uuid()` in `analyseResult`. This accepts exactly those two shapes and returns 400 for anything else.

Notes:

- Case-insensitive to match how ids appear in URLs.
- If older id shapes exist that are not visible in the repo, widen the regex rather than the key construction -- the invariant to keep is that the id alone can never change the key's prefix.
- Related hardening for a separate decision: the `/legacyResult` route now renders inert output since the `escapeXML` fix; retiring it would shrink this surface to zero.
