### PR TITLE
Use the shared-memory opcode cache and disable the cycle collector

### DIFF
--- a/playground-runner/bref.php
+++ b/playground-runner/bref.php
@@ -2,6 +2,10 @@
 
 use Symfony\Component\Console\Formatter\OutputFormatter;
 
+// bin/phpstan does the same: PHPStan allocates heavily and leans on the process
+// ending rather than on the cycle collector.
+gc_disable();
+
 require __DIR__.'/vendor/autoload.php';
 require __DIR__.'/runner-config.php';
 

--- a/playground-runner/php/conf.d/opcache.ini
+++ b/playground-runner/php/conf.d/opcache.ini
@@ -1,0 +1,12 @@
+; Bref defaults to opcache.file_cache_only, which reads compiled opcodes back from
+; /tmp on every include. With BREF_LOOP_MAX=50 a process serves many requests, so the
+; in-process shared memory cache is worth having; the file cache stays as the backing
+; store that survives the 1-in-50 process restart, which is why clearTemp() keeps it.
+;
+; validate_timestamps stays at Bref's default of 1. PHPStan writes its own cache files
+; to fixed paths in /tmp with per-request contents, so without the timestamp check a
+; warm process could serve a previous request's compiled cache file.
+opcache.file_cache_only = 0
+opcache.memory_consumption = 512
+opcache.interned_strings_buffer = 64
+opcache.max_accelerated_files = 32531


### PR DESCRIPTION
Follow-up to #15199, measured the same way. Two small changes; everything else I tried is below and did not earn its place.

## Changes

**`opcache.file_cache_only = 0`.** Bref's default reads compiled opcodes back from `/tmp` on every include. That was the right shape when each invocation got its own PHP process, but with `BREF_LOOP_MAX=50` a process serves many requests and the in-process shared-memory cache is worth having. The file cache stays on as the backing store for the 1-in-50 process restart — which is exactly what `clearTemp()` already preserves.

`opcache.validate_timestamps` stays at Bref's default of `1`. PHPStan writes its own cache files to fixed paths in `/tmp` with per-request contents, so without the timestamp check a warm process could serve a previous request's compiled cache file. I measured `validate_timestamps = 0` too — it was within noise (small 249 ms vs 256 ms), so there is nothing to buy by giving that up.

**`gc_disable()`**, which is what `bin/phpstan` does.

## Results

Fan-out over 9 PHP versions, on top of #15199:

| | before | after |
|---|---|---|
| 9-line snippet | 370 ms | **328 ms** |
| 170-line file | 900 ms | **787 ms** |

Peak memory over a 50-invocation process is unchanged: 591 MB with the collector off against 627 MB with it on, of 1769 MB. 192 configuration combinations still match production byte for byte.

## What I tried and dropped

**PHPStan Turbo — measured slower here.** It does load and activate on Bref: `turbo-ext/.version` matches the phar's `EXPECTED_EXTENSION_VERSION`, `linux-gnu-arm64/phpstan_turbo-8.5.so` is the right ABI for the `arm-php-85` layer, and loading it through `php/conf.d` plus calling `TurboExtensionEnabler::enableIfLoaded()` by hand gets to `turbo_active: true` with the TypeCombinator cache on. But per invocation it went 267 ms → 335 ms on a small snippet and was flat on the 170-line one.

That is not surprising in hindsight: `trustOwnTypesIfSuitable()` bails because it requires `Phar::running() !== ''` and the runner uses PHPStan as a library rather than executing the phar, so the ~8% from dropping the engine's own type checks never applies — and the native hot paths are built to pay off over a whole-project analysis, not a 150 ms single-file one.

**`preload.php` — no measurable effect.** Requiring it after the autoloader, the way `bin/phpstan` does, came out within noise (small 276 ms → 270 ms). Under process reuse it only front-loads on invocation 1 what invocation 1 would otherwise do lazily, while eagerly declaring ~2300 classes a single-file analysis never touches.

Two things worth recording if anyone tries it again:

- `opcache.preload` is the wrong mechanism. `preload.php` is a flat `require_once` list with no autoloader, so at PHP startup it dies on `Interface "PHPStan\Analyser\InternalScopeFactory" not found`.
- Loading PHPStan's internals registers the phar's own `Composer\InstalledVersions`, in which `phpstan/phpstan` is marked as replaced. Anything that boots the phar before `PrettyVersions::getVersion('phpstan/phpstan')` runs makes it throw `ReplacedPackageException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)