### PR TITLE
playground-runner: skip symlinks in clearTemp()

### DIFF
--- a/playground-runner/bref.php
+++ b/playground-runner/bref.php
@@ -26,6 +26,11 @@ function clearTemp(): void
 	);
 
 	foreach ($files as $fileinfo) {
+		if ($fileinfo->isLink()) {
+			// Remove the link itself; never operate on its target.
+			unlink($fileinfo->getPathname());
+			continue;
+		}
 		$todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
 		$todo($fileinfo->getRealPath());
 	}


### PR DESCRIPTION
`clearTemp()` deletes everything under `/tmp` between invocations:

```php
foreach ($files as $fileinfo) {
	$todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
	$todo($fileinfo->getRealPath());
}
```

Both `isDir()` and `getRealPath()` resolve symlinks. If a symlink ever lands in `/tmp` pointing outside it, the loop deletes or rmdir's the *target* instead of the link. Today nothing in the sandbox creates attacker-controlled symlinks, so this is not currently reachable -- but `/tmp` is the one writable location shared across warm invocations, and this loop is the only code that runs with that much delete power. Removing links as links costs nothing and makes the wipe structurally safe.

Notes:

- `unlink()` removes symlinks-to-directories as well on Linux, so one branch covers both.
- `RecursiveDirectoryIterator` without `FilesystemIterator::FOLLOW_SYMLINKS` does not descend into symlinked directories; this fixes the per-entry deletion.
- Behavior for regular files/dirs is unchanged.
