### PR TITLE
CI: fix PHP 7.4 build

### DIFF
--- a/e2e/rector-autoload/src/ImportPhpUnitFunctionsRector.php
+++ b/e2e/rector-autoload/src/ImportPhpUnitFunctionsRector.php
@@ -37,7 +37,7 @@ final class ImportPhpUnitFunctionsRector extends AbstractRector
 		$functionName = $this->getName($node);
 
 		// If function name is FQCN it's already imported or is a member of this file's namespace
-		if (str_contains($functionName, '\\')) {
+		if (strpos($functionName, '\\') !== false) {
 			return null;
 		}
 


### PR DESCRIPTION
fixes
```
 ------ ---------------------------------------------------------------------- 
  Line   ImportPhpUnitFunctionsRector.php                                      
 ------ ---------------------------------------------------------------------- 
  40     Function str_contains not found.                                      
         🪪  function.notFound                                                  
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols   
 ------ ---------------------------------------------------------------------- 
```