### PR TITLE
Add TYPO3 core to the integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -526,6 +526,13 @@ jobs:
             phpstan-command: ../../../phpstan.phar analyse -c ../drupal.neon -vvv
             baseline-file: drupal-baseline.neon
           - php-version: 8.5
+            repo: TYPO3/typo3
+            ref: d7b21b717b1acc3a228b7b99de23e07ad6060da1
+            setup: |
+              composer install
+            phpstan-command: ../../../phpstan.phar analyse -c ../typo3.neon --memory-limit=2G
+            baseline-file: typo3-baseline.neon
+          - php-version: 8.5
             repo: WordPress/wordpress-develop
             ref: 7924b71d7a2392a1ff27e09cdea6d4be809a4a34
             setup: |

--- a/e2e/integration/typo3-baseline.neon
+++ b/e2e/integration/typo3-baseline.neon
@@ -1,0 +1,19 @@
+parameters:
+	ignoreErrors:
+		-
+			rawMessage: 'Class Symfony\Component\Uid\UuidV4 referenced with incorrect case: Symfony\Component\Uid\Uuidv4.'
+			identifier: class.nameCase
+			count: 1
+			path: repo/typo3/sysext/backend/Classes/Security/ContentSecurityPolicy/CspAjaxController.php
+
+		-
+			rawMessage: 'Class Doctrine\DBAL\Platforms\PostgreSQLPlatform referenced with incorrect case: Doctrine\DBAL\Platforms\PostgreSqlPlatform.'
+			identifier: class.nameCase
+			count: 1
+			path: repo/typo3/sysext/core/Classes/DataHandling/DataHandler.php
+
+		-
+			rawMessage: 'Class TYPO3\CMS\Core\TypoScript\Tokenizer\Token\Token referenced with incorrect case: TYPO3\CMS\Core\TypoScript\Tokenizer\Token\token.'
+			identifier: class.nameCase
+			count: 3
+			path: repo/typo3/sysext/core/Tests/Unit/TypoScript/Tokenizer/TokenizerInterfaceTest.php

--- a/e2e/integration/typo3.neon
+++ b/e2e/integration/typo3.neon
@@ -1,0 +1,6 @@
+includes:
+	- repo/Build/phpstan/phpstan.neon
+	- typo3-baseline.neon
+
+parameters:
+	reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
As requested in phpstan/phpstan-src#6281.

TYPO3 exercises a shape no other project in the pipeline has: with `typo3/class-alias-loader` installed and `always-add-alias-loader: true`, requiring the project's `vendor/autoload.php` leaves **no `Composer\Autoload\ClassLoader` instance in the `spl_autoload` queue at all** - the loader that resolves classes is `TYPO3\ClassAliasLoader\ClassAliasLoader` wrapping it:

```
returned: Composer\Autoload\ClassLoader
Composer ClassLoader instances in queue: 0; other objects: TYPO3\ClassAliasLoader\ClassAliasLoader
```

That is the shape phpstan/phpstan#14976 and phpstan/phpstan#14988 keep turning on - both reopened by the revert in phpstan/phpstan-src#6292 - so having a real codebase of that shape under CI seems more useful now, not less. (#15102 itself is resolved by the revert, since 2.2.8 semantics is what its reporters wanted.)

**Scope, honestly:** it does not *guard* any of those fixes. Core ships no class aliases (`composer install` prints "Generating empty class alias map file"), so there is no alias-vs-stub conflict; the value is coverage of the queue shape on a large real codebase, plus the usual breadth.

## Baseline

**Empty** - the analysis is clean on current `2.2.x`. An earlier tip reported five `class.nameCase` errors on core (`PostgreSqlPlatform`, `Uuidv4`, 3x `Token`); those came from #6271 and are gated behind `checkImportedClassNameCase` since `e07268440`, so nothing needs baselining. Verified with a phar built from `09b0c9935`: `[OK] No errors`, both with and without the baseline file.

## Notes

- `COMPOSER_ROOT_VERSION=14.0.x-dev` in the setup is required: the monorepo replaces `typo3/cms-*` with `self.version`, and `actions/checkout` with a commit ref leaves no branch for Composer to derive the root version from, so `typo3/testing-framework`'s `typo3/cms-backend 14.*@dev` stops resolving. Reproduced locally by stripping a clone to that exact state.
- Runtime: **46 s** wall clock for the full `Build/phpstan/phpstan.neon` (level 5 over `typo3/sysext`, cold), well inside the 30-minute budget.
- Pinned at `d7b21b717b1acc3a228b7b99de23e07ad6060da1` (`main`, v14 dev, PHP ^8.5); core commits its own `composer.lock`.

