### PR TITLE
Create Flow's Data directories upfront in neos/flow integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -628,6 +628,10 @@ jobs:
               cp ../../../phpstan Packages/Libraries/phpstan/phpstan/phpstan
               cp ../../../bootstrap.php Packages/Libraries/phpstan/phpstan/bootstrap.php
               rm -rf Packages/Libraries/phpstan/phpstan/turbo-ext && cp -R ../../../turbo-ext Packages/Libraries/phpstan/phpstan/turbo-ext
+              # Flow's bootstrap (run by bootstrap-phpstan.php in every parallel
+              # worker) creates these directories non-atomically and exits on a
+              # lost mkdir race - create them upfront.
+              mkdir -p Data/Persistent Data/Temporary/Testing
             phpstan-command: bin/phpstan analyse -c ../neos.neon -vvv
             baseline-file: neos-baseline.neon
           - php-version: 8.5
@@ -650,6 +654,10 @@ jobs:
               cp ../../../phpstan Packages/Libraries/phpstan/phpstan/phpstan
               cp ../../../bootstrap.php Packages/Libraries/phpstan/phpstan/bootstrap.php
               rm -rf Packages/Libraries/phpstan/phpstan/turbo-ext && cp -R ../../../turbo-ext Packages/Libraries/phpstan/phpstan/turbo-ext
+              # Flow's bootstrap (run by bootstrap-phpstan.php in every parallel
+              # worker) creates these directories non-atomically and exits on a
+              # lost mkdir race - create them upfront.
+              mkdir -p Data/Persistent Data/Temporary/Testing
             phpstan-command: bin/phpstan analyse -c ../flow.neon
             baseline-file: flow-baseline.neon
           - php-version: 8.5
@@ -669,6 +677,10 @@ jobs:
               cp ../../../phpstan Packages/Libraries/phpstan/phpstan/phpstan
               cp ../../../bootstrap.php Packages/Libraries/phpstan/phpstan/bootstrap.php
               rm -rf Packages/Libraries/phpstan/phpstan/turbo-ext && cp -R ../../../turbo-ext Packages/Libraries/phpstan/phpstan/turbo-ext
+              # Flow's bootstrap (run by bootstrap-phpstan.php in every parallel
+              # worker) creates these directories non-atomically and exits on a
+              # lost mkdir race - create them upfront.
+              mkdir -p Data/Persistent Data/Temporary/Testing
             phpstan-command: bin/phpstan analyse -c ../flow-legacy.neon
             baseline-file: flow-legacy-baseline.neon
           - php-version: 8.5


### PR DESCRIPTION
The neos and flow integration jobs fail intermittently with:

```
Child process error (exit code 1): Flow could not create the directory ".../Data/Persistent". Please check the file permissions manually or run "sudo ./flow flow:core:setfilepermissions" to fix the problem. (Error #1347526553)
```

Flow's bootstrap, executed by `bootstrap-phpstan.php` in every parallel worker, creates `Data/Persistent` and `Data/Temporary/Testing` with a non-atomic `is_dir()` + `mkdir()` and exits on a lost race. Since phpstan-src 55d9d9bcc deferred bootstrapFiles in the main process, the concurrently spawned workers are the first to run it on a cold checkout, so whether a run passes is a coin toss on worker startup timing (first failure: the 2026-08-26 run for bbd47cbc).

Creating the directories in the setup step makes every `is_dir()` check short-circuit, so the race is unreachable regardless of bootstrap-file timing in phpstan-src. `Data/Temporary/Testing` includes the context subdirectory because Flow composes `FLOW_PATH_TEMPORARY` as `Data/Temporary/<context>/` and its recursive `mkdir()` races on the final component too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkSRuwXpkvy3WCdYZgCNhN